### PR TITLE
Add dispatch-on-save and prune-chunks command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.1.1](https://github.com/atlas-php/atlas/releases/tag/v3.1.1) - 2026-05-16
+
+### Added
+
+- Dispatch-on-save chunked indexing — edits embed within seconds, no polling. Opt out: `atlas.embeddings.dispatch_on_save = false`.
+- `atlas:prune-chunks` — split the orphan scan onto its own (daily) schedule.
+- `atlas:chunk --skip-orphans` flag for when running prune separately.
+
+### Changed
+
+- Rapid edits to the same record collapse into one queued job and debounce until `sweep_settle` seconds after the last save (`ShouldBeUnique`).
+- Recommended `atlas:chunk` cadence: `hourly()` (was every-minute). It's a safety net now.
+
+### Migration
+
+**No breaking changes.** 
+
+Existing schedules keep working. Recommended:
+
+```php
+$schedule->command('atlas:chunk')->hourly()->withoutOverlapping();
+$schedule->command('atlas:prune-chunks')->daily()->withoutOverlapping();
+```
+
+---
+
 ## [v3.1.0](https://github.com/atlas-php/atlas/releases/tag/v3.1.0) - 2026-05-12
 
 ### Added

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -272,11 +272,24 @@ return [
     | The chunked-embeddings keys below are used when a model includes the
     | HasChunkedEmbeddings trait. The chunker splits long content into pieces
     | sized to chunk_size (with chunk_overlap tokens of context between
-    | adjacent chunks), and a scheduled sweep reconciles edits against the
-    | atlas_chunks table. Token counts use a chars/4 heuristic — exact for
+    | adjacent chunks). Token counts use a chars/4 heuristic — exact for
     | OpenAI-family models within a few percent and dependency-free. Internal
     | hard limits live as class constants on MarkdownChunker; consumers who
     | need different limits swap in a custom chunker.
+    |
+    | Indexing trigger:
+    |   - `dispatch_on_save = true` (default): a chunkable model's `saved`
+    |     hook dispatches `ChunkContentJob` with a `sweep_settle` second
+    |     delay. Chunking happens within seconds of an edit. `atlas:chunk`
+    |     becomes a backstop and can run hourly.
+    |   - `dispatch_on_save = false`: skips the save-time dispatch entirely;
+    |     `atlas:chunk` runs every minute as the sole trigger (legacy mode).
+    |
+    | Cadences:
+    |   - sweep_settle  — delay before chunking after the last edit. Also
+    |                     filters the safety-net sweep's eligibility window.
+    |   - sweep_batch   — max jobs the safety-net sweep dispatches per tick.
+    |   - max_failures  — failure count past which a row is excluded.
     |
     */
 
@@ -285,6 +298,7 @@ return [
         'chunker' => MarkdownChunker::class,
         'chunk_size' => 512,
         'chunk_overlap' => 50,
+        'dispatch_on_save' => true,
         'sweep_batch' => 50,
         'sweep_settle' => 60,
         'max_failures' => 5,

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -278,8 +278,9 @@ return [
         'chunker' => MarkdownChunker::class,    // default chunker for HasChunkedEmbeddings models
         'chunk_size' => 512,                    // soft cap per chunk, in tokens (chars/4 heuristic)
         'chunk_overlap' => 50,                  // tokens of overlap between adjacent chunks
+        'dispatch_on_save' => true,             // dispatch ChunkContentJob from the saved hook (set false to use sweep-only)
         'sweep_batch' => 50,                    // rows the atlas:chunk sweep dispatches per model per run
-        'sweep_settle' => 60,                   // seconds since updated_at before a dirty row is eligible
+        'sweep_settle' => 60,                   // seconds to wait after the last edit before chunking (also debounces dispatch-on-save)
         'max_failures' => 5,                    // attempts before a row is excluded from sweeps
     ],
 

--- a/docs/guides/artisan-commands.md
+++ b/docs/guides/artisan-commands.md
@@ -134,7 +134,7 @@ The tool name is automatically generated as `snake_case` from the class name. A 
 
 ## atlas:chunk
 
-Sweep registered chunkable models for dirty rows and dispatch reconciler jobs:
+Safety-net sweep for chunkable rows that bypassed dispatch-on-save (raw `DB::table()->update()`, mass seeds, queue outages, or consumers running with `dispatch_on_save = false`). Also prunes orphan chunks unless `--skip-orphans` is passed.
 
 ```bash
 php artisan atlas:chunk
@@ -142,21 +142,39 @@ php artisan atlas:chunk
 
 A row is "dirty" when its `content_hash` differs from `indexed_hash` and its `updated_at` is older than `atlas.embeddings.sweep_settle` seconds (default 60). Each dirty row dispatches one `ChunkContentJob` onto the configured queue. Rows that have hit `atlas.embeddings.max_failures` are excluded.
 
-Schedule it in `routes/console.php`:
+Recommended schedule:
 
 ```php
 use Illuminate\Support\Facades\Schedule;
 
-Schedule::command('atlas:chunk')->everyMinute()->withoutOverlapping();
+Schedule::command('atlas:chunk')->hourly()->withoutOverlapping();
+Schedule::command('atlas:prune-chunks')->daily()->withoutOverlapping();
 ```
 
-The sweep also prunes orphan chunks left behind by mass-delete (query-builder `delete()`, which skips model events). Soft-deleted owners are not treated as orphans — their chunks survive for restore.
+With dispatch-on-save enabled (default), the trait's `saved` hook handles the hot path; `atlas:chunk` is just a backstop. If you keep the orphan scan here, you can drop `atlas:prune-chunks`; if you split them, pass `--skip-orphans` to `atlas:chunk`.
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
 | `--model={class}` | Only sweep the given fully-qualified model class. Default: every model registered via `Atlas::registerChunkable()`. |
+| `--skip-orphans` | Skip the orphan-chunk purge — run `atlas:prune-chunks` separately. |
+
+## atlas:prune-chunks
+
+Delete chunk rows whose owner record no longer exists. Use this when you want the orphan scan on a slower cadence than `atlas:chunk` (it's the more expensive of the two — a full `atlas_chunks` scan per chunkable type).
+
+```bash
+php artisan atlas:prune-chunks
+```
+
+Recommended cadence: daily. Soft-deleted owners are not treated as orphans — their chunks survive for restore.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--model={class}` | Only prune for the given chunkable class. Default: every registered chunkable model. |
 
 ## atlas:rechunk
 

--- a/docs/modalities/embeddings.md
+++ b/docs/modalities/embeddings.md
@@ -249,11 +249,13 @@ For long-form content that gets edited continuously, a single whole-record embed
 ### How it works
 
 1. The model uses the `HasChunkedEmbeddings` trait and declares which column holds the content.
-2. On save, the trait recomputes a `content_hash` of the column. **No embedding work happens on the save path.**
-3. A scheduled `atlas:chunk` artisan command sweeps dirty rows (`content_hash != indexed_hash`) past a settle period and dispatches a reconciler job per row.
+2. On save, the trait recomputes a `content_hash` of the column and dispatches `ChunkContentJob` with a `sweep_settle`-second delay. **No embedding work happens on the save path itself.**
+3. The job is `ShouldBeUnique` per row, so rapid edits collapse into a single queued job; it self-releases until `sweep_settle` seconds have passed since the last edit. Chunking runs once per edit burst, against the latest content.
 4. The job runs the configured chunker, diffs the result against existing chunks by content hash, and embeds only the chunks that are new or changed.
 
-A single-paragraph edit on a 20-chunk record re-embeds 1–2 chunks, not 20.
+A single-paragraph edit on a 20-chunk record re-embeds 1–2 chunks, not 20. A 60-save typing burst within a minute triggers one embed at the end, not 60.
+
+Set `atlas.embeddings.dispatch_on_save = false` to disable the save-hook trigger and rely solely on the `atlas:chunk` sweep (legacy mode).
 
 ### Setup
 
@@ -354,15 +356,16 @@ foreach (Atlas::chunkables() as $class) {
 }
 ```
 
-#### 4. Schedule the sweep
+#### 4. Schedule the safety-net commands
 
-In `routes/console.php` or `App\Console\Kernel`:
+Dispatch-on-save handles the hot path. Schedule `atlas:chunk` as a backstop (raw SQL updates, queue outages) and `atlas:prune-chunks` for orphan cleanup:
 
 ```php
-Schedule::command('atlas:chunk')->everyMinute()->withoutOverlapping();
+Schedule::command('atlas:chunk')->hourly()->withoutOverlapping();
+Schedule::command('atlas:prune-chunks')->daily()->withoutOverlapping();
 ```
 
-Saving a model with a non-empty `body` marks it dirty; the next sweep picks it up after the settle period.
+If you prefer everything in one command, keep the legacy `Schedule::command('atlas:chunk')->everyMinute()` — it still works and still does the orphan scan.
 
 ### Direct synchronous use (no queue, no command)
 
@@ -397,8 +400,9 @@ All knobs live under `config('atlas.embeddings')`:
     'chunker' => MarkdownChunker::class,    // changing this does NOT re-chunk existing rows
     'chunk_size' => 512,            // soft cap per chunk, in tokens (chars/4 heuristic) — does NOT re-chunk on change
     'chunk_overlap' => 50,          // tokens of overlap between adjacent chunks — does NOT re-chunk on change
-    'sweep_batch' => 50,            // rows the sweep dispatches per model per run
-    'sweep_settle' => 60,           // seconds since updated_at before a dirty row is eligible
+    'dispatch_on_save' => true,     // dispatch ChunkContentJob from the saved hook (false = sweep-only)
+    'sweep_batch' => 50,            // rows the safety-net sweep dispatches per model per run
+    'sweep_settle' => 60,           // seconds to wait after the last edit before chunking (also debounces dispatch-on-save)
     'max_failures' => 5,            // attempts before a row is excluded from sweeps
 ],
 ```
@@ -467,7 +471,7 @@ class Transcript extends Model implements Chunkable
 
 ### Orphan cleanup
 
-Polymorphic relations can't carry FK cascades, so deleting an owner row via Eloquent's mass-delete (`Project::where(...)->delete()`) bypasses the trait's `deleting` hook and would leave chunks behind. The `atlas:chunk` sweep cleans these up automatically — every run prunes any chunk whose `chunkable_id` is no longer present in its owner table. Soft-deleted rows are not treated as orphans by the sweep — the row still exists in the table.
+Polymorphic relations can't carry FK cascades, so deleting an owner row via Eloquent's mass-delete (`Project::where(...)->delete()`) bypasses the trait's `deleting` hook and would leave chunks behind. Both `atlas:chunk` (when run without `--skip-orphans`) and the dedicated `atlas:prune-chunks` command clean these up — every run prunes any chunk whose `chunkable_id` is no longer present in its owner table. Split the orphan scan onto its own daily schedule (`atlas:prune-chunks`) if you want `atlas:chunk` to run frequently without paying for the full `atlas_chunks` scan each tick. Soft-deleted rows are not treated as orphans — the row still exists in the table.
 
 If you delete owner rows one-by-one via `$model->delete()` or `Model::destroy(...)`, the trait fires its `deleting` hook synchronously and chunks are removed immediately. This applies to both hard deletes and soft deletes — `$model->delete()` on a `SoftDeletes` model fires `deleting`, so its chunks are wiped even though the owner row remains. After `restore()`, the owner's content is intact but its chunks are gone. The sweep won't automatically re-chunk the restored row because the delete didn't touch the hash columns — `content_hash` still equals `indexed_hash` from the last successful sweep, so the dirty-row predicate sees no work to do. To regenerate embeddings, call `$model->chunkNow()` inline, run `php artisan atlas:rechunk "App\Models\Project" {id}` to defer to the queue, or touch the indexed field on the model (which triggers the saving hook and re-hashes `content_hash`). This avoids stale embeddings accumulating forever for soft-deleted records that are never restored.
 

--- a/sandbox/test-chunked-embeddings-dispatch-on-save.php
+++ b/sandbox/test-chunked-embeddings-dispatch-on-save.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Chunked Embeddings — Dispatch-on-Save + Debounce End-to-End Test
+ *
+ * Validates the v3.1.1 dispatch path against a real Postgres + database
+ * queue + (optional) OpenAI provider. Where test-chunked-embeddings.php
+ * exercises the synchronous reconciler, this script exercises the path
+ * a real consumer would use in production: save the model, let the
+ * trait dispatch the job, let the queue worker process it.
+ *
+ * Sections:
+ *   1. Single save dispatches exactly one ChunkContentJob with the
+ *      configured settle delay.
+ *   2. ShouldBeUnique collapses an 11-save burst into one queued job.
+ *   3. Different rows get separate unique jobs (uniqueId is per-row).
+ *   4. dispatch_on_save = false suppresses dispatch entirely.
+ *   5. Queue worker processes the job past the settle window and
+ *      chunks land in atlas_chunks.
+ *   6. Debounce: a save mid-window causes the worker to release the
+ *      job back to the queue instead of chunking against fresh content.
+ *
+ * Usage:
+ *   cd sandbox
+ *   php artisan migrate:fresh           # one-time / schema reset
+ *   php test-chunked-embeddings-dispatch-on-save.php
+ *
+ * Requires:
+ *   - DB_CONNECTION=pgsql with pgvector
+ *   - QUEUE_CONNECTION=database (the script inspects the `jobs` table)
+ *   - OPENAI_API_KEY in sandbox/.env for section 5's embed call
+ *
+ * The script DOES NOT need an external `queue:work` running — it
+ * processes jobs inline via Artisan::call('queue:work --once').
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+use App\Models\Project;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Persistence\Models\Chunk;
+use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+$app['config']->set('atlas.defaults.embed', [
+    'provider' => 'openai',
+    'model' => env('ATLAS_EMBED_MODEL', 'text-embedding-3-small'),
+]);
+$app['config']->set('atlas.providers.openai', [
+    'api_key' => env('OPENAI_API_KEY'),
+    'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+]);
+// Tight settle so the queue worker can drain in a reasonable test runtime.
+$app['config']->set('atlas.embeddings.sweep_settle', 3);
+$app['config']->set('atlas.embeddings.dispatch_on_save', true);
+$app['config']->set('atlas.embeddings.chunk_size', 200);
+AtlasConfig::refresh();
+
+// ─── Preflight ──────────────────────────────────────────────────────────────
+
+if (DB::connection()->getDriverName() !== 'pgsql') {
+    echo "This test requires PostgreSQL (DB_CONNECTION=pgsql). Aborting.\n";
+    exit(1);
+}
+
+if (config('queue.default') !== 'database') {
+    echo "This test requires QUEUE_CONNECTION=database (it inspects the `jobs` table).\n";
+    echo 'Current: '.config('queue.default')."\n";
+    exit(1);
+}
+
+if (! Schema::hasTable('projects') || ! Schema::hasTable('atlas_chunks') || ! Schema::hasTable('jobs')) {
+    echo "Missing tables — run `php artisan migrate:fresh` first.\n";
+    exit(1);
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+$failures = [];
+
+function section(string $title): void
+{
+    echo "\n".str_repeat('─', 76)."\n  {$title}\n".str_repeat('─', 76)."\n";
+}
+
+function check(string $name, bool $ok, string $detail = ''): void
+{
+    global $failures;
+    $mark = $ok ? '✓' : '✗';
+    $line = "  {$mark} {$name}";
+    if ($detail !== '') {
+        $line .= " — {$detail}";
+    }
+    echo $line."\n";
+    if (! $ok) {
+        $failures[] = $name.($detail !== '' ? ": {$detail}" : '');
+    }
+}
+
+function queuedChunkJobs(): int
+{
+    return (int) DB::table('jobs')
+        ->where('payload', 'like', '%ChunkContentJob%')
+        ->count();
+}
+
+function clearAll(): void
+{
+    DB::table('atlas_chunks')->delete();
+    DB::table('projects')->delete();
+    DB::table('jobs')->delete();
+    DB::table('failed_jobs')->delete();
+    // Clear any lingering unique-lock keys from a prior run.
+    Cache::flush();
+}
+
+// ─── 1. Single save dispatches one delayed job ──────────────────────────────
+
+section('1. Single save dispatches exactly one ChunkContentJob (with delay)');
+
+clearAll();
+$now = time();
+
+$project = Project::create([
+    'title' => 'Single save',
+    'body' => 'A body that is long enough to chunk. '.str_repeat('Some prose content. ', 20),
+]);
+
+$jobs = DB::table('jobs')->where('payload', 'like', '%ChunkContentJob%')->get();
+check('exactly one ChunkContentJob is queued', $jobs->count() === 1, "got {$jobs->count()}");
+
+if ($jobs->isNotEmpty()) {
+    $job = $jobs->first();
+    $payload = json_decode($job->payload, true);
+    $expectedClass = 'Atlasphp\\Atlas\\Queue\\Jobs\\ChunkContentJob';
+    $actualClass = $payload['displayName'] ?? $payload['data']['commandName'] ?? null;
+    check('job class is ChunkContentJob', $actualClass === $expectedClass, "got: {$actualClass}");
+
+    // Verify the delay is approximately sweep_settle seconds.
+    $delay = $job->available_at - $now;
+    check('job is delayed approximately sweep_settle seconds',
+        $delay >= 2 && $delay <= 5,
+        "delay = {$delay}s (expected ~3s)");
+}
+
+// ─── 2. ShouldBeUnique collapses many rapid saves ───────────────────────────
+
+section('2. ShouldBeUnique collapses an 11-save burst into one queued job');
+
+clearAll();
+
+$project = Project::create(['title' => 'Burst project', 'body' => 'edit 0 — '.str_repeat('words ', 30)]);
+for ($i = 1; $i <= 10; $i++) {
+    $project->update(['body' => "edit {$i} — ".str_repeat('words ', 30)]);
+}
+
+$count = queuedChunkJobs();
+check('only one job queued despite 11 saves', $count === 1, "got {$count}");
+
+// ─── 3. Separate rows get separate unique jobs ──────────────────────────────
+
+section('3. Separate rows get separate unique jobs (uniqueId is per-row)');
+
+clearAll();
+
+$a = Project::create(['title' => 'Project A', 'body' => 'A '.str_repeat('words ', 30)]);
+$b = Project::create(['title' => 'Project B', 'body' => 'B '.str_repeat('words ', 30)]);
+$c = Project::create(['title' => 'Project C', 'body' => 'C '.str_repeat('words ', 30)]);
+
+$count = queuedChunkJobs();
+check('three separate jobs queued', $count === 3, "got {$count}");
+
+// ─── 4. dispatch_on_save = false suppresses dispatch ────────────────────────
+
+section('4. dispatch_on_save = false suppresses dispatch entirely');
+
+clearAll();
+config(['atlas.embeddings.dispatch_on_save' => false]);
+AtlasConfig::refresh();
+
+Project::create(['title' => 'No-dispatch', 'body' => 'content '.str_repeat('words ', 30)]);
+
+$count = queuedChunkJobs();
+check('no jobs queued when dispatch_on_save is false', $count === 0, "got {$count}");
+
+config(['atlas.embeddings.dispatch_on_save' => true]);
+AtlasConfig::refresh();
+
+// ─── 5. Queue worker processes and chunks land ──────────────────────────────
+
+section('5. Queue worker processes the job past the settle window');
+
+clearAll();
+
+$project = Project::create([
+    'title' => 'End-to-end project',
+    'body' => 'A multi-paragraph body that the chunker should produce real chunks for. '
+        .str_repeat('The architecture uses event sourcing and the projection rebuilds state on the fly. ', 5)
+        .'This is enough text to verify embedding lands in atlas_chunks.',
+]);
+
+check('one ChunkContentJob queued for the new project', queuedChunkJobs() === 1);
+
+// Sleep past the settle window so the worker can claim the job.
+echo '  waiting '.(config('atlas.embeddings.sweep_settle') + 1)."s for the settle window to elapse...\n";
+sleep((int) config('atlas.embeddings.sweep_settle') + 1);
+
+// Process the queue until empty (max 30s wall-clock).
+Artisan::call('queue:work', [
+    '--once' => true,
+    '--stop-when-empty' => true,
+    '--timeout' => 30,
+]);
+
+$project->refresh();
+$chunkCount = Chunk::query()->where('chunkable_id', $project->id)->count();
+
+check('project indexed_hash matches content_hash after processing',
+    $project->indexed_hash === $project->content_hash,
+    "indexed_hash={$project->indexed_hash}");
+check('atlas_chunks has rows for this project', $chunkCount > 0, "got {$chunkCount}");
+check('queue is empty after processing', queuedChunkJobs() === 0);
+
+// ─── 6. Debounce: mid-window save causes the worker to release ──────────────
+
+section('6. Debounce — mid-window save causes the worker to release, not embed');
+
+clearAll();
+// Stretch the settle so we have headroom to interleave timing.
+config(['atlas.embeddings.sweep_settle' => 8]);
+AtlasConfig::refresh();
+
+$project = Project::create([
+    'title' => 'Debounce project',
+    'body' => 'Initial body — '.str_repeat('words ', 30),
+]);
+
+// Wait long enough for the original delay to pass, then save again JUST
+// before processing so updated_at is fresh and the debounce engages.
+echo "  waiting 9s for the initial delay window...\n";
+sleep(9);
+
+// Mid-window edit: now updated_at = ~0s ago. The job will fire (available_at
+// has passed) but the worker should release it again because the row was
+// just touched.
+$project->update(['body' => 'Mid-window edit — '.str_repeat('words ', 30)]);
+echo "  saved again mid-window; updated_at is fresh\n";
+
+// Process one job — the worker should release the existing job, not embed.
+$attemptsBefore = (int) (DB::table('jobs')->where('payload', 'like', '%ChunkContentJob%')->value('attempts') ?? 0);
+
+Artisan::call('queue:work', [
+    '--once' => true,
+    '--stop-when-empty' => false,
+    '--timeout' => 5,
+]);
+
+$attemptsAfter = (int) (DB::table('jobs')->where('payload', 'like', '%ChunkContentJob%')->value('attempts') ?? 0);
+$stillQueued = queuedChunkJobs();
+
+check('job still in queue after worker run (was released, not completed)',
+    $stillQueued === 1,
+    "got {$stillQueued} job(s) queued; attempts before={$attemptsBefore}, after={$attemptsAfter}");
+
+// Now wait for the settle window to clear and let the worker finish it.
+echo "  waiting 9s for the settle window to clear...\n";
+sleep(9);
+
+Artisan::call('queue:work', [
+    '--once' => true,
+    '--stop-when-empty' => true,
+    '--timeout' => 30,
+]);
+
+$project->refresh();
+$chunkCount = Chunk::query()->where('chunkable_id', $project->id)->count();
+
+check('project indexed after the settle window passed',
+    $project->indexed_hash === $project->content_hash);
+check('atlas_chunks populated for the debounced project', $chunkCount > 0, "got {$chunkCount}");
+check('queue drained after final embed', queuedChunkJobs() === 0);
+
+// ─── Summary ────────────────────────────────────────────────────────────────
+
+section('Summary');
+
+if (! empty($failures)) {
+    echo "\n  ".count($failures)." assertion(s) FAILED:\n";
+    foreach ($failures as $f) {
+        echo "    - {$f}\n";
+    }
+    exit(1);
+}
+
+echo "\n  All assertions passed.\n";

--- a/src/AtlasConfig.php
+++ b/src/AtlasConfig.php
@@ -44,6 +44,7 @@ class AtlasConfig
         public readonly int $chunkSweepBatch = 50,
         public readonly int $chunkSweepSettle = 60,
         public readonly int $chunkMaxFailures = 5,
+        public readonly bool $chunkDispatchOnSave = true,
         public readonly ?string $cacheStore = null,
         public readonly string $cachePrefix = 'atlas',
         /** @var array{models: int, voices: int, embeddings: int} */
@@ -124,6 +125,7 @@ class AtlasConfig
             chunkSweepBatch: (int) config('atlas.embeddings.sweep_batch', 50),
             chunkSweepSettle: (int) config('atlas.embeddings.sweep_settle', 60),
             chunkMaxFailures: (int) config('atlas.embeddings.max_failures', 5),
+            chunkDispatchOnSave: (bool) config('atlas.embeddings.dispatch_on_save', true),
             cacheStore: config('atlas.cache.store'),
             cachePrefix: config('atlas.cache.prefix', 'atlas'),
             cacheTtl: config('atlas.cache.ttl', ['models' => 86400, 'voices' => 3600, 'embeddings' => 0]),

--- a/src/AtlasServiceProvider.php
+++ b/src/AtlasServiceProvider.php
@@ -114,6 +114,7 @@ class AtlasServiceProvider extends ServiceProvider
                 Console\CleanStaleVoiceSessionsCommand::class,
                 Console\MiddlewareCommand::class,
                 Console\ChunkCommand::class,
+                Console\PruneChunksCommand::class,
                 Console\RechunkCommand::class,
             ]);
 

--- a/src/Console/ChunkCommand.php
+++ b/src/Console/ChunkCommand.php
@@ -13,26 +13,48 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Sweeps registered chunkable models for dirty rows and dispatches reconciler jobs.
+ * Sweeps registered chunkable models for dirty rows and dispatches
+ * reconciler jobs. Also prunes orphan chunk rows on every tick.
  *
- * Schedule:
- *   Schedule::command('atlas:chunk')->everyMinute()->withoutOverlapping();
+ * As of the dispatch-on-save release, the trait's `saved` hook is
+ * the primary trigger and this command is a backstop for rows that
+ * bypass model events (raw `DB::table()->update()`, mass factory
+ * seeds, prior data, queue outages) plus the legacy code path for
+ * consumers running with `atlas.embeddings.dispatch_on_save = false`.
  *
- * The settle period (config: embeddings.sweep_settle) prevents re-embedding
- * mid-edit: a row whose updated_at is more recent than NOW() - settle is
- * not eligible. After max_failures consecutive failures, a row is excluded
- * from sweeps and shows up via the model's index_failure_count column.
+ * Recommended schedule:
+ *   Schedule::command('atlas:chunk')->hourly()->withoutOverlapping();
+ *
+ * The previously-recommended every-minute cadence still works; it's
+ * just unnecessary now that dispatch-on-save handles the hot path.
+ * Consumers wanting to split the orphan scan onto a different
+ * cadence can run `atlas:chunk --skip-orphans` here and schedule
+ * `atlas:prune-chunks` (daily) separately.
+ *
+ * Mechanics: scans each registered chunkable model for rows whose
+ * `content_hash` differs from `indexed_hash`, filters out rows
+ * inside the settle window or past the failure cap, and dispatches
+ * a `ChunkContentJob` per remaining row (capped at `sweep_batch`
+ * per tick). Orphan chunks (chunk rows whose owner no longer
+ * exists) are deleted unless `--skip-orphans` is passed.
+ *
+ * Scale note: the dirty predicate (`IS DISTINCT FROM`) is not
+ * served by a regular btree on `(content_hash, indexed_hash)`.
+ * Consumers expecting >1M-row tables should add a partial index
+ * — see ChunkedEmbeddingColumns docblock for the recommended DDL.
  */
 class ChunkCommand extends Command
 {
     protected $signature = 'atlas:chunk
-        {--model= : Only sweep this fully-qualified model class (default: all registered)}';
+        {--model= : Only sweep this fully-qualified model class (default: all registered)}
+        {--skip-orphans : Skip the orphan-chunk purge step (run atlas:prune-chunks separately)}';
 
     protected $description = 'Sweep dirty chunkable records and dispatch embedding reconciliation jobs.';
 
     public function handle(ChunkableRegistry $registry, AtlasConfig $config): int
     {
         $only = $this->option('model');
+        $skipOrphans = (bool) $this->option('skip-orphans');
         $classes = $registry->all();
 
         if ($only !== null) {
@@ -57,9 +79,11 @@ class ChunkCommand extends Command
 
         $totalDispatched = 0;
         $totalOrphansDeleted = 0;
-        // PG supports IS DISTINCT FROM and has a partial index keyed on it
-        // (see ChunkedEmbeddingColumns::add); use the same predicate so the
-        // index can be applied. Other drivers fall back to COALESCE.
+        // Postgres treats NULL-vs-value as distinct under `IS DISTINCT
+        // FROM`, which is the semantics we need (a fresh row has
+        // indexed_hash = NULL and content_hash = some-hash, and must be
+        // picked up). Other drivers don't have that operator; COALESCE
+        // approximates it.
         $isPostgres = DB::connection()->getDriverName() === 'pgsql';
         $dirtyPredicate = $isPostgres
             ? 'content_hash IS DISTINCT FROM indexed_hash'
@@ -78,22 +102,25 @@ class ChunkCommand extends Command
             // Polymorphic relations can't carry FK cascades, so chunks for
             // a hard-deleted owner can outlive the owner — most commonly
             // when a consumer mass-deletes (Eloquent skips model events on
-            // query-builder delete). Prune those orphans on every sweep.
+            // query-builder delete). Prune those orphans unless the caller
+            // opted out (e.g. running this hourly + atlas:prune-chunks daily).
             //
             // Use withoutGlobalScopes() so SoftDeletes-using owners are NOT
             // treated as orphans — the row still exists in the DB and can be
             // restored. Without this guard the sweep would prune chunks the
             // moment an owner is soft-deleted, losing the embedding work.
-            $orphanDeleted = $chunkModel::query()
-                ->where('chunkable_type', $morphClass)
-                ->whereNotIn(
-                    'chunkable_id',
-                    $class::query()->withoutGlobalScopes()->select($key),
-                )
-                ->delete();
-            if ($orphanDeleted > 0) {
-                $totalOrphansDeleted += $orphanDeleted;
-                $this->info('['.$class.'] pruned '.$orphanDeleted.' orphan chunk(s).');
+            if (! $skipOrphans) {
+                $orphanDeleted = $chunkModel::query()
+                    ->where('chunkable_type', $morphClass)
+                    ->whereNotIn(
+                        'chunkable_id',
+                        $class::query()->withoutGlobalScopes()->select($key),
+                    )
+                    ->delete();
+                if ($orphanDeleted > 0) {
+                    $totalOrphansDeleted += $orphanDeleted;
+                    $this->info('['.$class.'] pruned '.$orphanDeleted.' orphan chunk(s).');
+                }
             }
 
             $ids = $class::query()

--- a/src/Console/PruneChunksCommand.php
+++ b/src/Console/PruneChunksCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Console;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Embeddings\ChunkableRegistry;
+use Atlasphp\Atlas\Persistence\Models\Chunk;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Purges orphan chunk rows whose owner record no longer exists.
+ *
+ * Schedule:
+ *   Schedule::command('atlas:prune-chunks')->daily()->withoutOverlapping();
+ *
+ * Most chunk lifecycle is handled inline:
+ *   - Eloquent `$model->delete()` fires the trait's deleting hook and
+ *     removes chunks synchronously.
+ *   - `$model->update($body)` flips content_hash, dispatch-on-save
+ *     reconciles, the diff/insert/delete path inside
+ *     ChunkContentService keeps chunks aligned with current content.
+ *
+ * This command handles the residual cases those two paths can't see:
+ *   - DB-level FK CASCADE deletes that bypass Eloquent events entirely.
+ *   - Raw `DB::table('owners')->delete()` calls.
+ *   - Crash recovery: a chunk row written before its owner row was
+ *     committed in a failed transaction.
+ *
+ * Daily cadence is the right tradeoff: orphan chunks waste disk and
+ * may surface in similarity search until pruned, but they don't break
+ * correctness. A daily run keeps drift bounded without paying for an
+ * `atlas_chunks`-wide scan every minute.
+ *
+ * Soft-delete safety: `withoutGlobalScopes()` is applied so SoftDeletes
+ * owners are NOT treated as orphans — the row still exists in the DB
+ * and can be restored.
+ */
+class PruneChunksCommand extends Command
+{
+    protected $signature = 'atlas:prune-chunks
+        {--model= : Only prune chunks for this fully-qualified model class (default: all registered)}';
+
+    protected $description = 'Delete chunk rows whose owner record no longer exists.';
+
+    public function handle(ChunkableRegistry $registry, AtlasConfig $config): int
+    {
+        $only = $this->option('model');
+        $classes = $registry->all();
+
+        if ($only !== null) {
+            if (! $registry->has((string) $only)) {
+                $this->error("Model [{$only}] is not registered as chunkable.");
+
+                return self::FAILURE;
+            }
+            $classes = [(string) $only];
+        }
+
+        if (empty($classes)) {
+            $this->info('No chunkable models registered. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        /** @var class-string<Chunk> $chunkModel */
+        $chunkModel = $config->model('chunk', Chunk::class);
+
+        $totalDeleted = 0;
+
+        foreach ($classes as $class) {
+            /** @var class-string<Model> $class */
+            /** @var Model $sample */
+            $sample = new $class;
+            $key = $sample->getKeyName();
+            $morphClass = $sample->getMorphClass();
+
+            $deleted = $chunkModel::query()
+                ->where('chunkable_type', $morphClass)
+                ->whereNotIn(
+                    'chunkable_id',
+                    $class::query()->withoutGlobalScopes()->select($key),
+                )
+                ->delete();
+
+            if ($deleted > 0) {
+                $totalDeleted += $deleted;
+                $this->info('['.$class.'] pruned '.$deleted.' orphan chunk(s).');
+            }
+        }
+
+        $this->info("Done. {$totalDeleted} orphan chunk(s) pruned.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Persistence/Concerns/HasChunkedEmbeddings.php
+++ b/src/Persistence/Concerns/HasChunkedEmbeddings.php
@@ -11,17 +11,37 @@ use Atlasphp\Atlas\Embeddings\Chunkers\Chunker;
 use Atlasphp\Atlas\Embeddings\Chunkers\MarkdownChunker;
 use Atlasphp\Atlas\Persistence\Models\Chunk;
 use Atlasphp\Atlas\Persistence\Services\ChunkContentService;
+use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Queue\SyncQueue;
+use Illuminate\Support\Facades\Queue;
 
 /**
  * Adds chunked embedding support to an Eloquent model.
  *
- * Maintains a content_hash column on save (so the sweep can find dirty rows)
- * and cascade-deletes related atlas_chunks rows on delete (no FK because the
- * relation is polymorphic). The actual chunking + embedding happens out of
- * band in the atlas:chunk artisan command — saving is intentionally
- * lightweight and synchronous.
+ * The trait wires three hooks:
+ *
+ *  1. `saving` — stamps `content_hash` from the chunkable field whenever
+ *     the field is dirty. Cheap, synchronous, runs on every save.
+ *  2. `saved` — dispatches `ChunkContentJob` with a settle-window delay
+ *     when `content_hash` actually changed. This is the on-demand
+ *     trigger that replaces polling: chunking happens within ~settle
+ *     seconds of an edit instead of waiting for the next sweep tick.
+ *     Disable with `atlas.embeddings.dispatch_on_save = false` to fall
+ *     back to sweep-only behavior.
+ *  3. `deleting` — cascade-deletes chunks for this owner (the relation
+ *     is polymorphic, so no FK can carry the delete).
+ *
+ * The `atlas:chunk` sweep stays as a backstop — it catches rows that
+ * bypass the save hook (raw `DB::table()->update()`, factories, etc.)
+ * and rows where dispatch was lost (Redis crash, worker outage). With
+ * dispatch-on-save enabled, the recommended cadence drops from
+ * every-minute to hourly.
+ *
+ * Multi-tenant: dispatch runs in the request's tenant context, so the
+ * queued job inherits the right connection through whichever tenancy
+ * package the consumer uses. Atlas itself stores nothing about tenancy.
  *
  * To opt a model in:
  *   1. Add the trait
@@ -56,6 +76,45 @@ trait HasChunkedEmbeddings
                 'content_hash',
                 $value === '' ? null : hash('xxh128', $value),
             );
+        });
+
+        static::saved(function (Chunkable&Model $model): void {
+            // `wasChanged()` only reports changes on UPDATE — Eloquent
+            // does not call `syncChanges()` in `performInsert()`, so a
+            // fresh INSERT looks unchanged. Compare the current attribute
+            // against `getOriginal()` instead: that returns null for
+            // newly-created rows (their original snapshot hasn't been
+            // synced yet at the `saved` event) and the prior value for
+            // updates.
+            if ($model->getAttribute('content_hash') === $model->getOriginal('content_hash')) {
+                return;
+            }
+
+            $config = app(AtlasConfig::class);
+            if (! $config->chunkDispatchOnSave) {
+                return;
+            }
+
+            // The sync queue runs jobs immediately and treats `release()`
+            // as a no-op delete (the job vanishes), while ShouldBeUnique
+            // keeps the lock held for `uniqueFor` seconds — so a sync
+            // consumer would lose chunked work and block re-dispatch.
+            // Skip the dispatch path entirely on sync; the safety-net
+            // sweep still catches the dirty row. Resolves the default
+            // queue connection (the one the dispatch would actually use).
+            if (Queue::connection() instanceof SyncQueue) {
+                return;
+            }
+
+            // `$model::class` not `static::class` — `static` here resolves
+            // to the trait-using class at trait-boot time, but multiple
+            // models share the trait and the closure runs late, so we
+            // want the actual instance's class. ChunkContentJob uses this
+            // to query::find(); morph map aliases would silently break
+            // that lookup.
+            ChunkContentJob::dispatch($model::class, $model->getKey())
+                ->onQueue($config->queue)
+                ->delay(now()->addSeconds($config->chunkSweepSettle));
         });
 
         static::deleting(function (Model $model): void {

--- a/src/Persistence/Schema/ChunkedEmbeddingColumns.php
+++ b/src/Persistence/Schema/ChunkedEmbeddingColumns.php
@@ -10,15 +10,28 @@ use Illuminate\Database\Schema\Blueprint;
  * Schema helper for adding chunked-embedding tracking columns to a consumer model's table.
  *
  * Adds the five columns the HasChunkedEmbeddings trait expects:
- *  - content_hash, indexed_hash: drives the dirty-row detection in the sweep.
+ *  - content_hash, indexed_hash: drives the dirty-row detection.
  *  - indexed_at: last successful chunk run.
  *  - last_index_error, index_failure_count: backoff for repeated failures.
  *
- * Also adds a composite index on (content_hash, indexed_hash) — useful for
- * point lookups on either column during diagnostics. The sweep's main
- * dirty-row predicate (`IS DISTINCT FROM`) isn't directly served by this
- * index; that path benefits from the partial index the sweep creates at
- * its own query layer.
+ * Also adds a composite btree index on (content_hash, indexed_hash) for
+ * diagnostic point lookups.
+ *
+ * Scale note. The safety-net sweep's dirty predicate is
+ * `content_hash IS DISTINCT FROM indexed_hash`, which a regular btree
+ * cannot serve — Postgres has no equality/range bound to use either
+ * column. With dispatch-on-save enabled (default) this rarely matters:
+ * the safety net runs hourly and processes a small bounded batch.
+ * Consumers expecting >1M rows in a chunkable table — particularly if
+ * they also disable dispatch-on-save — should add a partial index in
+ * their own migration:
+ *
+ *   CREATE INDEX {table}_dirty_idx
+ *   ON {table} (updated_at)
+ *   WHERE content_hash IS DISTINCT FROM indexed_hash;
+ *
+ * Atlas does not create this automatically — it's Postgres-only DDL and
+ * the cost/benefit only kicks in at scale.
  *
  * Usage in a consumer migration:
  *

--- a/src/Queue/Jobs/ChunkContentJob.php
+++ b/src/Queue/Jobs/ChunkContentJob.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Queue\Jobs;
 
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Embeddings\Chunkable;
 use Atlasphp\Atlas\Exceptions\AtlasException;
 use Atlasphp\Atlas\Persistence\Services\ChunkContentService;
+use DateTimeInterface;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -17,24 +20,59 @@ use Illuminate\Queue\SerializesModels;
 /**
  * Queue job that reconciles a single record's chunked embeddings.
  *
- * Dispatched by the atlas:chunk sweep command per dirty row. Tries are
- * conservative — the sweep will pick up failures again on the next pass,
- * up to max_failures, so worker-level retry isn't load-bearing.
+ * Dispatched from two paths:
+ *   1. The trait's `saved` hook (on-demand, primary path).
+ *   2. The `atlas:chunk` safety-net sweep (backstop for rows that
+ *      bypassed Eloquent saves).
  *
- * The worker process is responsible for catching its own exceptions
- * (service handles that, and increments the record's failure counter);
- * the job re-raises so Laravel records the failure normally.
+ * Debounce semantics. The job implements `ShouldBeUnique` keyed by
+ * `modelClass:modelId`, so concurrent dispatches for the same row
+ * collapse into a single queued job. On execution the job checks
+ * `updated_at` against the settle window — if the row was edited
+ * within `sweep_settle` seconds, the job releases itself forward
+ * until the window passes since the last edit. The unique lock
+ * stays held across releases (Laravel only frees it once the job
+ * completes without releasing), so additional saves during the
+ * debounce period no-op at dispatch time. Net effect: chunking
+ * happens exactly once, `sweep_settle` seconds after the LAST
+ * edit, no matter how many saves came before.
+ *
+ * Idempotency. The handler also short-circuits when
+ * `content_hash === indexed_hash` (another job already reconciled,
+ * or content reverted) and when the failure cap is reached.
+ * ChunkContentService::reconcile()'s in-transaction content_hash
+ * recheck is a third layer of safety against stale writes.
+ *
+ * Retry budget. `retryUntil()` gives the job up to one hour of
+ * self-releases before Laravel marks it failed — a safety valve
+ * for never-ending edit storms. After that the row stays dirty
+ * and the safety-net sweep will pick it up.
  */
-class ChunkContentJob implements ShouldQueue
+class ChunkContentJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;
 
+    /**
+     * Preserved from v3.1.0 for backward-compat surface stability —
+     * `retryUntil()` is the authoritative budget (see the docblock),
+     * and the worker checks `retryUntil` first regardless of `$tries`.
+     * Kept so Horizon/Pulse dashboards and consumer tests that
+     * introspect `$tries` continue to see a non-null value.
+     */
     public int $tries = 1;
 
     public int $timeout = 300;
+
+    /**
+     * Unique-lock TTL in seconds. Long enough that an extended edit
+     * burst doesn't bypass debouncing by letting the lock expire,
+     * short enough that a crashed worker doesn't block dispatches
+     * forever.
+     */
+    public int $uniqueFor = 3600;
 
     /**
      * @param  class-string<Model>  $modelClass
@@ -44,10 +82,33 @@ class ChunkContentJob implements ShouldQueue
         public readonly int|string $modelId,
     ) {}
 
+    /**
+     * Per-row unique key. Two dispatches for the same model collapse
+     * into one queued job; the second dispatch is silently dropped
+     * (returns the existing job's payload).
+     */
+    public function uniqueId(): string
+    {
+        return $this->modelClass.':'.$this->modelId;
+    }
+
+    /**
+     * Allow self-releases to keep the job alive past the default
+     * `$tries` limit. After this timestamp Laravel marks the job
+     * failed; the row is then picked up by the safety-net sweep.
+     */
+    public function retryUntil(): DateTimeInterface
+    {
+        return now()->addHour();
+    }
+
     public function handle(ChunkContentService $service): void
     {
         $modelClass = $this->modelClass;
         $model = $modelClass::query()->find($this->modelId);
+
+        // Owner is gone — orphans are cleaned up by the sweep / prune
+        // command. Nothing to do here.
         if ($model === null) {
             return;
         }
@@ -56,6 +117,40 @@ class ChunkContentJob implements ShouldQueue
             throw new AtlasException(
                 "[{$modelClass}] dispatched to ChunkContentJob but does not implement ".Chunkable::class.'.'
             );
+        }
+
+        // Idempotent short-circuit: an earlier dispatch already reconciled
+        // this row, or content reverted to the indexed state. Exiting here
+        // is cheaper than going through the chunker + embed batch path.
+        if ($model->getAttribute('content_hash') === $model->getAttribute('indexed_hash')) {
+            return;
+        }
+
+        $config = app(AtlasConfig::class);
+
+        // Poison-row guard. After `max_failures` consecutive failures the
+        // row is excluded so the worker doesn't churn on a permanently
+        // broken record. Operators can clear `index_failure_count` and
+        // `last_index_error` to retry, or run `atlas:rechunk` to force.
+        if ((int) ($model->getAttribute('index_failure_count') ?? 0) >= $config->chunkMaxFailures) {
+            return;
+        }
+
+        // Debounce against the LAST edit. The dispatch-on-save delay only
+        // postpones the FIRST job in a burst; if the user keeps saving,
+        // we want chunking to wait until they stop. Re-release the same
+        // job until `sweep_settle` seconds have passed since the most
+        // recent edit. The unique lock is preserved across releases, so
+        // dispatches from intermediate saves continue to no-op.
+        $settle = $config->chunkSweepSettle;
+        $updatedAt = $model->getAttribute('updated_at');
+        if ($updatedAt instanceof DateTimeInterface) {
+            $secondsSinceEdit = max(0, now()->getTimestamp() - $updatedAt->getTimestamp());
+            if ($secondsSinceEdit < $settle) {
+                $this->release($settle - $secondsSinceEdit);
+
+                return;
+            }
         }
 
         $service->reconcile($model);

--- a/tests/Feature/Persistence/ChunkCommandTest.php
+++ b/tests/Feature/Persistence/ChunkCommandTest.php
@@ -138,6 +138,36 @@ it('prunes orphan chunks left behind by mass-delete', function () {
     expect(Chunk::query()->where('chunkable_id', $a->id)->count())->toBe(1);
 });
 
+it('skips the orphan purge when --skip-orphans is passed', function () {
+    Queue::fake();
+
+    app(ChunkableRegistry::class)->register(FakeCommandDoc::class);
+    $a = FakeCommandDoc::create(['body' => 'A body']);
+    $b = FakeCommandDoc::create(['body' => 'B body']);
+
+    foreach ([$a, $b] as $doc) {
+        Chunk::create(array_merge([
+            'chunkable_type' => $doc->getMorphClass(),
+            'chunkable_id' => $doc->id,
+            'ord' => 0,
+            'heading_path' => null,
+            'content' => 'chunk for '.$doc->id,
+            'content_hash' => hash('xxh128', (string) $doc->id),
+            'token_count' => 1,
+            'embedding_model' => 'text-embedding-3-small',
+            'embedded_at' => now(),
+        ], fakeChunkEmbedding()));
+    }
+    FakeCommandDoc::query()->whereKey($b->id)->delete();
+    expect(Chunk::query()->where('chunkable_id', $b->id)->count())->toBe(1);
+
+    $this->artisan('atlas:chunk', ['--skip-orphans' => true])->assertExitCode(0);
+
+    // Orphan survived — consumer using --skip-orphans is expected to run
+    // atlas:prune-chunks separately.
+    expect(Chunk::query()->where('chunkable_id', $b->id)->count())->toBe(1);
+});
+
 class FakeSoftDeletingDoc extends Model implements Chunkable
 {
     use HasChunkedEmbeddings;
@@ -177,42 +207,12 @@ it('does not treat soft-deleted owners as orphans (preserves chunks for restore)
         'embedded_at' => now(),
     ], fakeChunkEmbedding()));
 
-    // Soft-delete via mass-query — this skips model events (like the trait's
-    // deleting hook that synchronously removes chunks). The chunks survive
-    // until the sweep runs, which used to wrongly prune them since the
-    // default query builder filters out soft-deleted rows. With the fix,
-    // withoutGlobalScopes() includes them in the owner subquery, so they're
-    // not flagged as orphans.
+    // Soft-delete via mass-query — this skips model events.
     FakeSoftDeletingDoc::query()->whereKey($doc->id)->delete();
     expect(Chunk::query()->where('chunkable_id', $doc->id)->count())->toBe(1);
 
     $this->artisan('atlas:chunk')->assertExitCode(0);
 
-    expect(Chunk::query()->where('chunkable_id', $doc->id)->count())->toBe(1);
-});
-
-it('leaves chunks alone when soft-deleted rows still live in the owner table', function () {
-    // The orphan check uses whereNotIn against the bare table query, so soft
-    // deletes (rows still present with deleted_at set) are NOT treated as
-    // orphans. That's deliberate: soft-deleted records can be restored, and
-    // re-chunking would be wasted work.
-    Queue::fake();
-
-    app(ChunkableRegistry::class)->register(FakeCommandDoc::class);
-    $doc = FakeCommandDoc::create(['body' => 'A']);
-    Chunk::create(array_merge([
-        'chunkable_type' => $doc->getMorphClass(),
-        'chunkable_id' => $doc->id,
-        'ord' => 0,
-        'heading_path' => null,
-        'content' => 'X',
-        'content_hash' => 'abc',
-        'token_count' => 1,
-        'embedding_model' => 'text-embedding-3-small',
-        'embedded_at' => now(),
-    ], fakeChunkEmbedding()));
-
-    $this->artisan('atlas:chunk')->assertExitCode(0);
     expect(Chunk::query()->where('chunkable_id', $doc->id)->count())->toBe(1);
 });
 

--- a/tests/Feature/Persistence/PruneChunksCommandTest.php
+++ b/tests/Feature/Persistence/PruneChunksCommandTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Embeddings\Chunkable;
+use Atlasphp\Atlas\Embeddings\ChunkableRegistry;
+use Atlasphp\Atlas\Persistence\Concerns\HasChunkedEmbeddings;
+use Atlasphp\Atlas\Persistence\Models\Chunk;
+use Atlasphp\Atlas\Persistence\Schema\ChunkedEmbeddingColumns;
+use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+
+class FakePruneDoc extends Model implements Chunkable
+{
+    use HasChunkedEmbeddings;
+
+    protected $table = 'fake_prune_docs';
+
+    protected $guarded = [];
+
+    public $timestamps = true;
+}
+
+class FakePruneSoftDeletingDoc extends Model implements Chunkable
+{
+    use HasChunkedEmbeddings;
+    use SoftDeletes;
+
+    protected $table = 'fake_prune_soft_docs';
+
+    protected $guarded = [];
+
+    public $timestamps = true;
+}
+
+beforeEach(function () {
+    Schema::dropIfExists('fake_prune_docs');
+    Schema::create('fake_prune_docs', function (Blueprint $table) {
+        $table->id();
+        $table->text('body')->nullable();
+        $table->timestamps();
+        ChunkedEmbeddingColumns::add($table);
+    });
+
+    Schema::dropIfExists('fake_prune_soft_docs');
+    Schema::create('fake_prune_soft_docs', function (Blueprint $table) {
+        $table->id();
+        $table->text('body')->nullable();
+        $table->timestamps();
+        $table->softDeletes();
+        ChunkedEmbeddingColumns::add($table);
+    });
+
+    app(ChunkableRegistry::class)->clear();
+});
+
+it('exits cleanly when no chunkable models are registered', function () {
+    $this->artisan('atlas:prune-chunks')->assertExitCode(0);
+});
+
+it('deletes chunks whose owner row no longer exists', function () {
+    Queue::fake();
+
+    app(ChunkableRegistry::class)->register(FakePruneDoc::class);
+    $a = FakePruneDoc::create(['body' => 'A body']);
+    $b = FakePruneDoc::create(['body' => 'B body']);
+
+    foreach ([$a, $b] as $doc) {
+        Chunk::create(array_merge([
+            'chunkable_type' => $doc->getMorphClass(),
+            'chunkable_id' => $doc->id,
+            'ord' => 0,
+            'heading_path' => null,
+            'content' => 'chunk for '.$doc->id,
+            'content_hash' => hash('xxh128', (string) $doc->id),
+            'token_count' => 1,
+            'embedding_model' => 'text-embedding-3-small',
+            'embedded_at' => now(),
+        ], fakeChunkEmbedding()));
+    }
+    expect(Chunk::query()->count())->toBe(2);
+
+    FakePruneDoc::query()->whereKey($b->id)->delete();
+    expect(Chunk::query()->where('chunkable_id', $b->id)->count())->toBe(1);
+
+    $this->artisan('atlas:prune-chunks')
+        ->expectsOutputToContain('pruned 1 orphan')
+        ->assertExitCode(0);
+
+    expect(Chunk::query()->where('chunkable_id', $b->id)->count())->toBe(0);
+    expect(Chunk::query()->where('chunkable_id', $a->id)->count())->toBe(1);
+});
+
+it('does not dispatch any ChunkContentJob (orphan cleanup is its sole job)', function () {
+    Queue::fake();
+
+    app(ChunkableRegistry::class)->register(FakePruneDoc::class);
+    // Dirty row — but prune-chunks should not dispatch reconcile jobs.
+    FakePruneDoc::create(['body' => 'dirty content']);
+
+    $this->artisan('atlas:prune-chunks')->assertExitCode(0);
+
+    Queue::assertNotPushed(ChunkContentJob::class);
+});
+
+it('does not treat soft-deleted owners as orphans', function () {
+    app(ChunkableRegistry::class)->register(FakePruneSoftDeletingDoc::class);
+
+    $doc = FakePruneSoftDeletingDoc::create(['body' => 'content']);
+    Chunk::create(array_merge([
+        'chunkable_type' => $doc->getMorphClass(),
+        'chunkable_id' => $doc->id,
+        'ord' => 0,
+        'heading_path' => null,
+        'content' => 'chunk',
+        'content_hash' => 'h',
+        'token_count' => 1,
+        'embedding_model' => 'text-embedding-3-small',
+        'embedded_at' => now(),
+    ], fakeChunkEmbedding()));
+
+    // Soft-delete via mass-query: the row stays in the table with deleted_at
+    // set. The prune command's withoutGlobalScopes() owner subquery must
+    // include this row so its chunks aren't pruned.
+    FakePruneSoftDeletingDoc::query()->whereKey($doc->id)->delete();
+
+    $this->artisan('atlas:prune-chunks')->assertExitCode(0);
+
+    expect(Chunk::query()->where('chunkable_id', $doc->id)->count())->toBe(1);
+});
+
+it('fails with a descriptive error when --model targets an unregistered class', function () {
+    $this->artisan('atlas:prune-chunks', ['--model' => FakePruneDoc::class])
+        ->expectsOutputToContain('is not registered as chunkable')
+        ->assertExitCode(1);
+});
+
+it('only prunes orphans for the requested class when --model is provided', function () {
+    Queue::fake();
+
+    Schema::dropIfExists('fake_other_prune_docs');
+    Schema::create('fake_other_prune_docs', function (Blueprint $table) {
+        $table->id();
+        $table->text('body')->nullable();
+        $table->timestamps();
+        ChunkedEmbeddingColumns::add($table);
+    });
+
+    $otherClass = new class extends Model implements Chunkable
+    {
+        use HasChunkedEmbeddings;
+
+        protected $table = 'fake_other_prune_docs';
+
+        protected $guarded = [];
+
+        public $timestamps = true;
+    };
+    $otherClassName = get_class($otherClass);
+
+    app(ChunkableRegistry::class)->register(FakePruneDoc::class);
+    app(ChunkableRegistry::class)->register($otherClassName);
+
+    $a = FakePruneDoc::create(['body' => 'A']);
+    $b = $otherClassName::create(['body' => 'B']);
+
+    // Seed chunks for both.
+    foreach ([[$a, FakePruneDoc::class], [$b, $otherClassName]] as [$doc, $class]) {
+        Chunk::create(array_merge([
+            'chunkable_type' => $doc->getMorphClass(),
+            'chunkable_id' => $doc->id,
+            'ord' => 0,
+            'heading_path' => null,
+            'content' => 'chunk',
+            'content_hash' => hash('xxh128', $class.$doc->id),
+            'token_count' => 1,
+            'embedding_model' => 'text-embedding-3-small',
+            'embedded_at' => now(),
+        ], fakeChunkEmbedding()));
+    }
+
+    // Orphan both: mass-delete from both tables.
+    FakePruneDoc::query()->whereKey($a->id)->delete();
+    $otherClassName::query()->whereKey($b->id)->delete();
+
+    $this->artisan('atlas:prune-chunks', ['--model' => FakePruneDoc::class])->assertExitCode(0);
+
+    // Scope assertions to chunkable_type — autoincrement ids collide
+    // across the two tables (both rows are id=1).
+    expect(Chunk::query()
+        ->where('chunkable_type', $a->getMorphClass())
+        ->where('chunkable_id', $a->id)
+        ->count())->toBe(0);
+    expect(Chunk::query()
+        ->where('chunkable_type', $b->getMorphClass())
+        ->where('chunkable_id', $b->id)
+        ->count())->toBe(1);
+
+    Schema::dropIfExists('fake_other_prune_docs');
+});

--- a/tests/PersistenceTestCase.php
+++ b/tests/PersistenceTestCase.php
@@ -32,6 +32,12 @@ abstract class PersistenceTestCase extends TestCase
     {
         $app['config']->set('atlas.persistence.enabled', true);
         $app['config']->set('atlas.persistence.table_prefix', 'atlas_');
+        // Disable dispatch-on-save by default in persistence tests so that
+        // creating chunkable models in test setup doesn't fan out to the
+        // queue (where the sync driver would invoke the real chunker +
+        // embedding call). Tests that specifically verify the dispatch
+        // path enable it explicitly with config() + AtlasConfig::refresh().
+        $app['config']->set('atlas.embeddings.dispatch_on_save', false);
         // Respect DB_CONNECTION from environment (e.g. CI PostgreSQL job).
         // Only set SQLite in-memory config when no external DB is configured.
         $dbConnection = env('DB_CONNECTION');

--- a/tests/Unit/Persistence/Concerns/HasChunkedEmbeddingsTest.php
+++ b/tests/Unit/Persistence/Concerns/HasChunkedEmbeddingsTest.php
@@ -11,10 +11,12 @@ use Atlasphp\Atlas\Embeddings\Chunkers\MarkdownChunker;
 use Atlasphp\Atlas\Persistence\Concerns\HasChunkedEmbeddings;
 use Atlasphp\Atlas\Persistence\Models\Chunk;
 use Atlasphp\Atlas\Persistence\Schema\ChunkedEmbeddingColumns;
+use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
 use Atlasphp\Atlas\Testing\EmbeddingsResponseFake;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 
 class FakeChunkableDoc extends Model implements Chunkable
@@ -276,4 +278,92 @@ it('restore brings back model with no chunks (consumer calls chunkNow to regener
 
     expect($doc->trashed())->toBeFalse();
     expect($doc->fresh()->chunks)->toHaveCount(0);
+});
+
+// ─── Dispatch-on-save behaviour ─────────────────────────────────────────────
+//
+// PersistenceTestCase disables dispatch_on_save by default so tests above
+// can create chunkable models without queuing jobs. These tests opt back
+// in via config() + AtlasConfig::refresh().
+
+it('dispatches ChunkContentJob with a settle delay when content_hash changes on save', function () {
+    Queue::fake();
+    config(['atlas.embeddings.dispatch_on_save' => true]);
+    config(['atlas.embeddings.sweep_settle' => 60]);
+    AtlasConfig::refresh();
+
+    $doc = FakeChunkableDoc::create(['body' => 'first content']);
+
+    Queue::assertPushed(ChunkContentJob::class, function (ChunkContentJob $job) use ($doc) {
+        return $job->modelClass === FakeChunkableDoc::class
+            && $job->modelId === $doc->id
+            && $job->delay !== null;
+    });
+});
+
+it('does not dispatch ChunkContentJob when an unrelated column changes', function () {
+    config(['atlas.embeddings.dispatch_on_save' => true]);
+    AtlasConfig::refresh();
+
+    $doc = FakeChunkableDoc::create(['body' => 'stable content']);
+
+    Queue::fake();
+
+    // Touch timestamps without changing body — content_hash stays the same,
+    // saved() should observe no change and skip dispatch.
+    $doc->touch();
+
+    Queue::assertNotPushed(ChunkContentJob::class);
+});
+
+it('does not dispatch ChunkContentJob when dispatch_on_save is disabled', function () {
+    Queue::fake();
+    config(['atlas.embeddings.dispatch_on_save' => false]);
+    AtlasConfig::refresh();
+
+    FakeChunkableDoc::create(['body' => 'content that would have dispatched']);
+
+    Queue::assertNotPushed(ChunkContentJob::class);
+});
+
+it('collapses many rapid saves into a single queued job via ShouldBeUnique', function () {
+    Queue::fake();
+    config(['atlas.embeddings.dispatch_on_save' => true]);
+    AtlasConfig::refresh();
+
+    // Simulate a typing burst: many saves on the same row in quick
+    // succession. ShouldBeUnique (keyed on modelClass:modelId) should
+    // collapse all of these into one queued job — the second through
+    // Nth dispatches no-op because the unique lock is held.
+    $doc = FakeChunkableDoc::create(['body' => 'edit 0']);
+    for ($i = 1; $i <= 10; $i++) {
+        $doc->update(['body' => "edit {$i}"]);
+    }
+
+    Queue::assertPushed(ChunkContentJob::class, 1);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelClass === FakeChunkableDoc::class && $job->modelId === $doc->id,
+    );
+});
+
+it('dispatches separate unique jobs for different models', function () {
+    Queue::fake();
+    config(['atlas.embeddings.dispatch_on_save' => true]);
+    AtlasConfig::refresh();
+
+    // ShouldBeUnique keys per (modelClass, modelId), so distinct rows
+    // each get their own queued job.
+    $a = FakeChunkableDoc::create(['body' => 'doc A']);
+    $b = FakeChunkableDoc::create(['body' => 'doc B']);
+
+    Queue::assertPushed(ChunkContentJob::class, 2);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelId === $a->id,
+    );
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelId === $b->id,
+    );
 });

--- a/tests/Unit/Persistence/Queue/ChunkContentJobTest.php
+++ b/tests/Unit/Persistence/Queue/ChunkContentJobTest.php
@@ -88,8 +88,13 @@ it('throws AtlasException when the model class does not implement Chunkable', fu
     expect($spy->reconciled)->toBe([]);
 });
 
-it('calls reconcile on the ChunkContentService when the model is Chunkable', function () {
+it('reconciles a chunkable model whose updated_at is past the settle window', function () {
     $doc = FakeJobChunkableDoc::create(['body' => 'some body content']);
+    // Backdate past the default settle (60s) so the debounce guard doesn't
+    // release the job back to the queue.
+    FakeJobChunkableDoc::query()->whereKey($doc->id)
+        ->update(['updated_at' => now()->subMinutes(5)]);
+
     $job = new ChunkContentJob(FakeJobChunkableDoc::class, $doc->id);
     $spy = app(SpyChunkContentService::class);
 
@@ -98,4 +103,62 @@ it('calls reconcile on the ChunkContentService when the model is Chunkable', fun
     expect($spy->reconciled)->toHaveCount(1);
     expect($spy->reconciled[0])->toBeInstanceOf(FakeJobChunkableDoc::class);
     expect($spy->reconciled[0]->id)->toBe($doc->id);
+});
+
+it('short-circuits when content_hash matches indexed_hash', function () {
+    $doc = FakeJobChunkableDoc::create(['body' => 'already indexed body']);
+    $doc->indexed_hash = $doc->content_hash;
+    $doc->saveQuietly();
+
+    $job = new ChunkContentJob(FakeJobChunkableDoc::class, $doc->id);
+    $spy = app(SpyChunkContentService::class);
+
+    $job->handle($spy);
+
+    expect($spy->reconciled)->toBe([]);
+});
+
+it('short-circuits when index_failure_count is at or above max_failures', function () {
+    config(['atlas.embeddings.max_failures' => 3]);
+    AtlasConfig::refresh();
+
+    $doc = FakeJobChunkableDoc::create(['body' => 'poisoned content']);
+    $doc->index_failure_count = 3;
+    $doc->saveQuietly();
+    // Past the settle window so the debounce guard doesn't engage first.
+    FakeJobChunkableDoc::query()->whereKey($doc->id)
+        ->update(['updated_at' => now()->subMinutes(5)]);
+
+    $job = new ChunkContentJob(FakeJobChunkableDoc::class, $doc->id);
+    $spy = app(SpyChunkContentService::class);
+
+    $job->handle($spy);
+
+    expect($spy->reconciled)->toBe([]);
+});
+
+it('releases itself when the model was updated within the settle window', function () {
+    // settle = 60s (default). updated_at = now() (within the window).
+    $doc = FakeJobChunkableDoc::create(['body' => 'fresh edit']);
+
+    $job = new ChunkContentJob(FakeJobChunkableDoc::class, $doc->id);
+    $spy = app(SpyChunkContentService::class);
+
+    // No reconcile occurs. release() is a no-op on an unattached job
+    // ($this->job is null), so this just confirms the guard short-circuits.
+    // The integration test in HasChunkedEmbeddingsTest covers the full
+    // dispatch → release → re-process cycle.
+    $job->handle($spy);
+
+    expect($spy->reconciled)->toBe([]);
+});
+
+it('reports the correct unique id and retry budget', function () {
+    $job = new ChunkContentJob(FakeJobChunkableDoc::class, 42);
+
+    expect($job->uniqueId())->toBe(FakeJobChunkableDoc::class.':42');
+    expect($job->retryUntil())->toBeInstanceOf(DateTimeInterface::class);
+    // retryUntil should be ~1 hour from now (±a few seconds for test runtime).
+    $hourFromNow = now()->addHour()->getTimestamp();
+    expect(abs($job->retryUntil()->getTimestamp() - $hourFromNow))->toBeLessThan(5);
 });


### PR DESCRIPTION
This pull request introduces a new "dispatch-on-save" mechanism for chunked embeddings, allowing edits to be indexed within seconds and reducing the reliance on frequent scheduled sweeps. It also separates orphan chunk pruning into its own command for more flexible scheduling, updates documentation and configuration to reflect these changes, and adds a comprehensive end-to-end test for the new dispatch path. No breaking changes are introduced; existing schedules continue to work, but new best practices are recommended.

**Dispatch-on-save and chunking improvements:**
- Added a `dispatch_on_save` configuration option (default: true), enabling immediate dispatch of chunking jobs on model save, with debouncing to collapse rapid edits into a single job. This reduces indexing latency and makes the scheduled `atlas:chunk` command a safety net rather than the primary trigger. [[1]](diffhunk://#diff-0547b8abb0d1b756bd782300755c54f2f74633554fa48ae70413cc0cef6157a9L275-R301) [[2]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fR281-R283) [[3]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR47) [[4]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR128)
- Updated documentation and changelog to explain the new dispatch-on-save flow, debouncing, and configuration options. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R36) [[2]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L252-R258) [[3]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L400-R405)

**Orphan chunk pruning and scheduling:**
- Introduced a new `atlas:prune-chunks` Artisan command to handle orphan chunk cleanup, allowing it to be scheduled independently (e.g., daily), and added a `--skip-orphans` flag to `atlas:chunk` for when pruning is handled separately. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R36) [[2]](diffhunk://#diff-daba2c7c6a9e9dca80a20a06760a78c6bec5c4022a4543ed06a9e2e8ea60e51eL137-R177) [[3]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L470-R474)
- Updated recommended scheduling cadence: run `atlas:chunk` hourly as a safety net and `atlas:prune-chunks` daily for orphan cleanup. Legacy frequent sweep scheduling remains supported. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R36) [[2]](diffhunk://#diff-daba2c7c6a9e9dca80a20a06760a78c6bec5c4022a4543ed06a9e2e8ea60e51eL137-R177) [[3]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L357-R368)

**Testing and validation:**
- Added a new end-to-end test script (`sandbox/test-chunked-embeddings-dispatch-on-save.php`) that validates the dispatch-on-save path, debouncing, unique job handling, and queue processing against a real database and queue.