### PR TITLE
fix: improve Google Gemini tool-call compatibility

### DIFF
--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -248,6 +248,11 @@ $response = Atlas::text('openai', 'gpt-4o')
     ->asText();
 ```
 
+## Provider Compatibility
+
+Atlas adapts tool definitions to each provider's tool-calling format. For example, the Google provider normalizes tool parameter schemas
+for Gemini function declarations and preserves Gemini continuation metadata when a tool call must be sent back with the next request.
+
 ## Provider Tools
 
 Provider tools are native capabilities offered by AI providers (not your PHP code). They run server-side at the provider level. Atlas includes configuration objects for common provider tools:

--- a/src/Persistence/Models/ConversationMessage.php
+++ b/src/Persistence/Models/ConversationMessage.php
@@ -16,6 +16,7 @@ use Atlasphp\Atlas\Persistence\Concerns\HasAtlasTable;
 use Atlasphp\Atlas\Persistence\Concerns\HasOwner;
 use Atlasphp\Atlas\Persistence\Enums\MessageRole;
 use Atlasphp\Atlas\Persistence\Enums\MessageStatus;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -267,11 +268,9 @@ class ConversationMessage extends Model
         }
 
         // Build AssistantMessage with toolCalls array
-        $toolCalls = $toolCallRecords->map(fn (ExecutionToolCall $tc) => new ToolCall(
-            id: $tc->tool_call_id,
-            name: $tc->name,
-            arguments: $tc->arguments ?? [],
-        ))->all();
+        $toolCalls = $toolCallRecords->map(
+            fn (ExecutionToolCall $tc) => $this->toToolCall($tc),
+        )->all();
 
         $messages = [
             new AssistantMessage(
@@ -290,6 +289,26 @@ class ConversationMessage extends Model
         }
 
         return $messages;
+    }
+
+    protected function toToolCall(ExecutionToolCall $toolCall): ToolCall
+    {
+        $thoughtSignature = $toolCall->metadata[GoogleToolCall::THOUGHT_SIGNATURE_METADATA_KEY] ?? null;
+
+        if (is_string($thoughtSignature)) {
+            return new GoogleToolCall(
+                id: $toolCall->tool_call_id,
+                name: $toolCall->name,
+                arguments: $toolCall->arguments ?? [],
+                thoughtSignature: $thoughtSignature,
+            );
+        }
+
+        return new ToolCall(
+            id: $toolCall->tool_call_id,
+            name: $toolCall->name,
+            arguments: $toolCall->arguments ?? [],
+        );
     }
 
     // ─── Query Helpers ──────────────────────────────────────────

--- a/src/Persistence/Services/ExecutionService.php
+++ b/src/Persistence/Services/ExecutionService.php
@@ -14,6 +14,7 @@ use Atlasphp\Atlas\Persistence\Models\ConversationMessage;
 use Atlasphp\Atlas\Persistence\Models\Execution;
 use Atlasphp\Atlas\Persistence\Models\ExecutionStep;
 use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Atlasphp\Atlas\Responses\Usage;
 use Illuminate\Support\Facades\DB;
 
@@ -285,6 +286,7 @@ class ExecutionService
         }
 
         $toolCallModel = $this->toolCallModel;
+        $metadata = $this->toolCallMetadata($toolCall, $meta);
 
         $this->currentToolCall = $toolCallModel::create([
             'execution_id' => $this->execution->id,
@@ -294,10 +296,23 @@ class ExecutionService
             'type' => $type,
             'status' => ExecutionStatus::Pending,
             'arguments' => $toolCall->arguments,
-            'metadata' => $meta !== [] ? $meta : null,
+            'metadata' => $metadata !== [] ? $metadata : null,
         ]);
 
         return $this->currentToolCall;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    protected function toolCallMetadata(ToolCall $toolCall, array $meta): array
+    {
+        if ($toolCall instanceof GoogleToolCall && $toolCall->thoughtSignature !== null) {
+            $meta[GoogleToolCall::THOUGHT_SIGNATURE_METADATA_KEY] = $toolCall->thoughtSignature;
+        }
+
+        return $meta;
     }
 
     /**

--- a/src/Providers/Google/GoogleToolCall.php
+++ b/src/Providers/Google/GoogleToolCall.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Google;
+
+use Atlasphp\Atlas\Messages\ToolCall;
+
+/**
+ * Represents a Gemini function call with Google-specific continuation metadata.
+ */
+class GoogleToolCall extends ToolCall
+{
+    public const THOUGHT_SIGNATURE_METADATA_KEY = 'google_thought_signature';
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function __construct(
+        string $id,
+        string $name,
+        array $arguments,
+        public readonly ?string $thoughtSignature = null,
+    ) {
+        parent::__construct($id, $name, $arguments);
+    }
+}

--- a/src/Providers/Google/MessageFactory.php
+++ b/src/Providers/Google/MessageFactory.php
@@ -66,12 +66,18 @@ class MessageFactory implements MessageFactoryContract
         }
 
         foreach ($message->toolCalls as $toolCall) {
-            $parts[] = [
+            $part = [
                 'functionCall' => [
                     'name' => $toolCall->name,
                     'args' => $toolCall->arguments ?: (object) [],
                 ],
             ];
+
+            if ($toolCall instanceof GoogleToolCall && $toolCall->thoughtSignature !== null) {
+                $part['thoughtSignature'] = $toolCall->thoughtSignature;
+            }
+
+            $parts[] = $part;
         }
 
         return [

--- a/src/Providers/Google/ToolMapper.php
+++ b/src/Providers/Google/ToolMapper.php
@@ -27,7 +27,9 @@ class ToolMapper implements ToolMapperContract
         return array_map(fn (ToolDefinition $tool): array => [
             'name' => $tool->name,
             'description' => $tool->description,
-            'parameters' => $tool->hasParameters() ? $tool->parameters : ['type' => 'object', 'properties' => (object) []],
+            'parameters' => $tool->hasParameters()
+                ? $this->sanitizeSchema($tool->parameters)
+                : ['type' => 'object', 'properties' => (object) []],
         ], $tools);
     }
 
@@ -59,13 +61,60 @@ class ToolMapper implements ToolMapperContract
     public function parseToolCalls(array $functionCallParts): array
     {
         return array_map(function (array $part, int $index): ToolCall {
-            $fc = $part['functionCall'];
+            $functionCall = $part['functionCall'];
 
-            return new ToolCall(
-                id: $fc['id'] ?? 'gemini_call_'.$index,
-                name: $fc['name'],
-                arguments: $fc['args'] ?? [],
+            return new GoogleToolCall(
+                id: $functionCall['id'] ?? 'gemini_call_'.$index,
+                name: $functionCall['name'],
+                arguments: $functionCall['args'] ?? [],
+                thoughtSignature: $part['thoughtSignature'] ?? null,
             );
         }, $functionCallParts, array_keys($functionCallParts));
+    }
+
+    /**
+     * Remove JSON Schema keywords unsupported by Gemini function declarations.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    protected function sanitizeSchema(array $schema): array
+    {
+        unset($schema['additionalProperties']);
+
+        foreach ($schema as $key => $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if ($key === 'properties') {
+                $schema[$key] = $this->sanitizeProperties($value);
+
+                continue;
+            }
+
+            $schema[$key] = $this->sanitizeSchema($value);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $properties
+     * @return array<string, mixed>|\stdClass
+     */
+    protected function sanitizeProperties(array $properties): array|\stdClass
+    {
+        if ($properties === []) {
+            return (object) [];
+        }
+
+        foreach ($properties as $name => $schema) {
+            if (is_array($schema)) {
+                $properties[$name] = $this->sanitizeSchema($schema);
+            }
+        }
+
+        return $properties;
     }
 }

--- a/tests/Feature/Persistence/ConversationFlowTest.php
+++ b/tests/Feature/Persistence/ConversationFlowTest.php
@@ -11,6 +11,7 @@ use Atlasphp\Atlas\Persistence\Models\Execution;
 use Atlasphp\Atlas\Persistence\Models\ExecutionStep;
 use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
 use Atlasphp\Atlas\Persistence\Services\ConversationService;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 
 beforeEach(function () {
     $this->service = new ConversationService;
@@ -191,4 +192,47 @@ it('handles multiple tool calls in a single step', function () {
     $toolResultContents = array_map(fn ($m) => $m->content, array_values($toolResults));
     expect($toolResultContents)->toContain('{"temp": 72}')
         ->toContain('{"temp": 85}');
+});
+
+it('reconstructs Google tool calls with thought signatures', function () {
+    $conversation = Conversation::factory()->create();
+    $userMessage = $this->service->addMessage(
+        $conversation,
+        new UserMessage(content: 'Analyze this.'),
+    );
+
+    $execution = Execution::factory()->completed()->create([
+        'conversation_id' => $conversation->id,
+        'provider' => 'google',
+    ]);
+
+    $step = ExecutionStep::factory()->withToolCalls('Let me inspect that.')->create([
+        'execution_id' => $execution->id,
+        'sequence' => 1,
+    ]);
+
+    ExecutionToolCall::factory()->completed('{"status": "ok"}')->create([
+        'execution_id' => $execution->id,
+        'step_id' => $step->id,
+        'tool_call_id' => 'call_google_1',
+        'name' => 'inspect',
+        'arguments' => ['value' => 'test'],
+        'metadata' => [
+            GoogleToolCall::THOUGHT_SIGNATURE_METADATA_KEY => 'signature-from-gemini',
+        ],
+    ]);
+
+    $this->service->addAssistantMessages(
+        $conversation,
+        [['text' => 'Let me inspect that.', 'step_id' => $step->id]],
+        agent: 'google-bot',
+        parentId: $userMessage->id,
+    );
+
+    $messages = $this->service->loadMessages($conversation);
+    $assistant = array_values(array_filter($messages, fn ($message) => $message instanceof AssistantMessage))[0];
+
+    expect($assistant->toolCalls)->toHaveCount(1);
+    expect($assistant->toolCalls[0])->toBeInstanceOf(GoogleToolCall::class);
+    expect($assistant->toolCalls[0]->thoughtSignature)->toBe('signature-from-gemini');
 });

--- a/tests/Feature/Persistence/ExecutionTrackingTest.php
+++ b/tests/Feature/Persistence/ExecutionTrackingTest.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Persistence\Models\Execution;
 use Atlasphp\Atlas\Persistence\Models\ExecutionStep;
 use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
 use Atlasphp\Atlas\Persistence\Services\ExecutionService;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Atlasphp\Atlas\Responses\Usage;
 
 beforeEach(function () {
@@ -136,6 +137,27 @@ it('tracks multi-step execution with multiple tool calls', function () {
 
     expect(ExecutionStep::count())->toBe(2)
         ->and(ExecutionToolCall::count())->toBe(1);
+});
+
+it('stores Google thought signatures in tool call metadata', function () {
+    $this->service->createExecution(provider: 'google', model: 'gemini-2.5-flash');
+    $this->service->beginExecution();
+
+    $this->service->createStep();
+    $this->service->beginStep();
+
+    $toolCall = new GoogleToolCall(
+        id: 'call_google_1',
+        name: 'inspect',
+        arguments: ['value' => 'test'],
+        thoughtSignature: 'signature-from-gemini',
+    );
+
+    $record = $this->service->createToolCall($toolCall);
+
+    expect($record->metadata)->toBe([
+        GoogleToolCall::THOUGHT_SIGNATURE_METADATA_KEY => 'signature-from-gemini',
+    ]);
 });
 
 it('handles failure path: marks execution and in-flight step as failed', function () {

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -181,3 +181,37 @@ it('wraps tools in function_declarations', function () {
             && $tools[0]['function_declarations'][0]['name'] === 'search';
     });
 });
+
+it('sends Gemini-compatible function declaration schemas', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse()),
+    ]);
+
+    $handler = makeGoogleTextHandler();
+    $handler->text(makeGoogleTextRequest([
+        'tools' => [
+            new ToolDefinition('search', 'Search', [
+                'type' => 'object',
+                'additionalProperties' => false,
+                'properties' => [
+                    'q' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ]),
+        ],
+    ]));
+
+    Http::assertSent(function ($request) {
+        $parameters = $request['tools'][0]['function_declarations'][0]['parameters'] ?? [];
+
+        return $parameters === [
+            'type' => 'object',
+            'properties' => [
+                'q' => [
+                    'type' => 'string',
+                ],
+            ],
+        ];
+    });
+});

--- a/tests/Unit/Providers/Google/MessageFactoryTest.php
+++ b/tests/Unit/Providers/Google/MessageFactoryTest.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Messages\SystemMessage;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Messages\ToolResultMessage;
 use Atlasphp\Atlas\Messages\UserMessage;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Atlasphp\Atlas\Providers\Google\MediaResolver;
 use Atlasphp\Atlas\Providers\Google\MessageFactory;
 use Atlasphp\Atlas\Requests\TextRequest;
@@ -61,6 +62,20 @@ it('converts assistant message with tool calls', function () {
     expect($result['parts'])->toHaveCount(1);
     expect($result['parts'][0]['functionCall']['name'])->toBe('search');
     expect($result['parts'][0]['functionCall']['args'])->toBe(['query' => 'test']);
+});
+
+it('converts assistant message with thought signature tool calls', function () {
+    $factory = new MessageFactory;
+
+    $result = $factory->assistant(new AssistantMessage(null, [
+        new GoogleToolCall('call_1', 'search', ['query' => 'test'], 'signature-from-gemini'),
+    ]));
+
+    expect($result['role'])->toBe('model');
+    expect($result['parts'])->toHaveCount(1);
+    expect($result['parts'][0]['functionCall']['name'])->toBe('search');
+    expect($result['parts'][0]['functionCall']['args'])->toBe(['query' => 'test']);
+    expect($result['parts'][0]['thoughtSignature'])->toBe('signature-from-gemini');
 });
 
 it('converts tool result message', function () {

--- a/tests/Unit/Providers/Google/ResponseParserTest.php
+++ b/tests/Unit/Providers/Google/ResponseParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Atlasphp\Atlas\Providers\Google\ResponseParser;
 use Atlasphp\Atlas\Providers\Google\ToolMapper;
 use Atlasphp\Atlas\Responses\StreamChunk;
@@ -44,6 +45,27 @@ it('parses function calls from candidates', function () {
     expect($result->toolCalls)->toHaveCount(1);
     expect($result->toolCalls[0]->name)->toBe('search');
     expect($result->toolCalls[0]->arguments)->toBe(['query' => 'test']);
+});
+
+it('preserves function call thought signatures in assistant messages', function () {
+    $parser = makeGoogleResponseParser();
+
+    $result = $parser->parseText([
+        'candidates' => [
+            ['content' => ['parts' => [
+                [
+                    'functionCall' => ['name' => 'search', 'args' => ['query' => 'test']],
+                    'thoughtSignature' => 'signature-from-gemini',
+                ],
+            ], 'role' => 'model'], 'finishReason' => 'STOP'],
+        ],
+        'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5],
+    ]);
+
+    $message = $result->toMessage();
+
+    expect($message->toolCalls[0])->toBeInstanceOf(GoogleToolCall::class);
+    expect($message->toolCalls[0]->thoughtSignature)->toBe('signature-from-gemini');
 });
 
 it('parses thinking parts as reasoning', function () {
@@ -157,13 +179,18 @@ it('parses stream chunk with function call', function () {
 
     $result = $parser->parseStreamChunk([
         'candidates' => [['content' => ['parts' => [
-            ['functionCall' => ['name' => 'search', 'args' => ['q' => 'test']]],
+            [
+                'functionCall' => ['name' => 'search', 'args' => ['q' => 'test']],
+                'thoughtSignature' => 'signature-from-gemini',
+            ],
         ]]]],
     ]);
 
     expect($result->type)->toBe(ChunkType::ToolCall);
     expect($result->toolCalls)->toHaveCount(1);
+    expect($result->toolCalls[0])->toBeInstanceOf(GoogleToolCall::class);
     expect($result->toolCalls[0]->name)->toBe('search');
+    expect($result->toolCalls[0]->thoughtSignature)->toBe('signature-from-gemini');
 });
 
 it('parses stream chunk with thinking', function () {

--- a/tests/Unit/Providers/Google/ToolMapperTest.php
+++ b/tests/Unit/Providers/Google/ToolMapperTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Atlasphp\Atlas\Messages\ToolCall;
+use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Atlasphp\Atlas\Providers\Google\ToolMapper;
 use Atlasphp\Atlas\Providers\Tools\CodeExecution;
 use Atlasphp\Atlas\Providers\Tools\GoogleSearch;
@@ -32,6 +33,90 @@ it('maps tools with empty parameters to object with empty properties', function 
     expect($result[0]['parameters'])->toEqual(['type' => 'object', 'properties' => (object) []]);
 });
 
+it('removes unsupported Gemini schema keywords from tool parameters', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->mapTools([
+        new ToolDefinition('search', 'Search the web', [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'properties' => [
+                'query' => [
+                    'type' => 'string',
+                ],
+                'filters' => [
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => [
+                        'status' => ['type' => 'string'],
+                    ],
+                ],
+                'additionalProperties' => [
+                    'type' => 'string',
+                    'description' => 'A regular tool argument that happens to share a JSON Schema keyword name.',
+                ],
+            ],
+        ]),
+    ]);
+
+    expect($result[0]['parameters'])->toBe([
+        'type' => 'object',
+        'properties' => [
+            'query' => [
+                'type' => 'string',
+            ],
+            'filters' => [
+                'type' => 'object',
+                'properties' => [
+                    'status' => ['type' => 'string'],
+                ],
+            ],
+            'additionalProperties' => [
+                'type' => 'string',
+                'description' => 'A regular tool argument that happens to share a JSON Schema keyword name.',
+            ],
+        ],
+    ]);
+});
+
+it('keeps empty Gemini object properties encoded as objects', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->mapTools([
+        new ToolDefinition('empty', 'Inspect an empty object', [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'properties' => [],
+        ]),
+        new ToolDefinition('inspect', 'Inspect an empty object', [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'properties' => [
+                'payload' => [
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => [],
+                ],
+            ],
+        ]),
+    ]);
+
+    expect($result[0]['parameters'])->toEqual([
+        'type' => 'object',
+        'properties' => (object) [],
+    ]);
+
+    expect($result[1]['parameters'])->toEqual([
+        'type' => 'object',
+        'properties' => [
+            'payload' => [
+                'type' => 'object',
+                'properties' => (object) [],
+            ],
+        ],
+    ]);
+});
+
 it('parses tool calls extracting name and args from functionCall parts', function () {
     $mapper = new ToolMapper;
 
@@ -43,6 +128,20 @@ it('parses tool calls extracting name and args from functionCall parts', functio
     expect($result[0])->toBeInstanceOf(ToolCall::class);
     expect($result[0]->name)->toBe('search');
     expect($result[0]->arguments)->toBe(['query' => 'test']);
+});
+
+it('preserves thought signatures from functionCall parts', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->parseToolCalls([
+        [
+            'functionCall' => ['id' => 'call-1', 'name' => 'search', 'args' => ['query' => 'test']],
+            'thoughtSignature' => 'signature-from-gemini',
+        ],
+    ]);
+
+    expect($result[0])->toBeInstanceOf(GoogleToolCall::class);
+    expect($result[0]->thoughtSignature)->toBe('signature-from-gemini');
 });
 
 it('generates fallback ID when no id field', function () {


### PR DESCRIPTION
﻿## TL;DR

This PR makes the Google provider handle Gemini tool calling more like a provider adapter instead of passing generic Atlas tool metadata through unchanged.

It fixes two upgrade regressions seen in a generic tool-enabled Gemini workflow:

- Gemini can reject `functionDeclarations[].parameters` when Atlas includes JSON Schema keywords that are not part of Google's `Schema` object, such as `additionalProperties`.
- Gemini thinking models can reject the next tool-result request when a `functionCall` returned with `thoughtSignature` is replayed without that same signature.

Closes atlas-php/atlas#29.

## Why

Atlas tools are provider-neutral. A tool definition that works with OpenAI or Anthropic may include common JSON Schema keywords like `additionalProperties: false` because Atlas' base tool schema includes them.

Gemini is stricter in two places:

- [`FunctionDeclaration.parameters`](https://ai.google.dev/api/generate-content#FunctionDeclaration) uses Google's [`Schema`](https://ai.google.dev/api/generate-content#Schema), a selected subset of OpenAPI schema fields. `additionalProperties` belongs to `parametersJsonSchema`, not the `parameters` object Atlas currently sends.
- [Gemini thought signatures](https://ai.google.dev/gemini-api/docs/thought-signatures) must be passed back exactly when replaying function-call history. Google's docs note that omitting a required signature during function calling can produce a 400 validation error.

This showed up after upgrading Atlas in an application with an existing Gemini tool loop. The same high-level tool definitions worked before the upgrade and with other providers, but Gemini needed provider-specific normalization and continuation metadata preservation.

## Reproduction

### Schema normalization

A normal Atlas tool can define a closed object:

```php
new ToolDefinition('lookup_order', 'Look up an order', [
    'type' => 'object',
    'additionalProperties' => false,
    'properties' => [
        'order_id' => ['type' => 'string'],
    ],
    'required' => ['order_id'],
]);
```

Before this PR, the Google provider could send that schema directly as Gemini `parameters`:

```json
{
  "name": "lookup_order",
  "parameters": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
      "order_id": { "type": "string" }
    },
    "required": ["order_id"]
  }
}
```

That shape can fail because `parameters` is Gemini's `Schema` object. This PR keeps the provider-neutral Atlas tool definition intact, but sends Gemini a compatible declaration:

```json
{
  "name": "lookup_order",
  "parameters": {
    "type": "object",
    "properties": {
      "order_id": { "type": "string" }
    },
    "required": ["order_id"]
  }
}
```

### Thought signatures

Gemini can return a signed function call:

```json
{
  "functionCall": {
    "name": "lookup_order",
    "args": { "order_id": "1001" }
  },
  "thoughtSignature": "signature-from-gemini"
}
```

When Atlas sends the function call and tool result back to Gemini, that signature must remain beside the same `functionCall` part. This PR keeps that metadata through parsing, streaming chunks, message rebuilding, and persisted conversation replay.

## What Changed

### Google tool schemas

- Sanitizes Google function declaration parameters before sending them to Gemini.
- Removes unsupported schema keywords, currently `additionalProperties`, recursively from schema declarations.
- Keeps regular tool arguments named `additionalProperties` untouched.
- Keeps empty object `properties` encoded as JSON objects, not JSON arrays.

### Gemini tool-call continuation

- Adds a Google-specific `GoogleToolCall` value object for Gemini continuation metadata.
- Parses `thoughtSignature` from Gemini function-call parts.
- Preserves signatures from streaming function-call chunks.
- Emits `thoughtSignature` beside the matching `functionCall` when rebuilding assistant/model messages for Gemini.
- Stores and reconstructs the signature through persisted execution tool calls.
- Leaves the generic `ToolCall` constructor and provider-neutral API unchanged.

### Documentation

- Notes that Atlas adapts tool definitions for provider-specific tool-calling formats.

## Notes For Reviewers

- The scope is intentionally limited to the Google provider and Gemini tool-call compatibility.
- This does not change tool definitions for other providers.
- The persistence change stores the Google signature in tool-call metadata so persisted Gemini conversations can be replayed correctly.

## References

- [Google Gemini function calling guide](https://ai.google.dev/gemini-api/docs/function-calling)
- [Google generateContent API reference: FunctionDeclaration and Schema](https://ai.google.dev/api/generate-content#FunctionDeclaration)
- [Google thought signatures documentation](https://ai.google.dev/gemini-api/docs/thought-signatures)

## Testing

- `vendor\bin\pest.bat tests\Unit\Providers\Google\ToolMapperTest.php tests\Unit\Providers\Google\MessageFactoryTest.php tests\Unit\Providers\Google\Handlers\TextHandlerTest.php tests\Unit\Providers\Google\ResponseParserTest.php`
- `vendor\bin\pest.bat tests\Unit\Providers\Google\ToolMapperTest.php tests\Unit\Providers\Google\ResponseParserTest.php tests\Feature\Persistence\ConversationFlowTest.php tests\Feature\Persistence\ExecutionTrackingTest.php` (35 passed, 134 assertions)
- Controlled negative check: temporarily removed schema normalization and thought-signature replay; the targeted regression tests failed, then passed again after restoring the implementation.
- `composer analyse`
- `vendor\bin\pint.bat --dirty`
- `composer check` (2556 passed, 5574 assertions)
- Downstream validation with the local Gemini shim removed and this Atlas branch installed through a path repository: `.\vendor\bin\pest tests\Feature\Actions\CheckRuns\AnalyzeFailedCheckAtlasLoggingTest.php` (5 passed, 59 assertions)
