### PR TITLE
Enhance persistence connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,4 +528,46 @@ Horizon must be **restarted after code changes** to pick up new code. If tests s
 
 ---
 
+## Changelog Release Notes
+
+`CHANGELOG.md` is consumer-facing. Write for someone deciding whether to upgrade, not for someone reading the diff.
+
+### Rules
+
+- **One line per change.** Lead with the user-visible effect, not the internal mechanism.
+- **Section order:** `### Added` → `### Changed` → `### Fixed` → `### Migration`. Omit any empty section (except `### Migration`, which is always present).
+- **Consumer-facing only.** Skip housekeeping, refactors, test cleanup, dependency bumps, and anything else without consumer impact. No internal-only section.
+- **`### Added`** — new capabilities a consumer can use. Mention the config key or method signature only if a consumer needs it.
+- **`### Changed`** — only what a consumer needs to know about behavior that changed.
+- **`### Fixed`** — only what a consumer needs to know about a bug that's been corrected. No class names, file paths, or stack traces.
+- **`### Migration`** — always last, always present. If the release is drop-in, write: `No breaking changes — drop-in upgrade. No consumer action required.` If anything breaks, name what changed and the smallest steps a consumer must take.
+- **Header format:** `## [vX.Y.Z](https://github.com/atlas-php/atlas/releases/tag/vX.Y.Z) - YYYY-MM-DD`
+- **Separator:** trailing `---` between releases.
+
+### Template
+
+```markdown
+## [vX.Y.Z](https://github.com/atlas-php/atlas/releases/tag/vX.Y.Z) - YYYY-MM-DD
+
+### Added
+
+- <one-line user-visible addition>
+
+### Changed
+
+- <one-line consumer-visible behavior change>
+
+### Fixed
+
+- <one-line consumer-visible bug fix>
+
+### Migration
+
+No breaking changes — drop-in upgrade. No consumer action required.
+
+---
+```
+
+---
+
 All agents must follow this document and the referenced guides. Non-compliant contributions will be rejected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.0.3](https://github.com/atlas-php/atlas/releases/tag/v3.0.3) - 2026-05-12
+
+### Added
+
+- `StructuredResponse` now implements `JsonSerializable` and exposes `toArray()` for direct JSON encoding.
+- New `atlas.persistence.connection` config (env: `ATLAS_DB_CONNECTION`) routes Atlas persistence tables to a separate database connection.
+
+### Fixed
+
+- Anthropic native tools (web search, etc.) now flow through as tool calls — `server_tool_use` blocks were previously dropped.
+- Anthropic `pause_turn` stop reason now signals "more tool work" instead of ending the agent loop early.
+
+### Migration
+
+No breaking changes — drop-in upgrade. No consumer action required.
+
+---
+
 ## [v3.0.2](https://github.com/atlas-php/atlas/releases/tag/v3.0.2) - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.0.2](https://github.com/atlas-php/atlas/releases/tag/v3.0.2) - 2026-05-06
+
+### Fixed
+
+- Improved Google Gemini tool-call compatibility ([#30](https://github.com/atlas-php/atlas/pull/30) by @ianfortier)
+
+### New Contributors
+
+- @ianfortier made their first contribution in [#30](https://github.com/atlas-php/atlas/pull/30)
+
+**Full Changelog:** [v3.0.1...v3.0.2](https://github.com/atlas-php/atlas/compare/v3.0.1...v3.0.2)
+
+---
+
 ## [v3.0.1](https://github.com/atlas-php/atlas/releases/tag/v3.0.1) - 2026-04-14
 
 ### Changed

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -307,6 +307,7 @@ return [
 
     'persistence' => [
         'enabled' => env('ATLAS_PERSISTENCE_ENABLED', false),
+        'connection' => env('ATLAS_DB_CONNECTION'),
         'table_prefix' => env('ATLAS_TABLE_PREFIX', 'atlas_'),
         'message_limit' => (int) env('ATLAS_MESSAGE_LIMIT', 50),
         'auto_store_assets' => env('ATLAS_AUTO_STORE_ASSETS', true),

--- a/docs/advanced/persistence.md
+++ b/docs/advanced/persistence.md
@@ -523,6 +523,7 @@ Your custom models must extend the corresponding Atlas base model.
 // config/atlas.php → persistence
 'persistence' => [
     'enabled' => env('ATLAS_PERSISTENCE_ENABLED', false),
+    'connection' => env('ATLAS_DB_CONNECTION'),
     'table_prefix' => env('ATLAS_TABLE_PREFIX', 'atlas_'),
     'message_limit' => (int) env('ATLAS_MESSAGE_LIMIT', 50),
     'auto_store_assets' => env('ATLAS_AUTO_STORE_ASSETS', true),
@@ -532,6 +533,7 @@ Your custom models must extend the corresponding Atlas base model.
 | Option | Default | Purpose |
 |--------|---------|---------|
 | `enabled` | `false` | Enable persistence globally |
+| `connection` | `null` | Database connection name. When `null`, models use the framework's default connection. Set to a connection name (e.g. `analytics`) to route Atlas persistence tables to a separate database. |
 | `table_prefix` | `atlas_` | Prefix for all persistence tables |
 | `message_limit` | `50` | Default conversation history limit |
 | `auto_store_assets` | `true` | Automatically store generated files |

--- a/sandbox/config/atlas.php
+++ b/sandbox/config/atlas.php
@@ -97,6 +97,7 @@ return [
 
     'persistence' => [
         'enabled' => env('ATLAS_PERSISTENCE_ENABLED', true),
+        'connection' => env('ATLAS_DB_CONNECTION'),
         'table_prefix' => env('ATLAS_TABLE_PREFIX', 'atlas_'),
         'message_limit' => (int) env('ATLAS_MESSAGE_LIMIT', 50),
         'auto_store_assets' => env('ATLAS_AUTO_STORE_ASSETS', true),

--- a/src/AtlasConfig.php
+++ b/src/AtlasConfig.php
@@ -43,6 +43,7 @@ class AtlasConfig
         /** @var array{models: int, voices: int, embeddings: int} */
         public readonly array $cacheTtl = ['models' => 86400, 'voices' => 3600, 'embeddings' => 0],
         public readonly bool $persistenceEnabled = false,
+        public readonly ?string $persistenceConnection = null,
         public readonly string $tablePrefix = 'atlas_',
         public readonly int $messageLimit = 50,
         public readonly bool $autoStoreAssets = true,
@@ -115,6 +116,7 @@ class AtlasConfig
             cachePrefix: config('atlas.cache.prefix', 'atlas'),
             cacheTtl: config('atlas.cache.ttl', ['models' => 86400, 'voices' => 3600, 'embeddings' => 0]),
             persistenceEnabled: (bool) config('atlas.persistence.enabled', false),
+            persistenceConnection: config('atlas.persistence.connection'),
             tablePrefix: config('atlas.persistence.table_prefix', 'atlas_'),
             messageLimit: (int) config('atlas.persistence.message_limit', 50),
             autoStoreAssets: (bool) config('atlas.persistence.auto_store_assets', true),

--- a/src/Persistence/Concerns/HasAtlasTable.php
+++ b/src/Persistence/Concerns/HasAtlasTable.php
@@ -7,10 +7,11 @@ namespace Atlasphp\Atlas\Persistence\Concerns;
 use Atlasphp\Atlas\AtlasConfig;
 
 /**
- * Resolves the prefixed table name for persistence models.
+ * Resolves the prefixed table name and database connection for persistence models.
  *
  * Every persistence model uses this trait to support the configurable
- * table prefix from atlas.persistence.table_prefix.
+ * table prefix from atlas.persistence.table_prefix and the optional
+ * connection override from atlas.persistence.connection.
  */
 trait HasAtlasTable
 {
@@ -25,5 +26,10 @@ trait HasAtlasTable
         }
 
         return $prefix.$this->table;
+    }
+
+    public function getConnectionName(): ?string
+    {
+        return app(AtlasConfig::class)->persistenceConnection ?? $this->connection;
     }
 }

--- a/src/Providers/Anthropic/ResponseParser.php
+++ b/src/Providers/Anthropic/ResponseParser.php
@@ -40,7 +40,8 @@ class ResponseParser implements ResponseParserContract
                 $reasoning = ($reasoning ?? '').($block['thinking'] ?? '');
             }
 
-            if (($block['type'] ?? '') === 'tool_use') {
+            $blockType = $block['type'] ?? '';
+            if ($blockType === 'tool_use' || $blockType === 'server_tool_use') {
                 $toolUseBlocks[] = $block;
             }
         }
@@ -141,7 +142,7 @@ class ResponseParser implements ResponseParserContract
         return match ($reason) {
             'end_turn', 'stop_sequence' => FinishReason::Stop,
             'max_tokens' => FinishReason::Length,
-            'tool_use' => FinishReason::ToolCalls,
+            'tool_use', 'pause_turn' => FinishReason::ToolCalls,
             default => FinishReason::Stop,
         };
     }

--- a/src/Responses/StructuredResponse.php
+++ b/src/Responses/StructuredResponse.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Responses;
 
 use Atlasphp\Atlas\Enums\FinishReason;
+use JsonSerializable;
 
 /**
  * Response from a structured output request.
  */
-class StructuredResponse
+class StructuredResponse implements JsonSerializable
 {
     /**
      * @param  array<string, mixed>  $structured
@@ -21,4 +22,25 @@ class StructuredResponse
         public readonly FinishReason $finishReason,
         public readonly array $meta = [],
     ) {}
+
+    /**
+     * @return array{structured: array<string, mixed>, usage: array<string, int>, finish_reason: string, meta: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'structured' => $this->structured,
+            'usage' => $this->usage->toArray(),
+            'finish_reason' => $this->finishReason->value,
+            'meta' => $this->meta,
+        ];
+    }
+
+    /**
+     * @return array{structured: array<string, mixed>, usage: array<string, int>, finish_reason: string, meta: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
 }

--- a/tests/Unit/Persistence/Concerns/HasAtlasTableTest.php
+++ b/tests/Unit/Persistence/Concerns/HasAtlasTableTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Persistence\Models\Conversation;
+use Atlasphp\Atlas\Persistence\Models\ConversationMessage;
+use Atlasphp\Atlas\Persistence\Models\Execution;
+
+it('returns the framework default connection when atlas.persistence.connection is not set', function () {
+    config()->set('atlas.persistence.connection', null);
+    AtlasConfig::refresh();
+
+    expect((new Conversation)->getConnectionName())->toBeNull();
+    expect((new ConversationMessage)->getConnectionName())->toBeNull();
+    expect((new Execution)->getConnectionName())->toBeNull();
+});
+
+it('returns the configured connection when atlas.persistence.connection is set', function () {
+    config()->set('atlas.persistence.connection', 'analytics');
+    AtlasConfig::refresh();
+
+    expect((new Conversation)->getConnectionName())->toBe('analytics');
+    expect((new ConversationMessage)->getConnectionName())->toBe('analytics');
+    expect((new Execution)->getConnectionName())->toBe('analytics');
+});
+
+it('applies the table prefix on top of the configured connection', function () {
+    config()->set('atlas.persistence.connection', 'analytics');
+    config()->set('atlas.persistence.table_prefix', 'custom_');
+    AtlasConfig::refresh();
+
+    $conversation = new Conversation;
+
+    expect($conversation->getConnectionName())->toBe('analytics');
+    expect($conversation->getTable())->toBe('custom_conversations');
+});

--- a/tests/Unit/Providers/Anthropic/ResponseParserTest.php
+++ b/tests/Unit/Providers/Anthropic/ResponseParserTest.php
@@ -195,3 +195,49 @@ it('includes meta with id and model', function () {
     expect($result->meta['id'])->toBe('msg_abc123');
     expect($result->meta['model'])->toBe('claude-sonnet-4-5-20250514');
 });
+
+it('parses server_tool_use blocks as tool calls', function () {
+    $parser = makeAnthropicResponseParser();
+
+    $result = $parser->parseText([
+        'id' => 'msg_456',
+        'model' => 'claude-sonnet-4-5-20250514',
+        'content' => [
+            ['type' => 'server_tool_use', 'id' => 'srvtoolu_1', 'name' => 'web_search', 'input' => ['query' => 'php 8.3 release notes']],
+        ],
+        'stop_reason' => 'pause_turn',
+        'usage' => ['input_tokens' => 12, 'output_tokens' => 6],
+    ]);
+
+    expect($result->toolCalls)->toHaveCount(1);
+    expect($result->toolCalls[0]->name)->toBe('web_search');
+    expect($result->toolCalls[0]->id)->toBe('srvtoolu_1');
+    expect($result->toolCalls[0]->arguments)->toBe(['query' => 'php 8.3 release notes']);
+});
+
+it('collects both tool_use and server_tool_use blocks together', function () {
+    $parser = makeAnthropicResponseParser();
+
+    $result = $parser->parseText([
+        'id' => 'msg_789',
+        'model' => 'claude-sonnet-4-5-20250514',
+        'content' => [
+            ['type' => 'server_tool_use', 'id' => 'srvtoolu_a', 'name' => 'web_search', 'input' => ['query' => 'foo']],
+            ['type' => 'tool_use', 'id' => 'toolu_b', 'name' => 'user_tool', 'input' => ['arg' => 1]],
+        ],
+        'stop_reason' => 'tool_use',
+        'usage' => ['input_tokens' => 8, 'output_tokens' => 4],
+    ]);
+
+    expect($result->toolCalls)->toHaveCount(2);
+    expect($result->toolCalls[0]->name)->toBe('web_search');
+    expect($result->toolCalls[1]->name)->toBe('user_tool');
+});
+
+it('maps pause_turn stop reason to ToolCalls', function () {
+    $parser = makeAnthropicResponseParser();
+
+    $result = $parser->parseFinishReason(['stop_reason' => 'pause_turn']);
+
+    expect($result)->toBe(FinishReason::ToolCalls);
+});

--- a/tests/Unit/Responses/StructuredResponseTest.php
+++ b/tests/Unit/Responses/StructuredResponseTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Responses\StructuredResponse;
+use Atlasphp\Atlas\Responses\Usage;
+
+it('serializes to array with structured, usage, finish_reason, and meta', function () {
+    $response = new StructuredResponse(
+        structured: ['name' => 'Ada', 'age' => 36],
+        usage: new Usage(inputTokens: 10, outputTokens: 5),
+        finishReason: FinishReason::Stop,
+        meta: ['id' => 'resp_1', 'model' => 'gpt-4o-mini'],
+    );
+
+    expect($response->toArray())->toBe([
+        'structured' => ['name' => 'Ada', 'age' => 36],
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        'finish_reason' => 'stop',
+        'meta' => ['id' => 'resp_1', 'model' => 'gpt-4o-mini'],
+    ]);
+});
+
+it('json_encodes via JsonSerializable producing the same shape as toArray', function () {
+    $response = new StructuredResponse(
+        structured: ['ok' => true],
+        usage: new Usage(inputTokens: 3, outputTokens: 1),
+        finishReason: FinishReason::ToolCalls,
+    );
+
+    $json = json_encode($response);
+
+    expect($json)->not->toBeFalse();
+    expect(json_decode((string) $json, true))->toBe([
+        'structured' => ['ok' => true],
+        'usage' => ['input_tokens' => 3, 'output_tokens' => 1],
+        'finish_reason' => 'tool_calls',
+        'meta' => [],
+    ]);
+});

--- a/tests/Unit/Responses/VoiceSessionTest.php
+++ b/tests/Unit/Responses/VoiceSessionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\VoiceTransport;
 use Atlasphp\Atlas\Responses\VoiceSession;
-use DateTimeImmutable;
 
 it('reports not expired when expiresAt is null', function () {
     $session = new VoiceSession(


### PR DESCRIPTION
This pull request introduces several improvements and new features, primarily focused on enhancing Atlas's persistence configuration and structured response handling, as well as improving Anthropic tool-call compatibility. It also adds comprehensive documentation and tests for these changes.

**Persistence Configuration Enhancements:**

* Added a new `atlas.persistence.connection` config option (env: `ATLAS_DB_CONNECTION`) to allow routing Atlas persistence tables to a separate database connection. This is now documented in `docs/advanced/persistence.md`, and the option is supported in `config/atlas.php`, `sandbox/config/atlas.php`, and `AtlasConfig`. The `HasAtlasTable` trait now resolves the correct connection, and new unit tests verify this behavior. [[1]](diffhunk://#diff-0547b8abb0d1b756bd782300755c54f2f74633554fa48ae70413cc0cef6157a9R310) [[2]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268R526) [[3]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268R536) [[4]](diffhunk://#diff-cc739478f82e89e76475f7209095da48d48b3afb7d0e0ba3f6ddc3dc0d8c516aR100) [[5]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR46) [[6]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR119) [[7]](diffhunk://#diff-0f4d8e70db6f7eae9b95f8c4169df98ad38663e40043567b5e95f6476fdd8317L10-R14) [[8]](diffhunk://#diff-0f4d8e70db6f7eae9b95f8c4169df98ad38663e40043567b5e95f6476fdd8317R30-R34) [[9]](diffhunk://#diff-16f47fece7b9cc4e03475d1bea20117f684768dd77b5acaed258d4f72993e139R1-R37)

**Structured Response Improvements:**

* `StructuredResponse` now implements `JsonSerializable` and exposes a `toArray()` method for direct JSON encoding. Unit tests confirm correct serialization. [[1]](diffhunk://#diff-62483f3126981a57e2f981c256c4a5d17f2bc135ee279291747f4f5c1f23f3e7R8-R13) [[2]](diffhunk://#diff-62483f3126981a57e2f981c256c4a5d17f2bc135ee279291747f4f5c1f23f3e7R25-R45) [[3]](diffhunk://#diff-390488facbba3df8801333d58e624e56a09cea4c5457ec69df4c2d673f3dd84aR1-R41)

**Anthropic Tool-Call Compatibility:**

* Improved Anthropic provider compatibility: `server_tool_use` blocks are now parsed as tool calls, and the `pause_turn` stop reason is mapped to `ToolCalls` to ensure correct agent loop behavior. Unit tests cover these cases. [[1]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bL43-R44) [[2]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bL144-R145) [[3]](diffhunk://#diff-1fca6bdf2ab38e2e6046bd18562a79f68db42b9bb8cffa717a04ba967d7cc100R198-R243)

**Documentation and Changelog:**

* Added detailed release notes for v3.0.3 and v3.0.2 to `CHANGELOG.md`, including a new section with clear rules and a template for future changelog entries. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R42) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R531-R572)

**Other:**

* Minor cleanup in `VoiceSessionTest` (removed unused import).