### PR TITLE
Defer job dispatch until after DB commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.1.2](https://github.com/atlas-php/atlas/releases/tag/v3.1.2) - 2026-05-16
+
+### Fixed
+
+- Chunkable saves wrapped in `DB::transaction()` no longer abort with SQLSTATE 25P02 on Postgres + database cache. Verified across redis, file, array, and database cache drivers.
+- Rolled-back saves no longer queue a job for content that never persisted.
+
+### Migration
+
+**No breaking changes.**
+
+---
+
 ## [v3.1.1](https://github.com/atlas-php/atlas/releases/tag/v3.1.1) - 2026-05-16
 
 ### Added

--- a/sandbox/test-chunked-embeddings-dispatch-on-save.php
+++ b/sandbox/test-chunked-embeddings-dispatch-on-save.php
@@ -284,6 +284,190 @@ check('project indexed after the settle window passed',
 check('atlas_chunks populated for the debounced project', $chunkCount > 0, "got {$chunkCount}");
 check('queue drained after final embed', queuedChunkJobs() === 0);
 
+// ─── 7. Transaction safety across every cache driver ───────────────────────
+//
+// The v3.1.1 regression: a chunkable save wrapped in DB::transaction()
+// dispatched ChunkContentJob from the trait's `saved` hook → ShouldBeUnique
+// acquired its lock via the configured cache → with the database cache on
+// Postgres, the INSERT-then-fallback-UPDATE pattern aborted the wrapping
+// transaction with SQLSTATE 25P02.
+//
+// The fix wraps the entire dispatch in `Connection::afterCommit(...)` so the
+// lock acquisition always runs OUTSIDE the wrapping transaction. The
+// behavior must be correct for every cache driver — database (the broken
+// case), redis (most prod consumers), file, and array (test setups).
+
+$originalCacheStore = config('cache.default');
+
+// Configure additional cache stores inline so the script is self-contained
+// (the sandbox's config/cache.php only ships database + array). These are
+// the standard Laravel store configs, copied from Laravel's default
+// config/cache.php template.
+$app['config']->set('cache.stores.file', [
+    'driver' => 'file',
+    'path' => storage_path('framework/cache/data'),
+    'lock_path' => storage_path('framework/cache/data'),
+]);
+$app['config']->set('cache.stores.redis', [
+    'driver' => 'redis',
+    'connection' => 'cache',
+    'lock_connection' => 'default',
+]);
+// Redis connection for cache + lock. Reads from REDIS_HOST/REDIS_PORT
+// env if set, defaults to localhost.
+$app['config']->set('database.redis.client', 'phpredis');
+$app['config']->set('database.redis.options', ['cluster' => 'redis']);
+$app['config']->set('database.redis.default', [
+    'url' => null,
+    'host' => env('REDIS_HOST', '127.0.0.1'),
+    'username' => env('REDIS_USERNAME'),
+    'password' => env('REDIS_PASSWORD'),
+    'port' => env('REDIS_PORT', '6379'),
+    'database' => env('REDIS_DB', '0'),
+]);
+$app['config']->set('database.redis.cache', [
+    'url' => null,
+    'host' => env('REDIS_HOST', '127.0.0.1'),
+    'username' => env('REDIS_USERNAME'),
+    'password' => env('REDIS_PASSWORD'),
+    'port' => env('REDIS_PORT', '6379'),
+    'database' => env('REDIS_CACHE_DB', '1'),
+]);
+
+@mkdir(storage_path('framework/cache/data'), 0755, true);
+
+$cacheDriversToTest = ['database', 'redis', 'file', 'array'];
+
+/**
+ * Run the prod-equivalent scenario for the given cache driver:
+ *   - reset state, switch the cache driver, refresh config
+ *   - (database driver only) pre-seed a colliding lock to force the bug
+ *   - save a chunkable inside DB::transaction()
+ *   - assert the save completed and the row was persisted
+ *
+ * @return array{threw: ?Throwable, project: ?Project}
+ */
+function runTransactionSaveScenario(string $cacheDriver, $app, bool $forceLockContention): array
+{
+    DB::statement('TRUNCATE TABLE projects RESTART IDENTITY CASCADE');
+    DB::table('atlas_chunks')->delete();
+    DB::table('jobs')->delete();
+    if (Schema::hasTable('cache_locks')) {
+        DB::table('cache_locks')->delete();
+    }
+    Cache::flush();
+
+    $app['config']->set('cache.default', $cacheDriver);
+    AtlasConfig::refresh();
+
+    if ($forceLockContention && $cacheDriver === 'database') {
+        // Pre-seed a colliding lock with a different owner. Without this,
+        // the first INSERT into cache_locks succeeds and the bug doesn't
+        // surface. In production the lock pre-exists because the previous
+        // dispatch held it (`uniqueFor = 3600`s lingering locks). The
+        // sandbox cache prefix is the Laravel default for the database
+        // driver — see config('cache.prefix') in the sandbox.
+        $prefix = (string) ($app['config']->get('cache.prefix') ?: $app['config']->get('cache.stores.database.prefix') ?: '');
+        DB::table('cache_locks')->insert([
+            'key' => $prefix.'laravel_unique_job:Atlasphp\\Atlas\\Queue\\Jobs\\ChunkContentJob:App\\Models\\Project:1',
+            'owner' => 'sandbox-pre-seed-different-owner',
+            'expiration' => time() + 3600,
+        ]);
+    }
+
+    $threw = null;
+    $project = null;
+    try {
+        $project = DB::transaction(function () use ($cacheDriver) {
+            // Identical pattern to rundesk's ProjectPageService::update():
+            // chunkable save inside an explicit DB transaction.
+            return Project::create([
+                'title' => "Inside transaction (cache: {$cacheDriver})",
+                'body' => 'A body that is long enough to chunk. '.str_repeat('words ', 30),
+            ]);
+        });
+    } catch (Throwable $e) {
+        $threw = $e;
+    }
+
+    return ['threw' => $threw, 'project' => $project];
+}
+
+foreach ($cacheDriversToTest as $driver) {
+    section("7. Save inside DB::transaction with cache.default = '{$driver}'");
+
+    // Skip drivers that aren't actually available in this sandbox.
+    if ($driver === 'redis') {
+        try {
+            $app->make('redis')->connection()->ping();
+        } catch (Throwable $e) {
+            echo "  Redis not reachable — skipping. ({$e->getMessage()})\n";
+
+            continue;
+        }
+    }
+    if ($driver === 'database' && ! Schema::hasTable('cache_locks')) {
+        echo "  cache_locks table missing — skipping.\n";
+
+        continue;
+    }
+
+    // For the database driver, force the lock-contention scenario that
+    // triggered the prod bug. Other drivers don't have the SQL-transaction
+    // interaction, but we still run the scenario to prove afterCommit
+    // doesn't break anything for them.
+    $result = runTransactionSaveScenario($driver, $app, forceLockContention: true);
+
+    check("[{$driver}] save inside DB::transaction completed without throwing",
+        $result['threw'] === null,
+        $result['threw'] !== null ? get_class($result['threw']).': '.$result['threw']->getMessage() : '');
+
+    check("[{$driver}] project row was persisted by the transaction",
+        $result['project'] !== null && Project::query()->where('id', $result['project']->id)->exists());
+}
+
+section('8. Rolled-back transaction does not queue a job (database cache)');
+
+DB::statement('TRUNCATE TABLE projects RESTART IDENTITY CASCADE');
+DB::table('atlas_chunks')->delete();
+DB::table('jobs')->delete();
+if (Schema::hasTable('cache_locks')) {
+    DB::table('cache_locks')->delete();
+}
+Cache::flush();
+$app['config']->set('cache.default', 'database');
+AtlasConfig::refresh();
+
+if (! Schema::hasTable('cache_locks')) {
+    echo "  cache_locks table missing — skipping section 8.\n";
+} else {
+    $threw = null;
+    try {
+        DB::transaction(function () {
+            Project::create([
+                'title' => 'Will roll back',
+                'body' => 'A body that is long enough to chunk. '.str_repeat('words ', 30),
+            ]);
+            throw new RuntimeException('forced rollback');
+        });
+    } catch (RuntimeException $e) {
+        $threw = $e;
+    }
+
+    check('rollback throw propagated out of DB::transaction',
+        $threw instanceof RuntimeException);
+
+    check('project row was rolled back', Project::query()->count() === 0,
+        'got '.Project::query()->count().' projects after rollback');
+
+    check('no ChunkContentJob queued for the rolled-back save',
+        queuedChunkJobs() === 0, 'got '.queuedChunkJobs().' queued job(s)');
+}
+
+// Restore cache store for any later code that might rely on it.
+$app['config']->set('cache.default', $originalCacheStore);
+AtlasConfig::refresh();
+
 // ─── Summary ────────────────────────────────────────────────────────────────
 
 section('Summary');

--- a/sandbox/test-queued-message-dispatch.php
+++ b/sandbox/test-queued-message-dispatch.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Queued Message Dispatch — Transaction Safety End-to-End Test
+ *
+ * Companion to test-chunked-embeddings-dispatch-on-save.php — verifies the
+ * SECOND `ShouldBeUnique` job in atlas (`ProcessQueuedMessage`, dispatched
+ * from PersistConversation middleware) handles the same prod scenario
+ * correctly across every supported cache driver.
+ *
+ * The bug pattern is identical to the chunking case:
+ *   1. Consumer wraps an `Atlas::agent()` call in their own `DB::transaction()`.
+ *   2. Atlas's `PersistConversation` middleware fires inside that transaction.
+ *   3. After the inner message-save, it dispatches `ProcessQueuedMessage`.
+ *   4. `ShouldBeUnique` acquires a cache lock via `DatabaseLock` (when
+ *      `cache.default = database`).
+ *   5. The lock INSERT collides → fallback UPDATE → aborts the wrapping
+ *      Postgres transaction → SQLSTATE 25P02.
+ *
+ * The fix in PersistConversation.php wraps the dispatch in
+ * `$conversation->getConnection()->afterCommit(...)` so the entire chain
+ * (including the lock acquire) runs OUTSIDE the wrapping transaction.
+ *
+ * This script does NOT invoke a real agent — that would require a live
+ * provider, queue worker, and the full agent pipeline. Instead it executes
+ * the EXACT dispatch pattern PersistConversation uses (lines 215-230 of
+ * src/Persistence/Middleware/PersistConversation.php) so we can prove the
+ * pattern is safe under transactions + cache contention without standing
+ * up the full stack.
+ *
+ * Sections:
+ *   1. Direct dispatch outside any transaction → fires immediately.
+ *   2. Dispatch inside DB::transaction with each cache driver
+ *      (database, redis, file, array) → no 25P02, fires after commit.
+ *   3. Rolled-back transaction → no job queued.
+ *
+ * Usage:
+ *   cd sandbox
+ *   php artisan migrate:fresh
+ *   php test-queued-message-dispatch.php
+ *
+ * Requires:
+ *   - DB_CONNECTION=pgsql with pgvector
+ *   - QUEUE_CONNECTION=database
+ *   - Redis on 127.0.0.1:6379 for the redis-cache test (skipped if unreachable)
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Persistence\Models\Conversation;
+use Atlasphp\Atlas\Persistence\ProcessQueuedMessage;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+// ─── Preflight ──────────────────────────────────────────────────────────────
+
+if (DB::connection()->getDriverName() !== 'pgsql') {
+    echo "This test requires PostgreSQL (DB_CONNECTION=pgsql). Aborting.\n";
+    exit(1);
+}
+
+if (config('queue.default') !== 'database') {
+    echo "This test requires QUEUE_CONNECTION=database (it inspects the `jobs` table).\n";
+    echo 'Current: '.config('queue.default')."\n";
+    exit(1);
+}
+
+// The Conversation model uses HasAtlasTable, which applies the configured
+// table prefix (default `atlas_`). Resolve the actual table name from the
+// model to stay correct regardless of the consumer's atlas prefix config.
+$conversationsTable = (new Conversation)->getTable();
+if (! Schema::hasTable($conversationsTable) || ! Schema::hasTable('jobs')) {
+    echo "Missing tables ({$conversationsTable}, jobs) — run `php artisan migrate:fresh` first.\n";
+    exit(1);
+}
+
+// Configure additional cache stores inline so the script is self-contained
+// (sandbox's config/cache.php only ships database + array).
+$app['config']->set('cache.stores.file', [
+    'driver' => 'file',
+    'path' => storage_path('framework/cache/data'),
+    'lock_path' => storage_path('framework/cache/data'),
+]);
+$app['config']->set('cache.stores.redis', [
+    'driver' => 'redis',
+    'connection' => 'cache',
+    'lock_connection' => 'default',
+]);
+$app['config']->set('database.redis.client', 'phpredis');
+$app['config']->set('database.redis.options', ['cluster' => 'redis']);
+$app['config']->set('database.redis.default', [
+    'url' => null,
+    'host' => env('REDIS_HOST', '127.0.0.1'),
+    'username' => env('REDIS_USERNAME'),
+    'password' => env('REDIS_PASSWORD'),
+    'port' => env('REDIS_PORT', '6379'),
+    'database' => env('REDIS_DB', '0'),
+]);
+$app['config']->set('database.redis.cache', [
+    'url' => null,
+    'host' => env('REDIS_HOST', '127.0.0.1'),
+    'username' => env('REDIS_USERNAME'),
+    'password' => env('REDIS_PASSWORD'),
+    'port' => env('REDIS_PORT', '6379'),
+    'database' => env('REDIS_CACHE_DB', '1'),
+]);
+
+@mkdir(storage_path('framework/cache/data'), 0755, true);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+$failures = [];
+
+function section(string $title): void
+{
+    echo "\n".str_repeat('─', 76)."\n  {$title}\n".str_repeat('─', 76)."\n";
+}
+
+function check(string $name, bool $ok, string $detail = ''): void
+{
+    global $failures;
+    $mark = $ok ? '✓' : '✗';
+    $line = "  {$mark} {$name}";
+    if ($detail !== '') {
+        $line .= " — {$detail}";
+    }
+    echo $line."\n";
+    if (! $ok) {
+        $failures[] = $name.($detail !== '' ? ": {$detail}" : '');
+    }
+}
+
+function queuedProcessJobs(): int
+{
+    return (int) DB::table('jobs')
+        ->where('payload', 'like', '%ProcessQueuedMessage%')
+        ->count();
+}
+
+function resetState(): void
+{
+    $table = (new Conversation)->getTable();
+    DB::statement("TRUNCATE TABLE {$table} RESTART IDENTITY CASCADE");
+    DB::table('jobs')->delete();
+    DB::table('failed_jobs')->delete();
+    if (Schema::hasTable('cache_locks')) {
+        DB::table('cache_locks')->delete();
+    }
+    Cache::flush();
+}
+
+/**
+ * Execute the exact dispatch pattern from PersistConversation.php
+ * (lines 215-230). Kept as a separate function so we can call it
+ * inside or outside a wrapping transaction.
+ */
+function dispatchUsingPersistConversationPattern(Conversation $conversation, string $agentKey, string $queue): void
+{
+    $conversationId = $conversation->id;
+
+    $conversation->getConnection()->afterCommit(static function () use ($conversationId, $agentKey, $queue): void {
+        ProcessQueuedMessage::dispatch($conversationId, $agentKey)
+            ->onQueue($queue);
+    });
+}
+
+// ─── 1. Dispatch outside any transaction → fires immediately ────────────────
+
+section('1. Dispatch outside any transaction (immediate fire)');
+
+resetState();
+$queue = app(AtlasConfig::class)->queue;
+
+$conversation = Conversation::create([
+    'agent' => 'test-agent',
+    'title' => 'Outside transaction',
+]);
+
+dispatchUsingPersistConversationPattern($conversation, 'test-agent', $queue);
+
+check('one ProcessQueuedMessage queued immediately when no transaction is active',
+    queuedProcessJobs() === 1,
+    'got '.queuedProcessJobs().' queued job(s)');
+
+// ─── 2. Regression scenario: database cache + lock contention ───────────────
+//
+// This is the EXACT prod failure mode. A pre-seeded cache_locks row owned
+// by a different worker simulates a previous dispatch's lock still being
+// held. Before the fix, this would abort the wrapping transaction with
+// SQLSTATE 25P02 when PendingDispatch::__destruct tried to acquire the
+// already-held lock via DatabaseLock's INSERT/UPDATE pattern.
+//
+// With the fix, the transaction commits cleanly. ShouldBeUnique then
+// correctly suppresses the duplicate dispatch (zero new jobs queued — the
+// existing lock holder is doing the work).
+
+section('2. Regression scenario: DB::transaction + database cache + lock contention');
+
+$originalCacheStore = config('cache.default');
+
+if (! Schema::hasTable('cache_locks')) {
+    echo "  cache_locks table missing — skipping.\n";
+} else {
+    resetState();
+    $app['config']->set('cache.default', 'database');
+    AtlasConfig::refresh();
+
+    $conversation = Conversation::create([
+        'agent' => 'test-agent',
+        'title' => 'Regression scenario',
+    ]);
+
+    // Force lock contention. In prod the lock typically pre-exists because
+    // the previous dispatch's lock hasn't expired yet (ShouldBeUnique
+    // releases the lock when the job completes, but a recently-completed
+    // or in-flight job leaves it set for the rest of its TTL).
+    $prefix = (string) ($app['config']->get('cache.prefix') ?: '');
+    DB::table('cache_locks')->insert([
+        'key' => $prefix.'laravel_unique_job:Atlasphp\\Atlas\\Persistence\\ProcessQueuedMessage:atlas-queued-'.$conversation->id,
+        'owner' => 'sandbox-pre-seed-different-owner',
+        'expiration' => time() + 3600,
+    ]);
+
+    $threw = null;
+    try {
+        DB::transaction(function () use ($conversation, $queue) {
+            dispatchUsingPersistConversationPattern($conversation, 'test-agent', $queue);
+        });
+    } catch (Throwable $e) {
+        $threw = $e;
+    }
+
+    check('transaction completed without 25P02 (the v3.1.1 regression)',
+        $threw === null,
+        $threw !== null ? get_class($threw).': '.$threw->getMessage() : '');
+
+    check('ShouldBeUnique correctly suppressed the duplicate dispatch',
+        queuedProcessJobs() === 0,
+        'got '.queuedProcessJobs().' queued job(s) — should be 0 (lock held by simulated prior worker)');
+}
+
+// ─── 3. Normal scenario across every cache driver ───────────────────────────
+//
+// Without lock contention, the dispatch should fire after the transaction
+// commits, on every supported cache driver. This proves the afterCommit
+// wrap doesn't break the happy path for any consumer config.
+
+$cacheDriversToTest = ['database', 'redis', 'file', 'array'];
+
+foreach ($cacheDriversToTest as $driver) {
+    section("3. Normal dispatch inside DB::transaction with cache.default = '{$driver}'");
+
+    if ($driver === 'redis') {
+        try {
+            $app->make('redis')->connection()->ping();
+        } catch (Throwable $e) {
+            echo "  Redis not reachable — skipping. ({$e->getMessage()})\n";
+
+            continue;
+        }
+    }
+    if ($driver === 'database' && ! Schema::hasTable('cache_locks')) {
+        echo "  cache_locks table missing — skipping.\n";
+
+        continue;
+    }
+
+    resetState();
+    $app['config']->set('cache.default', $driver);
+    AtlasConfig::refresh();
+
+    $conversation = Conversation::create([
+        'agent' => 'test-agent',
+        'title' => "Cache: {$driver}",
+    ]);
+
+    $threw = null;
+    try {
+        DB::transaction(function () use ($conversation, $queue) {
+            dispatchUsingPersistConversationPattern($conversation, 'test-agent', $queue);
+        });
+    } catch (Throwable $e) {
+        $threw = $e;
+    }
+
+    check("[{$driver}] transaction completed without throwing",
+        $threw === null,
+        $threw !== null ? get_class($threw).': '.$threw->getMessage() : '');
+
+    check("[{$driver}] one ProcessQueuedMessage queued after commit",
+        queuedProcessJobs() === 1,
+        'got '.queuedProcessJobs().' queued job(s)');
+}
+
+// ─── 4. Rolled-back transaction → no dispatch ───────────────────────────────
+
+section('4. Rolled-back transaction does not queue a ProcessQueuedMessage');
+
+resetState();
+$app['config']->set('cache.default', 'database');
+AtlasConfig::refresh();
+
+$conversation = Conversation::create([
+    'agent' => 'test-agent',
+    'title' => 'Will roll back',
+]);
+
+$threw = null;
+try {
+    DB::transaction(function () use ($conversation, $queue) {
+        dispatchUsingPersistConversationPattern($conversation, 'test-agent', $queue);
+
+        throw new RuntimeException('forced rollback');
+    });
+} catch (RuntimeException $e) {
+    $threw = $e;
+}
+
+check('rollback throw propagated out of DB::transaction',
+    $threw instanceof RuntimeException);
+
+check('no ProcessQueuedMessage queued for the rolled-back transaction',
+    queuedProcessJobs() === 0,
+    'got '.queuedProcessJobs().' queued job(s)');
+
+// Restore original cache store.
+$app['config']->set('cache.default', $originalCacheStore);
+AtlasConfig::refresh();
+
+// ─── Summary ────────────────────────────────────────────────────────────────
+
+section('Summary');
+
+if (! empty($failures)) {
+    echo "\n  ".count($failures)." assertion(s) FAILED:\n";
+    foreach ($failures as $f) {
+        echo "    - {$f}\n";
+    }
+    exit(1);
+}
+
+echo "\n  All assertions passed.\n";

--- a/src/Persistence/Concerns/HasChunkedEmbeddings.php
+++ b/src/Persistence/Concerns/HasChunkedEmbeddings.php
@@ -112,9 +112,33 @@ trait HasChunkedEmbeddings
             // want the actual instance's class. ChunkContentJob uses this
             // to query::find(); morph map aliases would silently break
             // that lookup.
-            ChunkContentJob::dispatch($model::class, $model->getKey())
-                ->onQueue($config->queue)
-                ->delay(now()->addSeconds($config->chunkSweepSettle));
+            //
+            // The whole dispatch is wrapped in `Connection::afterCommit()`
+            // so that everything — including the ShouldBeUnique cache lock
+            // acquisition inside `PendingDispatch::__destruct` — runs
+            // OUTSIDE any wrapping `DB::transaction()`. The Laravel-shipped
+            // `->afterCommit()` modifier on PendingDispatch only defers the
+            // queue push, not the lock check; with the database cache
+            // driver on Postgres the lock's INSERT-then-fallback-UPDATE
+            // pattern aborts the wrapping transaction (SQLSTATE 25P02).
+            //
+            // `Connection::afterCommit` invokes the closure immediately
+            // when no transaction is active and defers it to commit
+            // otherwise — works on every SQL driver (the method ships on
+            // the base Connection class), every cache driver (lock acquire
+            // always happens outside the transaction), every queue driver,
+            // with no consumer configuration. Using the model's connection
+            // (not the default) keeps tenant-per-connection setups correct.
+            $modelClass = $model::class;
+            $modelKey = $model->getKey();
+            $queue = $config->queue;
+            $delaySeconds = $config->chunkSweepSettle;
+
+            $model->getConnection()->afterCommit(static function () use ($modelClass, $modelKey, $queue, $delaySeconds): void {
+                ChunkContentJob::dispatch($modelClass, $modelKey)
+                    ->onQueue($queue)
+                    ->delay(now()->addSeconds($delaySeconds));
+            });
         });
 
         static::deleting(function (Model $model): void {

--- a/src/Persistence/Middleware/PersistConversation.php
+++ b/src/Persistence/Middleware/PersistConversation.php
@@ -213,15 +213,23 @@ class PersistConversation implements AgentMiddleware
         $nextQueued = $this->conversations->nextQueuedMessage($conversation);
 
         if ($nextQueued !== null) {
-            $job = new ProcessQueuedMessage(
-                conversationId: $conversation->id,
-                agentKey: $agentKey,
-            );
+            // Defer the dispatch through the connection's afterCommit
+            // hook so the ENTIRE chain — including ShouldBeUnique's
+            // cache-lock acquisition in PendingDispatch::__destruct —
+            // runs OUTSIDE any consumer-wrapping transaction. The
+            // job's built-in `afterCommit()` flag only defers the
+            // queue push, not the lock check; on Postgres with a
+            // database cache that would abort the wrapping
+            // transaction (SQLSTATE 25P02). `afterCommit` here
+            // invokes the closure immediately when no transaction
+            // is active — same as the legacy direct-dispatch path.
+            $conversationId = $conversation->id;
+            $queue = app(AtlasConfig::class)->queue;
 
-            $job->onQueue(app(AtlasConfig::class)->queue);
-            $job->afterCommit();
-
-            dispatch($job);
+            $conversation->getConnection()->afterCommit(static function () use ($conversationId, $agentKey, $queue): void {
+                ProcessQueuedMessage::dispatch($conversationId, $agentKey)
+                    ->onQueue($queue);
+            });
         }
 
         return $result;

--- a/tests/Unit/Persistence/Concerns/HasChunkedEmbeddingsTest.php
+++ b/tests/Unit/Persistence/Concerns/HasChunkedEmbeddingsTest.php
@@ -16,6 +16,7 @@ use Atlasphp\Atlas\Testing\EmbeddingsResponseFake;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 
@@ -366,4 +367,56 @@ it('dispatches separate unique jobs for different models', function () {
         ChunkContentJob::class,
         fn (ChunkContentJob $job) => $job->modelId === $b->id,
     );
+});
+
+// ─── Transaction safety (regression test for v3.1.1) ───────────────────────
+//
+// v3.1.1 dispatched ChunkContentJob from the trait's saved hook, which ran
+// inside the consumer's wrapping DB::transaction(). On Postgres with the
+// database cache driver, ShouldBeUnique's lock acquire aborted the
+// transaction with SQLSTATE 25P02 and crashed page saves in production.
+// The fix wraps the entire dispatch in Connection::afterCommit() so the
+// lock acquire runs OUTSIDE the wrapping transaction. These tests lock
+// down the deferral behavior so a future PR can't silently regress it.
+
+it('defers ChunkContentJob dispatch until the wrapping DB::transaction commits', function () {
+    Queue::fake();
+    config(['atlas.embeddings.dispatch_on_save' => true]);
+    AtlasConfig::refresh();
+
+    $doc = null;
+    DB::transaction(function () use (&$doc) {
+        $doc = FakeChunkableDoc::create(['body' => 'inside an explicit transaction']);
+
+        // While the transaction is open, the dispatch is registered via
+        // Connection::afterCommit but the job has NOT been pushed yet.
+        Queue::assertNotPushed(ChunkContentJob::class);
+    });
+
+    // After the transaction commits, the registered callback fires and
+    // pushes the job.
+    Queue::assertPushed(ChunkContentJob::class, 1);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelClass === FakeChunkableDoc::class && $job->modelId === $doc->id,
+    );
+});
+
+it('does not dispatch ChunkContentJob when the wrapping DB::transaction rolls back', function () {
+    Queue::fake();
+    config(['atlas.embeddings.dispatch_on_save' => true]);
+    AtlasConfig::refresh();
+
+    $threw = null;
+    try {
+        DB::transaction(function () {
+            FakeChunkableDoc::create(['body' => 'this save will be rolled back']);
+            throw new RuntimeException('rollback');
+        });
+    } catch (RuntimeException $e) {
+        $threw = $e;
+    }
+
+    expect($threw)->toBeInstanceOf(RuntimeException::class);
+    Queue::assertNotPushed(ChunkContentJob::class);
 });

--- a/tests/Unit/Persistence/Middleware/PersistConversationTest.php
+++ b/tests/Unit/Persistence/Middleware/PersistConversationTest.php
@@ -29,6 +29,7 @@ use Atlasphp\Atlas\Persistence\Services\ExecutionService;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -449,6 +450,93 @@ it('does not dispatch ProcessQueuedMessage when no queued messages exist', funct
 
     $middleware->handle($context, fn () => makeFakeExecutorResult());
 
+    Queue::assertNotPushed(ProcessQueuedMessage::class);
+});
+
+// Regression tests for v3.1.2 — the dispatch path must work when the
+// middleware runs inside a consumer-wrapping `DB::transaction()`. Before
+// the fix, ShouldBeUnique's cache-lock acquisition (in
+// PendingDispatch::__destruct) ran INSIDE the wrapping transaction and
+// on Postgres + database cache aborted it with SQLSTATE 25P02.
+
+it('defers ProcessQueuedMessage dispatch until the wrapping DB::transaction commits', function () {
+    Queue::fake();
+
+    $middleware = app(PersistConversation::class);
+
+    $conversation = Conversation::create(['agent' => 'test-agent']);
+
+    ConversationMessage::create([
+        'conversation_id' => $conversation->id,
+        'role' => MessageRole::User,
+        'content' => 'Queued question',
+        'sequence' => 1,
+        'is_active' => true,
+        'status' => MessageStatus::Queued,
+    ]);
+
+    $agent = makeTestAgent();
+    $agent->forConversation($conversation->id);
+
+    $context = new AgentContext(
+        request: makePersistConversationRequest(),
+        agent: $agent,
+        messages: [new UserMessage(content: 'Current message')],
+        meta: [],
+    );
+
+    DB::transaction(function () use ($middleware, $context) {
+        $middleware->handle($context, fn () => makeFakeExecutorResult());
+
+        // Inside the wrapping transaction the dispatch is registered via
+        // Connection::afterCommit and the job has NOT been pushed yet.
+        Queue::assertNotPushed(ProcessQueuedMessage::class);
+    });
+
+    // After commit, the deferred callback fires and pushes the job.
+    Queue::assertPushed(ProcessQueuedMessage::class, function ($job) use ($conversation) {
+        return $job->conversationId === $conversation->id;
+    });
+});
+
+it('does not dispatch ProcessQueuedMessage when the wrapping DB::transaction rolls back', function () {
+    Queue::fake();
+
+    $middleware = app(PersistConversation::class);
+
+    $conversation = Conversation::create(['agent' => 'test-agent']);
+
+    ConversationMessage::create([
+        'conversation_id' => $conversation->id,
+        'role' => MessageRole::User,
+        'content' => 'Queued question',
+        'sequence' => 1,
+        'is_active' => true,
+        'status' => MessageStatus::Queued,
+    ]);
+
+    $agent = makeTestAgent();
+    $agent->forConversation($conversation->id);
+
+    $context = new AgentContext(
+        request: makePersistConversationRequest(),
+        agent: $agent,
+        messages: [new UserMessage(content: 'Current message')],
+        meta: [],
+    );
+
+    $threw = null;
+    try {
+        DB::transaction(function () use ($middleware, $context) {
+            $middleware->handle($context, fn () => makeFakeExecutorResult());
+
+            throw new RuntimeException('rollback');
+        });
+    } catch (RuntimeException $e) {
+        $threw = $e;
+    }
+
+    expect($threw)->toBeInstanceOf(RuntimeException::class);
     Queue::assertNotPushed(ProcessQueuedMessage::class);
 });
 


### PR DESCRIPTION
Wrap job dispatches in Connection::afterCommit to ensure ShouldBeUnique's cache lock acquisition runs outside any consumer-wrapping DB::transaction, preventing Postgres SQLSTATE 25P02 with the database cache. Updates: use afterCommit in HasChunkedEmbeddings and PersistConversation, add sandbox tests (chunked embeddings + queued message dispatch) to validate behavior across cache drivers, and add unit regression tests to assert dispatch deferral and rollback suppression. Also bump changelog for v3.1.2. No breaking changes.