### PR TITLE
Support base64 (b64_json) OpenAI image responses

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,50 @@
+# Live API Audit
+
+Status of each provider's modalities against **real provider APIs**, exercised via the
+sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
+records the date each modality last **passed a live API test** — not unit-test coverage.
+
+**Last full run: 2026-06-02**
+
+Reproduce: `cd sandbox && php test-{provider}-provider.php` (requires the provider's API key in `sandbox/.env`).
+
+### Legend
+
+- ✅ — passed live on the date below
+- — — not part of this provider's offering / not in its live suite
+- ⚠️ — supported but **not** exercised live (see notes)
+- ❌ — could not verify live (blocked — see notes)
+
+## Modality matrix
+
+| Provider    | Text | Stream | Structured | Tools | Vision | Image | TTS | STT | Embeddings | Moderation | Rerank | Video | Voice | Last live pass |
+|-------------|:----:|:------:|:----------:|:-----:|:------:|:-----:|:---:|:---:|:----------:|:----------:|:------:|:-----:|:-----:|:--------------:|
+| OpenAI      | ✅   | ✅     | ✅         | ✅    | ✅     | ✅    | ✅  | ✅  | ✅         | ✅         | —      | ✅    | ⚠️    | 2026-06-02     |
+| Anthropic   | ✅   | ✅     | ✅         | ✅    | ✅     | —     | —   | —   | —          | —          | —      | —     | —     | 2026-06-02     |
+| Google      | ✅   | ✅     | ✅         | ✅    | ✅     | ✅    | —   | —   | ✅         | —          | —      | —     | —     | 2026-06-02     |
+| xAI         | ✅   | ✅     | ✅         | ✅    | —      | ✅    | ✅  | —   | —          | —          | —      | ✅    | ⚠️    | 2026-06-02     |
+| ElevenLabs  | —    | —      | —          | —     | —      | —     | ❌  | ❌  | —          | —          | —      | —     | ⚠️    | —              |
+| Cohere      | —    | —      | —          | —     | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
+| Jina        | —    | —      | —          | —     | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
+| Ollama¹     | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
+| LM Studio¹  | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
+
+¹ OpenAI-compatible endpoints via the shared `chat_completions` driver.
+
+## Per-provider results (2026-06-02)
+
+| Provider   | Live suite        | Notes |
+|------------|-------------------|-------|
+| OpenAI     | **35/35 passed**  | Vision verified with a live image-input call (`gpt-4o-mini`). Image generation uses `gpt-image-1` (base64/`b64_json`); generation, store/storeAs, `contents()`, and auto-persist all verified. Also passed: provider tools (web search), media storage. Realtime **Voice** not exercised live. |
+| Anthropic  | **17/17 passed**  | Text, streaming, structured, tools, vision (image-from-base64). |
+| Google     | **22/22 passed**  | Vision verified with a live image-input call (`gemini-2.5-flash`). Includes Google Search grounding (provider tool), embeddings, image generation. |
+| xAI        | **20/20 passed**  | Includes web search + X search (provider tools), image, TTS, video. Realtime Voice not exercised live. |
+| ElevenLabs | **not verified**  | Blocked: sandbox `config/atlas.php` has no `elevenlabs` provider block, so the base URL is empty. Package URL resolution is correct — purely a sandbox config gap. TTS / STT / SFX / Music unverified live. |
+| Cohere     | **not verified**  | No `COHERE_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
+| Jina       | **not verified**  | No `JINA_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
+| Ollama     | **not run**       | Points at a LAN host (`OLLAMA_URL`); not exercised in this run. |
+| LM Studio  | **not run**       | Requires a local LM Studio instance; not exercised in this run. |
+
+## Package checks (2026-06-02)
+
+`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 2768 Pest tests ✓**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.1.4](https://github.com/atlas-php/atlas/releases/tag/v3.1.4) - 2026-06-02
+
+### Fixed
+
+- OpenAI image responses that return base64 data can now be saved, stored, and auto-persisted. The base64 payload was previously mistaken for a URL, so storing the image failed; it is now decoded correctly. URL-based responses are unaffected.
+
+### Migration
+
+No breaking changes — drop-in upgrade. No consumer action required.
+
+---
+
 ## [v3.1.3](https://github.com/atlas-php/atlas/releases/tag/v3.1.3) - 2026-05-24
 
 ### Fixed

--- a/sandbox/test-google-provider.php
+++ b/sandbox/test-google-provider.php
@@ -27,6 +27,7 @@ use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Input\Image;
 use Atlasphp\Atlas\Messages\AssistantMessage;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Messages\ToolResultMessage;
@@ -361,6 +362,29 @@ test('Google Search grounding returns response', function () {
 
     assert_true($r->text !== '', 'Should return a response with Google Search grounding');
     assert_true($r->finishReason === FinishReason::Stop, 'Should finish with Stop');
+});
+
+// ── Vision ───────────────────────────────────────────────────────────────────
+
+echo "\n\n── Vision";
+
+test('image understanding from base64', function () {
+    // Create a minimal red PNG
+    $img = imagecreatetruecolor(10, 10);
+    $red = imagecolorallocate($img, 255, 0, 0);
+    imagefill($img, 0, 0, $red);
+    ob_start();
+    imagepng($img);
+    $pngData = ob_get_clean();
+    imagedestroy($img);
+
+    $r = Atlas::text(Provider::Google, 'gemini-2.5-flash')
+        ->instructions('Describe what you see in the image. Be brief.')
+        ->message('What color is this image?', [Image::fromBase64(base64_encode($pngData), 'image/png')])
+        ->asText();
+
+    assert_true($r->text !== '', 'Should describe the image');
+    assert_true(str_contains(strtolower($r->text), 'red'), "Should identify red color, got: {$r->text}");
 });
 
 // ── Embeddings ───────────────────────────────────────────────────────────────

--- a/sandbox/test-openai-provider.php
+++ b/sandbox/test-openai-provider.php
@@ -25,6 +25,7 @@ $app['config']->set('atlas.providers', [
 ]);
 
 use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Enums\Provider;
@@ -379,22 +380,22 @@ test('web search provider tool', function () {
 
 echo "\n\n── Image Generation";
 
-test('DALL-E image generation', function () {
-    $r = Atlas::image(Provider::OpenAI, 'dall-e-3')
+test('gpt-image-1 image generation', function () {
+    $r = Atlas::image(Provider::OpenAI, 'gpt-image-1')
         ->instructions('A simple blue square on a white background')
         ->withSize('1024x1024')
+        ->withQuality('low')
         ->asImage();
 
-    assert_true($r->url !== '', 'Should have an image URL');
-    assert_true(str_starts_with($r->url, 'https://'), 'URL should be HTTPS');
-    assert_true($r->revisedPrompt !== null, 'DALL-E 3 should return revised prompt');
-    assert_true(strlen($r->revisedPrompt) > 10, 'Revised prompt should be substantial');
+    // gpt-image-1 returns base64 (b64_json), not a hosted URL.
+    assert_true($r->base64 !== null, 'Should have base64 image data');
+    assert_true($r->format === 'png', "Format should be png, got: {$r->format}");
+    assert_true(str_starts_with($r->url, 'data:image/png;base64,'), 'URL should be a data URI');
 
-    // Download and save the image
-    $imgData = file_get_contents($r->url);
-    if ($imgData !== false) {
-        saveFile('image-dalle3', $imgData, 'png');
-    }
+    // contents() must decode the base64 (not try to fetch it as a URL).
+    $imgData = $r->contents();
+    assert_true(strlen($imgData) > 1000, 'Decoded image should be substantial ('.strlen($imgData).' bytes)');
+    saveFile('image-gpt-image-1', $imgData, 'png');
 });
 
 // ── Audio TTS ────────────────────────────────────────────────────────────────
@@ -551,7 +552,7 @@ test('models list returns known models', function () {
     assert_true(count($models->models) > 10, 'Should have many models, got: '.count($models->models));
     assert_true(in_array('gpt-4o', $models->models, true), 'Should include gpt-4o');
     assert_true(in_array('gpt-4o-mini', $models->models, true), 'Should include gpt-4o-mini');
-    assert_true(in_array('dall-e-3', $models->models, true), 'Should include dall-e-3');
+    assert_true(in_array('gpt-image-1', $models->models, true), 'Should include gpt-image-1');
 
     // Verify sorted
     $sorted = $models->models;
@@ -649,14 +650,15 @@ echo "\n\n── Media Storage";
 test('store generated image to disk', function () {
     Storage::fake('test');
 
-    $response = Atlas::image(Provider::OpenAI, 'dall-e-3')
+    $response = Atlas::image(Provider::OpenAI, 'gpt-image-1')
         ->instructions('A small red dot')
         ->withSize('1024x1024')
+        ->withQuality('low')
         ->asImage();
 
-    assert_true($response->url !== '', 'Should have image URL');
+    assert_true($response->base64 !== null, 'Should have base64 image data');
 
-    // Store the image via the URL
+    // Store the image (decodes base64 for gpt-image-1)
     $path = $response->storeAs('generated/image.png', 'test');
 
     assert_true($path === 'generated/image.png', "Path should match, got: {$path}");
@@ -738,10 +740,13 @@ test('audio response toBase64 and contents', function () {
 test('image response auto-generates storage path', function () {
     Storage::fake('test');
     config()->set('atlas.storage.prefix', 'atlas-test');
+    // AtlasConfig is a boot-time singleton snapshot — forget it so the prefix above is read.
+    app()->forgetInstance(AtlasConfig::class);
 
-    $response = Atlas::image(Provider::OpenAI, 'dall-e-3')
+    $response = Atlas::image(Provider::OpenAI, 'gpt-image-1')
         ->instructions('A tiny green square')
         ->withSize('1024x1024')
+        ->withQuality('low')
         ->asImage();
 
     $path = $response->store('test');

--- a/sandbox/test-openai-provider.php
+++ b/sandbox/test-openai-provider.php
@@ -378,6 +378,27 @@ test('web search provider tool', function () {
 
 // ── Image Generation ─────────────────────────────────────────────────────────
 
+echo "\n\n── Vision";
+
+test('image understanding from base64', function () {
+    // Create a minimal red PNG
+    $img = imagecreatetruecolor(10, 10);
+    $red = imagecolorallocate($img, 255, 0, 0);
+    imagefill($img, 0, 0, $red);
+    ob_start();
+    imagepng($img);
+    $pngData = ob_get_clean();
+    imagedestroy($img);
+
+    $r = Atlas::text(Provider::OpenAI, 'gpt-4o-mini')
+        ->instructions('Describe what you see in the image. Be brief.')
+        ->message('What color is this image?', [Image::fromBase64(base64_encode($pngData), 'image/png')])
+        ->asText();
+
+    assert_true($r->text !== '', 'Should describe the image');
+    assert_true(str_contains(strtolower($r->text), 'red'), "Should identify red color, got: {$r->text}");
+});
+
 echo "\n\n── Image Generation";
 
 test('gpt-image-1 image generation', function () {

--- a/src/Providers/OpenAi/Handlers/Image.php
+++ b/src/Providers/OpenAi/Handlers/Image.php
@@ -15,7 +15,10 @@ use Atlasphp\Atlas\Responses\ImageResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 
 /**
- * OpenAI image handler using the DALL-E image generation endpoint.
+ * OpenAI image handler for the images/generations endpoint.
+ *
+ * Handles both response shapes: hosted URLs (legacy DALL-E) and base64
+ * payloads (b64_json, the only mode for gpt-image-* models).
  */
 class Image implements ImageHandler
 {
@@ -50,18 +53,27 @@ class Image implements ImageHandler
         /** @var array<int, array<string, mixed>> $results */
         $results = $data['data'] ?? [];
 
+        $format = $this->resolveFormat($request);
+
         if ($request->count === 1) {
             $first = $results[0] ?? [];
+            $base64 = $this->base64For($first);
 
             return new ImageResponse(
-                url: (string) ($first['url'] ?? $first['b64_json'] ?? ''),
+                url: $this->referenceFor($first, $base64, $format),
                 revisedPrompt: isset($first['revised_prompt']) ? (string) $first['revised_prompt'] : null,
                 meta: ['model' => $request->model],
+                base64: $base64,
+                format: $base64 !== null ? $format : null,
             );
         }
 
+        // Only the first result is surfaced on the base64 property; callers
+        // needing every payload should decode from the urls array (data URIs).
+        $firstBase64 = $this->base64For($results[0] ?? []);
+
         $urls = array_map(
-            fn (array $item): string => (string) ($item['url'] ?? $item['b64_json'] ?? ''),
+            fn (array $item): string => $this->referenceFor($item, $this->base64For($item), $format),
             $results,
         );
 
@@ -73,7 +85,59 @@ class Image implements ImageHandler
             url: $urls,
             revisedPrompt: $revisedPrompt,
             meta: ['model' => $request->model, 'count' => count($results)],
+            base64: $firstBase64,
+            format: $firstBase64 !== null ? $format : null,
         );
+    }
+
+    /**
+     * Extract the base64 payload for a result item, but only when no hosted URL
+     * is present — a real URL always wins so storage resolves it over inline data.
+     *
+     * @param  array<string, mixed>  $item
+     */
+    private function base64For(array $item): ?string
+    {
+        if (isset($item['url'])) {
+            return null;
+        }
+
+        return isset($item['b64_json']) ? (string) $item['b64_json'] : null;
+    }
+
+    /**
+     * Build the URL reference for a result item. Prefers a hosted URL; when the
+     * provider returns base64 (b64_json) — the only mode for gpt-image-* models —
+     * falls back to a data URI so the value remains a usable, renderable reference.
+     *
+     * @param  array<string, mixed>  $item
+     */
+    private function referenceFor(array $item, ?string $base64, string $format): string
+    {
+        if (isset($item['url'])) {
+            return (string) $item['url'];
+        }
+
+        if ($base64 !== null) {
+            return "data:image/{$format};base64,{$base64}";
+        }
+
+        return '';
+    }
+
+    /**
+     * Resolve the output image format from the request or provider options,
+     * defaulting to png (the OpenAI image default).
+     */
+    private function resolveFormat(ImageRequest $request): string
+    {
+        if ($request->format !== null) {
+            return $request->format;
+        }
+
+        $option = $request->providerOptions['output_format'] ?? null;
+
+        return is_string($option) ? $option : 'png';
     }
 
     public function imageToText(ImageRequest $request): TextResponse

--- a/tests/Unit/Providers/OpenAi/Handlers/ImageHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/ImageHandlerTest.php
@@ -101,3 +101,171 @@ it('throws UnsupportedFeatureException for imageToText', function () {
 
     $handler->imageToText($request);
 })->throws(UnsupportedFeatureException::class);
+
+it('populates base64 and a data URI when the response is b64_json (gpt-image-1)', function () {
+    $raw = 'fake-png-bytes';
+    $b64 = base64_encode($raw);
+
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                ['b64_json' => $b64],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'A blue square',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->base64)->toBe($b64);
+    expect($response->format)->toBe('png');
+    expect($response->url)->toBe("data:image/png;base64,{$b64}");
+    // Storage path: contents() must decode the base64, not try to fetch it as a URL.
+    expect($response->contents())->toBe($raw);
+    expect($response->revisedPrompt)->toBeNull();
+});
+
+it('honours output_format provider option for b64_json responses', function () {
+    $b64 = base64_encode('jpeg-bytes');
+
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                ['b64_json' => $b64],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'A blue square',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+        providerOptions: ['output_format' => 'jpeg'],
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->format)->toBe('jpeg');
+    expect($response->url)->toBe("data:image/jpeg;base64,{$b64}");
+});
+
+it('uses request format over the png default for b64_json responses', function () {
+    $b64 = base64_encode('webp-bytes');
+
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                ['b64_json' => $b64],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'A blue square',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: 'webp',
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->format)->toBe('webp');
+    expect($response->url)->toBe("data:image/webp;base64,{$b64}");
+});
+
+it('prefers a hosted URL and leaves base64 null when both url and b64_json are present', function () {
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                ['url' => 'https://images.openai.com/generated.png', 'b64_json' => base64_encode('ignored')],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'A blue square',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->url)->toBe('https://images.openai.com/generated.png');
+    expect($response->base64)->toBeNull();
+    expect($response->format)->toBeNull();
+});
+
+it('returns data URIs and first base64 when count > 1 with b64_json', function () {
+    $a = base64_encode('img-a');
+    $b = base64_encode('img-b');
+
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                ['b64_json' => $a],
+                ['b64_json' => $b],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'Two squares',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+        count: 2,
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->url)->toBe([
+        "data:image/png;base64,{$a}",
+        "data:image/png;base64,{$b}",
+    ]);
+    expect($response->base64)->toBe($a);
+    expect($response->format)->toBe('png');
+    expect($response->meta['count'])->toBe(2);
+});
+
+it('leaves base64 and format null for hosted URL responses', function () {
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                ['url' => 'https://images.openai.com/generated.png', 'revised_prompt' => 'A cat'],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'dall-e-3',
+        instructions: 'A cat',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->url)->toBe('https://images.openai.com/generated.png');
+    expect($response->base64)->toBeNull();
+    expect($response->format)->toBeNull();
+});

--- a/tests/Unit/Providers/OpenAi/Handlers/ImageHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/ImageHandlerTest.php
@@ -211,6 +211,56 @@ it('prefers a hosted URL and leaves base64 null when both url and b64_json are p
     expect($response->format)->toBeNull();
 });
 
+it('returns an empty reference when the response has no url or b64_json', function () {
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'A blue square',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->url)->toBe('');
+    expect($response->base64)->toBeNull();
+    expect($response->format)->toBeNull();
+});
+
+it('returns empty strings for items missing url and b64_json when count > 1', function () {
+    Http::fake([
+        'api.openai.com/v1/images/generations' => Http::response([
+            'data' => [
+                [],
+                ['unexpected' => 'shape'],
+            ],
+        ]),
+    ]);
+
+    $request = new ImageRequest(
+        model: 'gpt-image-1',
+        instructions: 'Two squares',
+        media: [],
+        size: '1024x1024',
+        quality: null,
+        format: null,
+        count: 2,
+    );
+
+    $response = makeImageHandler()->image($request);
+
+    expect($response->url)->toBe(['', '']);
+    expect($response->base64)->toBeNull();
+    expect($response->format)->toBeNull();
+});
+
 it('returns data URIs and first base64 when count > 1 with b64_json', function () {
     $a = base64_encode('img-a');
     $b = base64_encode('img-b');


### PR DESCRIPTION
Handle OpenAI images/generations responses that return inline base64 (b64_json) payloads (e.g. gpt-image-1). Image handler now: detects and exposes base64 and format on ImageResponse, prefers hosted URLs when present, builds data URI references for inline images, and resolves output format from the request or provider options (defaulting to png). Added helper methods (base64For, referenceFor, resolveFormat) and updated contents/storage behavior to decode b64_json instead of treating it as a URL. Updated sandbox examples and unit tests to use gpt-image-1 and verify base64/data-URI handling, and added a changelog entry for v3.1.4.