### PR TITLE
Scope unique job locks by database (multi-tenant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.1.3](https://github.com/atlas-php/atlas/releases/tag/v3.1.3) - 2026-05-24
+
+### Fixed
+
+- Multi-tenant (database-per-tenant) support: queued jobs no longer collide across tenants that share the same row IDs — one tenant's job could previously suppress another's. Job lock keys are now scoped per database.
+
+### Migration
+
+**No breaking changes.** Drop-in upgrade.
+
+---
+
 ## [v3.1.2](https://github.com/atlas-php/atlas/releases/tag/v3.1.2) - 2026-05-16
 
 ### Fixed

--- a/sandbox/test-chunked-embeddings-dispatch-on-save.php
+++ b/sandbox/test-chunked-embeddings-dispatch-on-save.php
@@ -368,8 +368,14 @@ function runTransactionSaveScenario(string $cacheDriver, $app, bool $forceLockCo
         // sandbox cache prefix is the Laravel default for the database
         // driver — see config('cache.prefix') in the sandbox.
         $prefix = (string) ($app['config']->get('cache.prefix') ?: $app['config']->get('cache.stores.database.prefix') ?: '');
+        // Derive the lock key from the real job (project will be id=1 in the
+        // fresh DB) so it matches the job's current uniqueId(), which is now
+        // database-scoped for multi-tenant safety. Never hardcode the format.
+        $lockKey = $prefix.\Illuminate\Bus\UniqueLock::getKey(
+            new \Atlasphp\Atlas\Queue\Jobs\ChunkContentJob(\App\Models\Project::class, 1)
+        );
         DB::table('cache_locks')->insert([
-            'key' => $prefix.'laravel_unique_job:Atlasphp\\Atlas\\Queue\\Jobs\\ChunkContentJob:App\\Models\\Project:1',
+            'key' => $lockKey,
             'owner' => 'sandbox-pre-seed-different-owner',
             'expiration' => time() + 3600,
         ]);

--- a/sandbox/test-chunked-embeddings-dispatch-on-save.php
+++ b/sandbox/test-chunked-embeddings-dispatch-on-save.php
@@ -41,6 +41,7 @@ use App\Models\Project;
 use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Persistence\Models\Chunk;
 use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
+use Illuminate\Bus\UniqueLock;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -371,8 +372,8 @@ function runTransactionSaveScenario(string $cacheDriver, $app, bool $forceLockCo
         // Derive the lock key from the real job (project will be id=1 in the
         // fresh DB) so it matches the job's current uniqueId(), which is now
         // database-scoped for multi-tenant safety. Never hardcode the format.
-        $lockKey = $prefix.\Illuminate\Bus\UniqueLock::getKey(
-            new \Atlasphp\Atlas\Queue\Jobs\ChunkContentJob(\App\Models\Project::class, 1)
+        $lockKey = $prefix.UniqueLock::getKey(
+            new ChunkContentJob(Project::class, 1)
         );
         DB::table('cache_locks')->insert([
             'key' => $lockKey,

--- a/sandbox/test-multitenant-job-locks.php
+++ b/sandbox/test-multitenant-job-locks.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Multi-tenant job-lock isolation — live two-database proof (v3.1.3 fix).
+ *
+ * Stands up a SECOND real Postgres database and proves the database-scoped
+ * `ShouldBeUnique` key fix on live infrastructure:
+ *
+ *   1. Two tenants whose conversation id=1 lives in separate databases produce
+ *      DIFFERENT lock keys → both jobs queue independently (no cross-tenant
+ *      suppression). This is the bug the v3.1.3 fix resolves — before it, both
+ *      keys were `atlas-queued-1` and the second tenant's job was dropped.
+ *   2. Same tenant + same conversation id still dedups to one job (ShouldBeUnique
+ *      semantics preserved within a database).
+ *
+ * Uses the real `database` cache lock (the production mechanism) + `database`
+ * queue (so we can count rows in the `jobs` table).
+ *
+ * Usage:
+ *   cd sandbox
+ *   php artisan migrate:fresh
+ *   php test-multitenant-job-locks.php
+ *
+ * Requires DB_CONNECTION=pgsql (CREATE DATABASE privilege) and QUEUE_CONNECTION=database.
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Persistence\ProcessQueuedMessage;
+use Illuminate\Bus\UniqueLock;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+$failures = [];
+
+function section(string $title): void
+{
+    echo "\n".str_repeat('─', 76)."\n  {$title}\n".str_repeat('─', 76)."\n";
+}
+
+function check(string $name, bool $ok, string $detail = ''): void
+{
+    global $failures;
+    echo '  '.($ok ? '✓' : '✗')." {$name}".($detail !== '' ? " — {$detail}" : '')."\n";
+    if (! $ok) {
+        $failures[] = $name.($detail !== '' ? ": {$detail}" : '');
+    }
+}
+
+function queuedProcessJobs(): int
+{
+    return (int) DB::table('jobs')->where('payload', 'like', '%ProcessQueuedMessage%')->count();
+}
+
+function resetJobsAndLocks(): void
+{
+    DB::table('jobs')->delete();
+    if (Schema::hasTable('cache_locks')) {
+        DB::table('cache_locks')->delete();
+    }
+    Cache::flush();
+}
+
+// ─── Preflight ──────────────────────────────────────────────────────────────
+
+if (DB::connection()->getDriverName() !== 'pgsql') {
+    echo "This test requires PostgreSQL (DB_CONNECTION=pgsql). Aborting.\n";
+    exit(1);
+}
+if (config('queue.default') !== 'database' || ! Schema::hasTable('jobs')) {
+    echo "This test requires QUEUE_CONNECTION=database and a migrated `jobs` table (run migrate:fresh).\n";
+    exit(1);
+}
+
+$app['config']->set('cache.default', 'database');
+
+$queue = app(AtlasConfig::class)->queue;
+$centralDb = DB::connection()->getDatabaseName();
+$tenantBDb = $centralDb.'_tenant_b';
+
+// ─── Provision a real second tenant database + connection ────────────────────
+
+section('Setup: provision a second real Postgres database');
+
+DB::statement('DROP DATABASE IF EXISTS "'.$tenantBDb.'"');
+DB::statement('CREATE DATABASE "'.$tenantBDb.'"');
+
+$base = config('database.connections.'.config('database.default'));
+$base['database'] = $tenantBDb;
+$app['config']->set('database.connections.tenant_b', $base);
+
+check('central and tenant-b are distinct databases',
+    DB::connection('tenant_b')->getDatabaseName() === $tenantBDb && $tenantBDb !== $centralDb,
+    "central={$centralDb} tenant_b=".DB::connection('tenant_b')->getDatabaseName());
+
+/**
+ * Dispatch a ProcessQueuedMessage as the given tenant (by pointing Atlas
+ * persistence at that connection). Forces the PendingDispatch to resolve so
+ * the ShouldBeUnique lock is acquired at dispatch time.
+ */
+function dispatchAs(?string $persistenceConnection, int $conversationId, string $queue): void
+{
+    config(['atlas.persistence.connection' => $persistenceConnection]);
+    AtlasConfig::refresh();
+
+    $pending = ProcessQueuedMessage::dispatch($conversationId, 'test-agent')->onQueue($queue);
+    unset($pending); // __destruct → dispatchToQueue → ShouldBeUnique lock check
+}
+
+// ─── 1. The keys differ across tenant databases ─────────────────────────────
+
+section('1. Same conversation id in two databases → different lock keys');
+
+config(['atlas.persistence.connection' => null]);
+AtlasConfig::refresh();
+$keyA = UniqueLock::getKey(new ProcessQueuedMessage(1, 'test-agent'));
+
+config(['atlas.persistence.connection' => 'tenant_b']);
+AtlasConfig::refresh();
+$keyB = UniqueLock::getKey(new ProcessQueuedMessage(1, 'test-agent'));
+
+check('lock keys differ for conversation id=1 across the two databases',
+    $keyA !== $keyB, "A=[{$keyA}] B=[{$keyB}]");
+
+// ─── 2. Cross-tenant: both jobs queue independently (THE FIX) ────────────────
+
+section('2. Two tenants, conversation id=1 each → both jobs queue (no collision)');
+
+resetJobsAndLocks();
+dispatchAs(null, 1, $queue);        // tenant A (central) conversation 1
+dispatchAs('tenant_b', 1, $queue);  // tenant B conversation 1
+
+check('both tenants\' conversation-1 jobs were queued independently',
+    queuedProcessJobs() === 2,
+    'queued='.queuedProcessJobs().' (expected 2 — pre-fix this was 1, the second tenant dropped)');
+
+// ─── 3. Same-tenant dedup still works ────────────────────────────────────────
+
+section('3. Same tenant + same conversation id → dedups to one job');
+
+resetJobsAndLocks();
+dispatchAs(null, 1, $queue);
+dispatchAs(null, 1, $queue);
+
+check('duplicate dispatch within the same database is suppressed by ShouldBeUnique',
+    queuedProcessJobs() === 1,
+    'queued='.queuedProcessJobs().' (expected 1)');
+
+// ─── Cleanup ─────────────────────────────────────────────────────────────────
+
+config(['atlas.persistence.connection' => null]);
+AtlasConfig::refresh();
+DB::purge('tenant_b');
+DB::statement('DROP DATABASE IF EXISTS "'.$tenantBDb.'"');
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+section('Summary');
+if ($failures === []) {
+    echo "\n  All assertions passed.\n";
+    exit(0);
+}
+echo "\n  ".count($failures)." assertion(s) FAILED:\n";
+foreach ($failures as $f) {
+    echo "    - {$f}\n";
+}
+exit(1);

--- a/sandbox/test-queued-message-dispatch.php
+++ b/sandbox/test-queued-message-dispatch.php
@@ -217,9 +217,15 @@ if (! Schema::hasTable('cache_locks')) {
     // the previous dispatch's lock hasn't expired yet (ShouldBeUnique
     // releases the lock when the job completes, but a recently-completed
     // or in-flight job leaves it set for the rest of its TTL).
+    // Derive the lock key from the real job via the framework's own helper so
+    // it always matches the job's current uniqueId() (which is database-scoped
+    // for multi-tenant safety) — never hardcode the format.
     $prefix = (string) ($app['config']->get('cache.prefix') ?: '');
+    $lockKey = $prefix.\Illuminate\Bus\UniqueLock::getKey(
+        new ProcessQueuedMessage($conversation->id, 'test-agent')
+    );
     DB::table('cache_locks')->insert([
-        'key' => $prefix.'laravel_unique_job:Atlasphp\\Atlas\\Persistence\\ProcessQueuedMessage:atlas-queued-'.$conversation->id,
+        'key' => $lockKey,
         'owner' => 'sandbox-pre-seed-different-owner',
         'expiration' => time() + 3600,
     ]);

--- a/sandbox/test-queued-message-dispatch.php
+++ b/sandbox/test-queued-message-dispatch.php
@@ -51,6 +51,7 @@ $app = require __DIR__.'/bootstrap.php';
 use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Persistence\Models\Conversation;
 use Atlasphp\Atlas\Persistence\ProcessQueuedMessage;
+use Illuminate\Bus\UniqueLock;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -221,7 +222,7 @@ if (! Schema::hasTable('cache_locks')) {
     // it always matches the job's current uniqueId() (which is database-scoped
     // for multi-tenant safety) — never hardcode the format.
     $prefix = (string) ($app['config']->get('cache.prefix') ?: '');
-    $lockKey = $prefix.\Illuminate\Bus\UniqueLock::getKey(
+    $lockKey = $prefix.UniqueLock::getKey(
         new ProcessQueuedMessage($conversation->id, 'test-agent')
     );
     DB::table('cache_locks')->insert([

--- a/src/Concerns/ResolvesDatabaseScope.php
+++ b/src/Concerns/ResolvesDatabaseScope.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Concerns;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Resolves a database-scoped discriminator for unique-job lock keys.
+ *
+ * Under DB-per-tenant multi-tenancy the framework repoints a connection at
+ * each tenant's database, so per-database auto-increment IDs repeat across
+ * tenants (every tenant has a row id 1, 2, 3…). ShouldBeUnique locks live in
+ * a shared cache, so a key built from an id alone lets one tenant's job
+ * suppress another tenant's same-id job — silently dropping the second.
+ *
+ * Including the connection's database name in the key scopes the lock to the
+ * physical database. This is tenancy-package agnostic (it reads the resolved
+ * connection, not any tenancy API); a single-database app simply gets a
+ * constant segment and behaves exactly as before.
+ */
+trait ResolvesDatabaseScope
+{
+    /**
+     * The database name backing the given connection (null = default).
+     */
+    protected function databaseScope(?string $connection = null): string
+    {
+        return (string) DB::connection($connection)->getDatabaseName();
+    }
+}

--- a/src/Console/RechunkCommand.php
+++ b/src/Console/RechunkCommand.php
@@ -4,76 +4,235 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Console;
 
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Embeddings\ChunkableRegistry;
+use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Marks chunkable model rows dirty so the next atlas:chunk sweep re-chunks them.
  *
- * Two usage modes:
+ * Usage modes:
+ *
+ *   php artisan atlas:rechunk
+ *     → marks every row of every registered chunkable class dirty. Use after
+ *       a global change (new embedding model, new chunker, dimension swap).
+ *
+ *   php artisan atlas:rechunk --all
+ *     → identical to no-arg form, kept as an explicit synonym.
  *
  *   php artisan atlas:rechunk "App\Models\Project"
- *     → marks every row of the class dirty. Use after deploying a new
- *       chunker, changing chunk_size, or any other change that should
- *       rebuild every record's chunks from scratch.
+ *     → marks every row of one class dirty. Use after deploying a new
+ *       chunker, changing chunk_size, or any other class-scoped change.
  *
  *   php artisan atlas:rechunk "App\Models\Project" 42
  *     → marks only row id=42 dirty. Use to fix one record's chunks after
  *       investigating bad retrieval results for it.
+ *
+ * Flags:
+ *
+ *   --reset-failures
+ *     Also zero out `index_failure_count` and `last_index_error`. Without
+ *     this, rows past the failure cap (`atlas.embeddings.max_failures`) are
+ *     silently skipped by both the sweep and the job — the row stays
+ *     "dirty" but never reindexes. The command reports the poisoned count
+ *     when this flag is omitted so the operator can see why nothing moved.
+ *
+ *   --dispatch
+ *     Dispatch ChunkContentJob for every dirty target immediately, bypassing
+ *     the sweep's `sweep_batch` per-tick cap and the cron wait. Useful when
+ *     you want immediate, visible progress instead of trusting the next
+ *     scheduled atlas:chunk tick.
+ *
+ * The update is wrapped in `Model::withoutTimestamps()` so `updated_at` is
+ * not bumped — the settle window protects in-flight user edits, not
+ * operator rechunks, and bumping `updated_at` would otherwise push every
+ * row into the 60-second settle window on the next sweep tick.
  */
 class RechunkCommand extends Command
 {
     protected $signature = 'atlas:rechunk
-        {class : Fully-qualified model class to mark dirty}
+        {class? : Fully-qualified model class to mark dirty (omit to mark all registered classes)}
         {id? : Optional model ID — if provided, only that row is marked dirty}
-        {--reset-failures : Also reset index_failure_count so previously-skipped rows are picked up}';
+        {--all : Mark every registered chunkable class dirty (synonym for omitting class)}
+        {--reset-failures : Also reset index_failure_count so previously-skipped rows are picked up}
+        {--dispatch : Dispatch ChunkContentJob for every dirty target immediately instead of waiting for the next atlas:chunk tick}';
 
     protected $description = 'Mark chunkable rows dirty (whole class or a single ID) so the next sweep re-chunks them.';
 
-    public function handle(ChunkableRegistry $registry): int
+    public function handle(ChunkableRegistry $registry, AtlasConfig $config): int
     {
-        $class = (string) $this->argument('class');
+        $class = $this->argument('class');
         $id = $this->argument('id');
+        $all = (bool) $this->option('all');
+        $resetFailures = (bool) $this->option('reset-failures');
+        $dispatch = (bool) $this->option('dispatch');
+
+        if ($id !== null && ($class === null || $all)) {
+            $this->error('Cannot pass an id without a single class argument.');
+
+            return self::FAILURE;
+        }
+
+        if ($class !== null && $all) {
+            $this->error('Pass either a class argument or --all, not both.');
+
+            return self::FAILURE;
+        }
+
+        $targets = $this->resolveTargets($registry, $class === null || $all ? null : (string) $class);
+        if ($targets === null) {
+            return self::FAILURE;
+        }
+
+        if (empty($targets)) {
+            $this->warn('No chunkable models registered. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $updates = ['indexed_hash' => null];
+        if ($resetFailures) {
+            $updates['index_failure_count'] = 0;
+            $updates['last_index_error'] = null;
+        }
+
+        $maxFailures = $config->chunkMaxFailures;
+
+        $totalMarked = 0;
+        $totalPoisoned = 0;
+
+        foreach ($targets as $targetClass) {
+            $result = $this->rechunkOne($targetClass, $id, $updates, $resetFailures, $maxFailures);
+            $totalMarked += $result['marked'];
+            $totalPoisoned += $result['poisoned'];
+        }
+
+        if (count($targets) > 1) {
+            $this->newLine();
+            $this->info("Total: {$totalMarked} row(s) marked dirty across ".count($targets).' class(es).');
+        }
+
+        if ($totalPoisoned > 0 && ! $resetFailures) {
+            $this->newLine();
+            $this->warn("{$totalPoisoned} row(s) past the failure cap (index_failure_count >= {$maxFailures}) will be skipped by the sweep.");
+            $this->warn('Pass --reset-failures to rechunk them as well.');
+        }
+
+        if ($dispatch) {
+            $this->newLine();
+            $this->dispatchAll($targets, $id, $resetFailures, $maxFailures, $config->queue);
+        } elseif ($totalMarked > 0) {
+            $this->newLine();
+            $this->line('Next: wait for the atlas:chunk cron tick, or pass --dispatch to push jobs now.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<int, class-string<Model>>|null
+     */
+    protected function resolveTargets(ChunkableRegistry $registry, ?string $class): ?array
+    {
+        if ($class === null) {
+            return $registry->all();
+        }
 
         if (! class_exists($class)) {
             $this->error("Class [{$class}] does not exist.");
 
-            return self::FAILURE;
+            return null;
         }
 
         if (! $registry->has($class)) {
             $this->error("Class [{$class}] is not registered as chunkable. Register it via Atlas::registerChunkable() in your service provider.");
 
-            return self::FAILURE;
+            return null;
         }
 
-        $updates = ['indexed_hash' => null];
-        if ((bool) $this->option('reset-failures')) {
-            $updates['index_failure_count'] = 0;
-            $updates['last_index_error'] = null;
+        return [$class];
+    }
+
+    /**
+     * @param  class-string<Model>  $targetClass
+     * @param  array<string, mixed>  $updates
+     * @return array{marked: int, poisoned: int}
+     */
+    protected function rechunkOne(string $targetClass, int|string|null $id, array $updates, bool $resetFailures, int $maxFailures): array
+    {
+        $poisonedCount = 0;
+        if (! $resetFailures) {
+            $poisonQuery = $targetClass::query()->where('index_failure_count', '>=', $maxFailures);
+            if ($id !== null) {
+                $poisonQuery->whereKey($id);
+            }
+            $poisonedCount = $poisonQuery->count();
         }
 
-        /** @var class-string<Model> $class */
-        $query = $class::query();
+        // Skip the timestamp bump so freshly-rechunked rows are immediately
+        // sweep-eligible — the settle window protects in-flight user edits,
+        // not operator rechunks.
+        $count = $targetClass::withoutTimestamps(function () use ($targetClass, $id, $updates): int {
+            $query = $targetClass::query();
+            if ($id !== null) {
+                $query->whereKey($id);
+            }
 
-        if ($id !== null) {
-            $query->whereKey($id);
-        }
-
-        $count = $query->update($updates);
+            return $query->update($updates);
+        });
 
         if ($id !== null) {
             if ($count === 0) {
-                $this->warn("No row found for [{$class}] with id [{$id}].");
+                $this->warn("[{$targetClass}] No row found with id [{$id}].");
 
-                return self::SUCCESS;
+                return ['marked' => 0, 'poisoned' => 0];
             }
-            $this->info("Marked [{$class}] id={$id} dirty.");
+            $this->info("[{$targetClass}] Marked id={$id} dirty.");
         } else {
-            $this->info("Marked {$count} row(s) of [{$class}] dirty.");
+            $line = "[{$targetClass}] Marked {$count} row(s) dirty";
+            if ($poisonedCount > 0) {
+                $line .= " ({$poisonedCount} past failure cap)";
+            }
+            $line .= '.';
+            $this->info($line);
         }
 
-        return self::SUCCESS;
+        return ['marked' => $count, 'poisoned' => $poisonedCount];
+    }
+
+    /**
+     * @param  array<int, class-string<Model>>  $targets
+     */
+    protected function dispatchAll(array $targets, int|string|null $id, bool $resetFailures, int $maxFailures, string $queue): void
+    {
+        $this->info('Dispatching ChunkContentJob(s)...');
+
+        $totalDispatched = 0;
+        foreach ($targets as $targetClass) {
+            /** @var Model $sample */
+            $sample = new $targetClass;
+            $key = $sample->getKeyName();
+
+            $query = $targetClass::query()->whereNull('indexed_hash');
+            if (! $resetFailures) {
+                $query->where('index_failure_count', '<', $maxFailures);
+            }
+            if ($id !== null) {
+                $query->whereKey($id);
+            }
+
+            $ids = $query->pluck($key)->all();
+            foreach ($ids as $rowId) {
+                ChunkContentJob::dispatch($targetClass, $rowId)->onQueue($queue);
+            }
+
+            $this->info('['.$targetClass.'] '.count($ids).' job(s) dispatched.');
+            $totalDispatched += count($ids);
+        }
+
+        $this->newLine();
+        $this->info("Total: {$totalDispatched} job(s) dispatched. Monitor Horizon for processing.");
     }
 }

--- a/src/Persistence/ProcessQueuedMessage.php
+++ b/src/Persistence/ProcessQueuedMessage.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Persistence;
 
 use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Concerns\ResolvesDatabaseScope;
 use Atlasphp\Atlas\Persistence\Enums\MessageStatus;
 use Atlasphp\Atlas\Persistence\Models\ConversationMessage;
 use Atlasphp\Atlas\Persistence\Services\ConversationService;
@@ -28,13 +29,16 @@ use Throwable;
  * The agent's own middleware stack handles all lifecycle concerns. The
  * execution path is identical to a direct consumer call — only timing differs.
  *
- * Unique per conversation to prevent concurrent processing.
+ * Unique per conversation (and per database, so concurrent same-id
+ * conversations in different tenant databases don't collide) to prevent
+ * concurrent processing.
  */
 class ProcessQueuedMessage implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
+    use ResolvesDatabaseScope;
     use SerializesModels;
 
     public int $tries = 3;
@@ -53,7 +57,14 @@ class ProcessQueuedMessage implements ShouldBeUnique, ShouldQueue
 
     public function uniqueId(): string
     {
-        return 'atlas-queued-'.$this->conversationId;
+        // Scope the lock to the persistence database so the same conversation id
+        // in two different tenant databases doesn't share one lock (which would
+        // drop the second tenant's job). AtlasConfig is resolved from the
+        // container rather than constructor-injected to keep the queued payload
+        // small — same reason failed() resolves it via app() below.
+        $scope = $this->databaseScope(app(AtlasConfig::class)->persistenceConnection);
+
+        return 'atlas-queued-'.$scope.'-'.$this->conversationId;
     }
 
     public function handle(ConversationService $conversations): void

--- a/src/Queue/Jobs/ChunkContentJob.php
+++ b/src/Queue/Jobs/ChunkContentJob.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Queue\Jobs;
 
 use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Concerns\ResolvesDatabaseScope;
 use Atlasphp\Atlas\Embeddings\Chunkable;
 use Atlasphp\Atlas\Exceptions\AtlasException;
 use Atlasphp\Atlas\Persistence\Services\ChunkContentService;
@@ -26,8 +27,9 @@ use Illuminate\Queue\SerializesModels;
  *      bypassed Eloquent saves).
  *
  * Debounce semantics. The job implements `ShouldBeUnique` keyed by
- * `modelClass:modelId`, so concurrent dispatches for the same row
- * collapse into a single queued job. On execution the job checks
+ * `modelClass:database:modelId` (the database segment keeps same-id rows
+ * in different tenant databases from sharing one lock), so concurrent
+ * dispatches for the same row collapse into a single queued job. On execution the job checks
  * `updated_at` against the settle window — if the row was edited
  * within `sweep_settle` seconds, the job releases itself forward
  * until the window passes since the last edit. The unique lock
@@ -53,6 +55,7 @@ class ChunkContentJob implements ShouldBeUnique, ShouldQueue
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
+    use ResolvesDatabaseScope;
     use SerializesModels;
 
     /**
@@ -83,13 +86,20 @@ class ChunkContentJob implements ShouldBeUnique, ShouldQueue
     ) {}
 
     /**
-     * Per-row unique key. Two dispatches for the same model collapse
-     * into one queued job; the second dispatch is silently dropped
-     * (returns the existing job's payload).
+     * Per-row unique key, scoped to the row's database. Two dispatches for
+     * the same model collapse into one queued job; the second dispatch is
+     * silently dropped (returns the existing job's payload). The database
+     * segment keeps the same row id in different tenant databases from
+     * colliding on one lock.
      */
     public function uniqueId(): string
     {
-        return $this->modelClass.':'.$this->modelId;
+        // getConnectionName() reads the model's static $connection property — it
+        // does not open a database connection. Eloquent boots each model class
+        // once per process, so the instantiation is cheap on repeat calls.
+        $scope = $this->databaseScope((new $this->modelClass)->getConnectionName());
+
+        return $this->modelClass.':'.$scope.':'.$this->modelId;
     }
 
     /**

--- a/tests/Feature/Persistence/RechunkCommandTest.php
+++ b/tests/Feature/Persistence/RechunkCommandTest.php
@@ -6,8 +6,10 @@ use Atlasphp\Atlas\Embeddings\Chunkable;
 use Atlasphp\Atlas\Embeddings\ChunkableRegistry;
 use Atlasphp\Atlas\Persistence\Concerns\HasChunkedEmbeddings;
 use Atlasphp\Atlas\Persistence\Schema\ChunkedEmbeddingColumns;
+use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 
 class FakeRechunkDoc extends Model implements Chunkable
@@ -21,9 +23,28 @@ class FakeRechunkDoc extends Model implements Chunkable
     public $timestamps = true;
 }
 
+class FakeRechunkDocB extends Model implements Chunkable
+{
+    use HasChunkedEmbeddings;
+
+    protected $table = 'fake_rechunk_docs_b';
+
+    protected $guarded = [];
+
+    public $timestamps = true;
+}
+
 beforeEach(function () {
     Schema::dropIfExists('fake_rechunk_docs');
     Schema::create('fake_rechunk_docs', function (Blueprint $table) {
+        $table->id();
+        $table->text('body')->nullable();
+        $table->timestamps();
+        ChunkedEmbeddingColumns::add($table);
+    });
+
+    Schema::dropIfExists('fake_rechunk_docs_b');
+    Schema::create('fake_rechunk_docs_b', function (Blueprint $table) {
         $table->id();
         $table->text('body')->nullable();
         $table->timestamps();
@@ -151,4 +172,267 @@ it('resets failure counters on a single-id rechunk when --reset-failures is pass
     expect($doc->indexed_hash)->toBeNull();
     expect($doc->index_failure_count)->toBe(0);
     expect($doc->last_index_error)->toBeNull();
+});
+
+it('marks every registered chunkable class dirty when no class is given', function () {
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+    app(ChunkableRegistry::class)->register(FakeRechunkDocB::class);
+
+    FakeRechunkDoc::create(['body' => 'A1']);
+    FakeRechunkDoc::create(['body' => 'A2']);
+    FakeRechunkDocB::create(['body' => 'B1']);
+
+    FakeRechunkDoc::query()->update(['indexed_hash' => 'old']);
+    FakeRechunkDocB::query()->update(['indexed_hash' => 'old']);
+
+    $this->artisan('atlas:rechunk')
+        ->expectsOutputToContain('Marked 2 row(s)')
+        ->expectsOutputToContain('Marked 1 row(s)')
+        ->expectsOutputToContain('Total: 3 row(s)')
+        ->assertExitCode(0);
+
+    expect(FakeRechunkDoc::query()->whereNotNull('indexed_hash')->count())->toBe(0);
+    expect(FakeRechunkDocB::query()->whereNotNull('indexed_hash')->count())->toBe(0);
+});
+
+it('warns and exits cleanly when no chunkable classes are registered', function () {
+    $this->artisan('atlas:rechunk')
+        ->expectsOutputToContain('No chunkable models registered')
+        ->assertExitCode(0);
+});
+
+it('--all is a synonym for omitting the class argument', function () {
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+    app(ChunkableRegistry::class)->register(FakeRechunkDocB::class);
+
+    FakeRechunkDoc::create(['body' => 'A']);
+    FakeRechunkDocB::create(['body' => 'B']);
+    FakeRechunkDoc::query()->update(['indexed_hash' => 'old']);
+    FakeRechunkDocB::query()->update(['indexed_hash' => 'old']);
+
+    $this->artisan('atlas:rechunk', ['--all' => true])
+        ->expectsOutputToContain('Total: 2 row(s)')
+        ->assertExitCode(0);
+
+    expect(FakeRechunkDoc::query()->whereNotNull('indexed_hash')->count())->toBe(0);
+    expect(FakeRechunkDocB::query()->whereNotNull('indexed_hash')->count())->toBe(0);
+});
+
+it('errors when class and --all are both passed', function () {
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $this->artisan('atlas:rechunk', ['class' => FakeRechunkDoc::class, '--all' => true])
+        ->expectsOutputToContain('Pass either a class argument or --all')
+        ->assertExitCode(1);
+});
+
+it('errors when an id is passed without a class', function () {
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $this->artisan('atlas:rechunk', ['id' => 42])
+        ->expectsOutputToContain('Cannot pass an id without a single class')
+        ->assertExitCode(1);
+});
+
+it('reports rows past the failure cap so the operator knows to pass --reset-failures', function () {
+    config(['atlas.embeddings.max_failures' => 5]);
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $clean = FakeRechunkDoc::create(['body' => 'clean']);
+    $poisoned = FakeRechunkDoc::create(['body' => 'poisoned']);
+    $poisoned->update(['index_failure_count' => 7]);
+
+    $this->artisan('atlas:rechunk', ['class' => FakeRechunkDoc::class])
+        ->expectsOutputToContain('Marked 2 row(s) dirty (1 past failure cap)')
+        ->expectsOutputToContain('1 row(s) past the failure cap')
+        ->expectsOutputToContain('--reset-failures')
+        ->assertExitCode(0);
+});
+
+it('does not warn about the failure cap when --reset-failures is passed', function () {
+    config(['atlas.embeddings.max_failures' => 5]);
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $doc = FakeRechunkDoc::create(['body' => 'poisoned']);
+    $doc->update(['index_failure_count' => 7]);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        '--reset-failures' => true,
+    ])
+        ->doesntExpectOutputToContain('past the failure cap')
+        ->assertExitCode(0);
+});
+
+it('preserves updated_at so freshly-rechunked rows are immediately sweep-eligible', function () {
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $doc = FakeRechunkDoc::create(['body' => 'body']);
+    $originalUpdatedAt = now()->subHours(3);
+    FakeRechunkDoc::query()->update(['updated_at' => $originalUpdatedAt, 'indexed_hash' => 'old']);
+
+    $this->artisan('atlas:rechunk', ['class' => FakeRechunkDoc::class])->assertExitCode(0);
+
+    $doc->refresh();
+    // Allow ±2s of clock skew between PHP and the DB but reject a bump to now().
+    expect($doc->updated_at->getTimestamp())
+        ->toBeGreaterThan($originalUpdatedAt->getTimestamp() - 2)
+        ->toBeLessThan($originalUpdatedAt->getTimestamp() + 2);
+});
+
+it('dispatches ChunkContentJob for every dirty row when --dispatch is passed', function () {
+    Queue::fake();
+
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $a = FakeRechunkDoc::create(['body' => 'A']);
+    $b = FakeRechunkDoc::create(['body' => 'B']);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        '--dispatch' => true,
+    ])
+        ->expectsOutputToContain('2 job(s) dispatched')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(ChunkContentJob::class, 2);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelId === $a->id,
+    );
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelId === $b->id,
+    );
+});
+
+it('--dispatch skips poisoned rows unless --reset-failures is also passed', function () {
+    Queue::fake();
+    config(['atlas.embeddings.max_failures' => 5]);
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $clean = FakeRechunkDoc::create(['body' => 'clean']);
+    $poisoned = FakeRechunkDoc::create(['body' => 'poisoned']);
+    $poisoned->update(['index_failure_count' => 7]);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        '--dispatch' => true,
+    ])->assertExitCode(0);
+
+    Queue::assertPushed(ChunkContentJob::class, 1);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelId === $clean->id,
+    );
+});
+
+it('--dispatch with --reset-failures dispatches every dirty row, including poisoned ones', function () {
+    Queue::fake();
+    config(['atlas.embeddings.max_failures' => 5]);
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    FakeRechunkDoc::create(['body' => 'clean']);
+    $poisoned = FakeRechunkDoc::create(['body' => 'poisoned']);
+    $poisoned->update(['index_failure_count' => 7]);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        '--dispatch' => true,
+        '--reset-failures' => true,
+    ])->assertExitCode(0);
+
+    Queue::assertPushed(ChunkContentJob::class, 2);
+});
+
+it('--dispatch with a single id dispatches only that job', function () {
+    Queue::fake();
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $a = FakeRechunkDoc::create(['body' => 'A']);
+    $b = FakeRechunkDoc::create(['body' => 'B']);
+    $c = FakeRechunkDoc::create(['body' => 'C']);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        'id' => $b->id,
+        '--dispatch' => true,
+    ])->assertExitCode(0);
+
+    Queue::assertPushed(ChunkContentJob::class, 1);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelId === $b->id,
+    );
+});
+
+it('--dispatch with no class dispatches for every registered class', function () {
+    Queue::fake();
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+    app(ChunkableRegistry::class)->register(FakeRechunkDocB::class);
+
+    FakeRechunkDoc::create(['body' => 'A']);
+    FakeRechunkDocB::create(['body' => 'B']);
+
+    $this->artisan('atlas:rechunk', ['--dispatch' => true])
+        ->expectsOutputToContain('Total: 2 job(s) dispatched')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(ChunkContentJob::class, 2);
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelClass === FakeRechunkDoc::class,
+    );
+    Queue::assertPushed(
+        ChunkContentJob::class,
+        fn (ChunkContentJob $job) => $job->modelClass === FakeRechunkDocB::class,
+    );
+});
+
+it('errors when an id is passed together with --all', function () {
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        'id' => 5,
+        '--all' => true,
+    ])
+        ->expectsOutputToContain('Cannot pass an id without a single class')
+        ->assertExitCode(1);
+});
+
+it('marks zero rows and dispatches zero jobs for a registered class with no rows', function () {
+    Queue::fake();
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        '--dispatch' => true,
+    ])
+        ->expectsOutputToContain('Marked 0 row(s) dirty')
+        ->expectsOutputToContain('0 job(s) dispatched')
+        ->assertExitCode(0);
+
+    Queue::assertNothingPushed();
+});
+
+it('reports the failure cap warning for a single poisoned id', function () {
+    config(['atlas.embeddings.max_failures' => 5]);
+    app(ChunkableRegistry::class)->register(FakeRechunkDoc::class);
+
+    $doc = FakeRechunkDoc::create(['body' => 'poisoned']);
+    $doc->update(['index_failure_count' => 7]);
+
+    $this->artisan('atlas:rechunk', [
+        'class' => FakeRechunkDoc::class,
+        'id' => $doc->id,
+    ])
+        ->expectsOutputToContain("Marked id={$doc->id} dirty")
+        ->expectsOutputToContain('1 row(s) past the failure cap')
+        ->assertExitCode(0);
+
+    // The poisoned row is still marked dirty (indexed_hash cleared); the warning
+    // just tells the operator the sweep will skip it without --reset-failures.
+    expect($doc->fresh()->indexed_hash)->toBeNull();
+    expect($doc->fresh()->index_failure_count)->toBe(7);
 });

--- a/tests/Unit/Persistence/ProcessQueuedMessageTest.php
+++ b/tests/Unit/Persistence/ProcessQueuedMessageTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Messages\UserMessage;
 use Atlasphp\Atlas\Persistence\Enums\MessageStatus;
 use Atlasphp\Atlas\Persistence\Models\Conversation;
@@ -12,6 +13,7 @@ use Atlasphp\Atlas\Persistence\Services\ConversationService;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\DB;
 
 it('stores correct properties', function () {
     $job = new ProcessQueuedMessage(
@@ -30,10 +32,31 @@ it('implements ShouldQueue and ShouldBeUnique', function () {
         ->and($job)->toBeInstanceOf(ShouldBeUnique::class);
 });
 
-it('uniqueId returns conversation-scoped string', function () {
+it('uniqueId is scoped to the conversation and the persistence database', function () {
     $job = new ProcessQueuedMessage(conversationId: 99, agentKey: 'writer');
 
-    expect($job->uniqueId())->toBe('atlas-queued-99');
+    $db = DB::connection()->getDatabaseName();
+
+    expect($job->uniqueId())->toBe('atlas-queued-'.$db.'-99');
+});
+
+it('uniqueId differs across tenant databases for the same conversation id', function () {
+    $job = new ProcessQueuedMessage(conversationId: 1, agentKey: 'writer');
+
+    config()->set('database.connections.tenant_a', ['driver' => 'sqlite', 'database' => 'tenant_a_db', 'prefix' => '']);
+    config()->set('database.connections.tenant_b', ['driver' => 'sqlite', 'database' => 'tenant_b_db', 'prefix' => '']);
+
+    config()->set('atlas.persistence.connection', 'tenant_a');
+    AtlasConfig::refresh();
+    $keyA = $job->uniqueId();
+
+    config()->set('atlas.persistence.connection', 'tenant_b');
+    AtlasConfig::refresh();
+    $keyB = $job->uniqueId();
+
+    expect($keyA)->toBe('atlas-queued-tenant_a_db-1')
+        ->and($keyB)->toBe('atlas-queued-tenant_b_db-1')
+        ->and($keyA)->not->toBe($keyB);
 });
 
 it('has default tries', function () {

--- a/tests/Unit/Persistence/Queue/ChunkContentJobTest.php
+++ b/tests/Unit/Persistence/Queue/ChunkContentJobTest.php
@@ -12,6 +12,7 @@ use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class FakeJobChunkableDoc extends Model implements Chunkable
@@ -28,6 +29,19 @@ class FakeJobChunkableDoc extends Model implements Chunkable
 class FakeJobBareDoc extends Model
 {
     protected $table = 'fake_job_bare_docs';
+
+    protected $guarded = [];
+
+    public $timestamps = true;
+}
+
+class FakeScopedChunkableDoc extends Model implements Chunkable
+{
+    use HasChunkedEmbeddings;
+
+    protected $connection = 'tenant_scope';
+
+    protected $table = 'fake_scoped_chunkable_docs';
 
     protected $guarded = [];
 
@@ -156,9 +170,26 @@ it('releases itself when the model was updated within the settle window', functi
 it('reports the correct unique id and retry budget', function () {
     $job = new ChunkContentJob(FakeJobChunkableDoc::class, 42);
 
-    expect($job->uniqueId())->toBe(FakeJobChunkableDoc::class.':42');
+    $db = DB::connection()->getDatabaseName();
+
+    expect($job->uniqueId())->toBe(FakeJobChunkableDoc::class.':'.$db.':42');
     expect($job->retryUntil())->toBeInstanceOf(DateTimeInterface::class);
     // retryUntil should be ~1 hour from now (±a few seconds for test runtime).
     $hourFromNow = now()->addHour()->getTimestamp();
     expect(abs($job->retryUntil()->getTimestamp() - $hourFromNow))->toBeLessThan(5);
+});
+
+it('scopes uniqueId by the model connection database (no cross-tenant collision)', function () {
+    // A chunkable model pinned to a named connection whose database we vary,
+    // the way a DB-per-tenant package repoints a connection between tenants.
+    config()->set('database.connections.tenant_scope', ['driver' => 'sqlite', 'database' => 'chunk_tenant_a', 'prefix' => '']);
+    $keyA = (new ChunkContentJob(FakeScopedChunkableDoc::class, 7))->uniqueId();
+
+    DB::purge('tenant_scope');
+    config()->set('database.connections.tenant_scope.database', 'chunk_tenant_b');
+    $keyB = (new ChunkContentJob(FakeScopedChunkableDoc::class, 7))->uniqueId();
+
+    expect($keyA)->toBe(FakeScopedChunkableDoc::class.':chunk_tenant_a:7')
+        ->and($keyB)->toBe(FakeScopedChunkableDoc::class.':chunk_tenant_b:7')
+        ->and($keyA)->not->toBe($keyB);
 });


### PR DESCRIPTION
Fix cross-tenant job collisions by scoping ShouldBeUnique lock keys to the backing database. Add ResolvesDatabaseScope trait and include the database name in uniqueId() for ProcessQueuedMessage and ChunkContentJob so same row IDs in different DBs no longer share a lock.

Also:
- Enhance atlas:rechunk command: support omitting class to target all registered chunkables, add --all, --dispatch and improved reset-failures handling and reporting; preserve updated_at during operator rechunks; allow immediate dispatch of ChunkContentJob.
- Add sandbox integration tests for multi-tenant job-lock isolation and update existing sandbox/tests and unit tests to cover the new behavior.
- Update CHANGELOG with v3.1.3 note.

No breaking changes; drop-in upgrade.