### PR TITLE
Add sub-agent delegation and tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.2.0](https://github.com/atlas-php/atlas/releases/tag/v3.2.0) - 2026-06-02
+
+### Added
+
+- Sub-agents: one agent can now hand off work to another. List an agent in another agent's `tools()` and it can delegate a task to that specialist, which runs on its own and returns its answer — the same way any tool call works (including in the UI).
+- With persistence enabled, each delegation is tracked: you can see which agent called which, and the token cost of every agent individually as well as the whole chain.
+
+### Migration
+
+Run `php artisan migrate` to add the new tracking columns. No other changes needed — drop-in upgrade.
+
+---
+
 ## [v3.1.4](https://github.com/atlas-php/atlas/releases/tag/v3.1.4) - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Atlas is a unified AI SDK for Laravel applications. It owns its own provider lay
 
 - **Agents** — Reusable classes encapsulating provider, model, instructions, tools, and behavior
 - **Tools** — Typed tool classes with parameter schemas and dependency injection
+- **Sub-agents** — Delegate tasks to other agents as tools, with isolated context, depth/cycle guards, and an auditable parent → child execution tree. Fan out to multiple sub-agents **concurrently** (true parallel execution via forking) so independent work runs at the same time
 - **10 Modalities** — Text, images, audio (speech, music, sound effects), video, voice, embeddings, reranking
 - **Similarity Search** — Unified `Atlas::similaritySearch()` over whole-record or chunked embeddings; also available as an agent tool
 - **Chunked Embeddings** — Index long-form, frequently-edited content with diff-based reconciliation — edits re-embed only what changed
@@ -185,6 +186,7 @@ See the [Voice Integration Guide](https://atlasphp.org/guides/voice-integration.
 - [Getting Started](https://atlasphp.org/getting-started/installation.html) — Installation and configuration
 - [Agents](https://atlasphp.org/features/agents.html) — Define reusable AI configurations
 - [Tools](https://atlasphp.org/features/tools.html) — Connect agents to your application
+- [Sub-agents](https://atlasphp.org/features/sub-agents.html) — Agent-to-agent delegation, including concurrent (parallel) fan-out
 - [Middleware](https://atlasphp.org/features/middleware.html) — Extend with four middleware layers
 - [Similarity Search](https://atlasphp.org/features/similarity-search.html) — Semantic search over whole-record or chunked embeddings
 - [Modalities](https://atlasphp.org/modalities/text.html) — Text, images, audio, video, voice, embeddings, and more

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -40,11 +40,19 @@ return [
     | Auto-discovery path and namespace for agent classes. Agents found in
     | the configured directory are automatically registered at boot time.
     |
+    | Sub-agents: an agent listed in another agent's tools() is exposed as a
+    | delegation tool. max_delegation_depth bounds how deeply agents may nest
+    | (cycles are always rejected). delegation_errors controls what happens
+    | when a sub-agent throws: 'throw' surfaces it as a failed tool call,
+    | 'return' hands the error message back to the parent model as the result.
+    |
     */
 
     'agents' => [
         'path' => null,
         'namespace' => null,
+        'max_delegation_depth' => env('ATLAS_MAX_DELEGATION_DEPTH', 5),
+        'delegation_errors' => env('ATLAS_DELEGATION_ERRORS', 'throw'),
     ],
 
     /*

--- a/database/migrations/0015_add_delegation_lineage_to_atlas_executions_table.php
+++ b/database/migrations/0015_add_delegation_lineage_to_atlas_executions_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function tableName(string $name): string
+    {
+        return config('atlas.persistence.table_prefix', 'atlas_').$name;
+    }
+
+    public function up(): void
+    {
+        Schema::table($this->tableName('executions'), function (Blueprint $table) {
+            // Self-referential parent for sub-agent delegation trees.
+            $table->foreignId('parent_execution_id')
+                ->nullable()
+                ->after('conversation_id')
+                ->constrained($this->tableName('executions'))
+                ->nullOnDelete();
+
+            // The delegating tool call that spawned this execution.
+            $table->foreignId('parent_tool_call_id')
+                ->nullable()
+                ->after('parent_execution_id')
+                ->constrained($this->tableName('execution_tool_calls'))
+                ->nullOnDelete();
+
+            // Delegation depth (0 = root agent run).
+            $table->unsignedTinyInteger('depth')->default(0)->after('parent_tool_call_id');
+
+            $table->index('parent_execution_id');
+            $table->index('parent_tool_call_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->tableName('executions'), function (Blueprint $table) {
+            $table->dropConstrainedForeignId('parent_execution_id');
+            $table->dropConstrainedForeignId('parent_tool_call_id');
+            $table->dropColumn('depth');
+        });
+    }
+};

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -42,6 +42,7 @@ gtag('config', 'G-JEV06LWG7N');`],
                 items: [
                     { text: 'Agents', link: '/features/agents' },
                     { text: 'Tools', link: '/features/tools' },
+                    { text: 'Sub-agents', link: '/features/sub-agents' },
                     { text: 'Instructions', link: '/features/instructions' },
                     { text: 'Schema', link: '/features/schema' },
                     { text: 'Middleware', link: '/features/middleware' },
@@ -103,7 +104,7 @@ gtag('config', 'G-JEV06LWG7N');`],
 
         footer: {
             message: 'Released under the MIT License.',
-            copyright: 'Copyright 2025-2026 Atlas PHP · Created by <a href="https://marois.dev" target="_blank">Timothy Marois</a>'
+            copyright: 'Copyright 2025-2026 Atlas PHP · Created by <a href="https://marois.dev" target="_blank">Tim Marois</a>'
         }
     },
 

--- a/docs/advanced/persistence.md
+++ b/docs/advanced/persistence.md
@@ -99,6 +99,9 @@ All tables are prefixed with `atlas_` by default (configurable via `persistence.
 |--------|------|-----|
 | `id` | `bigint` | Primary key |
 | `conversation_id` | `bigint nullable` | FK → conversations. Set when the execution is part of a conversation. Null for standalone direct calls |
+| `parent_execution_id` | `bigint nullable` | FK → executions (self). Set when this is a sub-agent run, pointing to the execution that delegated to it. Null for a root run |
+| `parent_tool_call_id` | `bigint nullable` | FK → execution_tool_calls. The delegating tool call (typed `agent`) that spawned this sub-agent run |
+| `depth` | `unsignedTinyInteger` | Delegation depth: `0` for a root agent run, incremented per nested sub-agent level |
 | `status` | `unsignedTinyInteger` | Lifecycle state as int-backed `ExecutionStatus` enum: `0` (Pending) → `1` (Queued) → `2` (Processing) → `3` (Completed) or `4` (Failed) |
 | `agent` | `string(255) nullable` | Agent key. Null for direct modality calls |
 | `type` | `string(30)` | What type of execution, backed by `ExecutionType` enum: `text`, `structured`, `stream`, `image`, `image_to_text`, `audio`, `audio_to_text`, `video`, `video_to_text`, `music`, `sfx`, `speech`, `embed`, `moderate`, `rerank`, `voice` |
@@ -150,7 +153,7 @@ All tables are prefixed with `atlas_` by default (configurable via `persistence.
 | `tool_call_id` | `string(100)` | The provider's unique ID for this tool call (used to match results back to requests) |
 | `status` | `unsignedTinyInteger` | Int-backed `ExecutionStatus` enum: `0` (Pending) → `2` (Processing) → `3` (Completed) or `4` (Failed) |
 | `name` | `string(100)` | Tool name (e.g. `lookup_order`, `web_search`) |
-| `type` | `string(20)` | `local` for user-defined tools, `mcp` for MCP tools, `provider` for native provider tools (backed by `ToolCallType` enum) |
+| `type` | `string(20)` | `local` for user-defined tools, `mcp` for MCP tools, `provider` for native provider tools, `agent` for sub-agent delegation (backed by `ToolCallType` enum) |
 | `arguments` | `json nullable` | The arguments the model passed to the tool. Stored as JSON for inspection |
 | `result` | `text nullable` | The serialized return value from the tool. What was sent back to the model |
 | `started_at` | `timestamp nullable` | When tool execution started |
@@ -234,6 +237,9 @@ ConversationMessage
 
 Execution
 ├── belongs to Conversation (optional)
+├── belongs to Execution parent (via parent_execution_id, for sub-agent runs)
+├── belongs to ExecutionToolCall parentToolCall (the delegating call)
+├── has many Execution children (sub-agent runs it spawned)
 ├── has one ConversationMessage (via conversation_messages.execution_id)
 ├── has one VoiceCall (via conversation_voice_calls.execution_id)
 ├── has many ExecutionSteps

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -270,6 +270,10 @@ class ResearchAgent extends Agent
 }
 ```
 
+::: tip Delegating to another agent
+You can also list an **agent** in `tools()` to hand a task off to it. See [Sub-agents](/features/sub-agents).
+:::
+
 Use `maxSteps()` to limit tool loop iterations and prevent runaway execution.
 
 ## Concurrent Tool Execution

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -309,28 +309,59 @@ $response = Atlas::agent('research')
 
 When the model requests multiple tool calls in a single step, Atlas runs them simultaneously using Laravel's `Concurrency` facade:
 
-- **With `spatie/fork` + `pcntl`** — true parallel execution via OS-level forking
+- **With `spatie/fork` + `pcntl`** — true parallel execution via OS-level process forking
 - **Without** — falls back to sequential execution through the sync driver
 
-### Requirements
+A step that contains only **one** tool call always runs inline — there is nothing to parallelize.
 
-Atlas ships with `spatie/fork` as a dependency — no extra installation needed. However, true parallelism requires the `pcntl` PHP extension, which is standard on most Linux/macOS setups but **not available on Windows**. Without `pcntl`, concurrent mode falls back to sequential execution.
+### Concurrent Sub-agents
+
+Sub-agent delegations parallelize too. When the model delegates to several [sub-agents](/features/sub-agents) in a single step, they run **at the same time** — each in its own forked process — and every sub-agent's response is returned to the parent. The parent's tool loop resumes only once **all** of them complete, so it always continues with the full set of results:
+
+```php
+class CoordinatorAgent extends Agent
+{
+    public function concurrent(): bool
+    {
+        return true;
+    }
+
+    public function tools(): array
+    {
+        // Three independent sub-agents the model can fan out to in one step.
+        return [ResearchAgent::class, PricingAgent::class, LegalAgent::class];
+    }
+}
+```
+
+The complete execution lineage is preserved across the fork boundary: the parent → child tree, each sub-agent's own token usage, the rolled-up subtree usage, and the depth/cycle guards all behave exactly as they do sequentially. Only wall-clock time changes.
+
+::: warning Real-time events from concurrent sub-agents
+The parent still emits its own `AgentToolCallStarted` / `AgentToolCallCompleted` events for each delegation (so the call and its result broadcast normally). But a sub-agent's **internal** orchestration events — its own `AgentStarted` / `AgentCompleted`, step events, and nested tool-call events — fire inside the forked child process and are **not** delivered to in-process listeners in the parent. There is no inter-process channel back.
+
+This affects only **live, in-process** observability of a sub-agent's internals (broadcasting each step, listener-driven side effects). It does **not** affect persistence: the child writes the full execution / step / tool-call tree to the database, so post-run auditing via the [delegation tree](/features/sub-agents#auditing-the-delegation-tree) is complete. If you need real-time per-step events from sub-agents, use **sequential** delegation (the default).
+:::
+
+### Persistence & Fork Safety
+
+Persistence tracking writes to the database from **inside** the forked child processes. Database connections (PostgreSQL, MySQL) are not fork-safe — a child that inherits and uses the parent's connection socket would corrupt the wire protocol.
+
+**Atlas handles this for you.** Before forking, it closes the parent's resolved database connections so each child opens its own fresh connection; the parent transparently reconnects on its next query. This reset runs **only** when the fork driver is active *and* persistence is enabled, so the in-process sync driver and non-persistent runs are never affected. Concurrent execution with persistence tracking is safe out of the box — no configuration required.
+
+### Requirements & Environment
+
+- Atlas ships with `spatie/fork` as a dependency — no extra installation needed. True parallelism requires the **`pcntl`** PHP extension (standard on Linux/macOS, **not available on Windows**). Without `pcntl`, concurrent mode falls back to sequential execution.
+- Fork-based parallelism runs in **CLI, queue-worker, and Artisan** contexts. It does **not** run inside PHP-FPM web requests (forking a live web worker is unsafe), where Atlas falls back to sequential. To parallelize long-running agent work from a web request without blocking it, dispatch the execution to the [queue](/guides/queue) and let workers run concurrently.
 
 ### When to Use
 
 Enable concurrency when:
-- Tools are **independent** and don't depend on each other's results
-- Tools make **external API calls** where parallelism reduces wall-clock time
-- You're **not using persistence** or understand the fork-safety implications
+- Tools or sub-agents are **independent** and don't depend on each other's results
+- They make **external API calls** (including sub-agent model calls) where parallelism reduces wall-clock time
 
 Keep sequential (default) when:
 - Tools have **side effects** that depend on execution order
-- You need **reliable persistence tracking** for every tool call
-- You're running on Windows or an environment without `pcntl`
-
-::: warning Fork Safety
-When using the fork driver with persistence enabled, tool call tracking runs inside forked child processes. Database connections are not fork-safe — the child inherits the parent's TCP socket. For production use with persistence, prefer sequential execution or ensure your database driver handles reconnection after fork.
-:::
+- You're running on Windows or an environment without `pcntl` (it falls back to sequential anyway)
 
 ## Conversations (Optional)
 

--- a/docs/features/agents.md
+++ b/docs/features/agents.md
@@ -339,7 +339,20 @@ The complete execution lineage is preserved across the fork boundary: the parent
 ::: warning Real-time events from concurrent sub-agents
 The parent still emits its own `AgentToolCallStarted` / `AgentToolCallCompleted` events for each delegation (so the call and its result broadcast normally). But a sub-agent's **internal** orchestration events — its own `AgentStarted` / `AgentCompleted`, step events, and nested tool-call events — fire inside the forked child process and are **not** delivered to in-process listeners in the parent. There is no inter-process channel back.
 
-This affects only **live, in-process** observability of a sub-agent's internals (broadcasting each step, listener-driven side effects). It does **not** affect persistence: the child writes the full execution / step / tool-call tree to the database, so post-run auditing via the [delegation tree](/features/sub-agents#auditing-the-delegation-tree) is complete. If you need real-time per-step events from sub-agents, use **sequential** delegation (the default).
+This affects only **live, in-process** observability *while a sub-agent is still running* (broadcasting each step as it happens, listener-driven side effects). It does **not** limit what you can show **after** it completes. The child writes its full execution / step / tool-call tree to the database from inside the fork, so once a concurrent sub-agent finishes you can load and display **everything** it did — its final response, each step's text, and every tool it ran (with arguments, results, and timing) — by drilling into the [delegation tree](/features/sub-agents#auditing-the-delegation-tree):
+
+```php
+use Atlasphp\Atlas\Persistence\Models\Execution;
+
+// Open a completed delegation tool call → the sub-agent that ran it.
+$child = Execution::where('parent_tool_call_id', $toolCallId)->first();
+
+$child->steps;      // each step, with ->content (response text) and ->reasoning
+$child->toolCalls;  // every tool it ran, with ->arguments, ->result, ->duration_ms
+$child->usage;      // its own token usage
+```
+
+So a UI that opens a finished sub-agent call shows its complete response, steps, and tools. Only the **live, as-it-happens** stream of a sub-agent's internals is unavailable under concurrency — for that, use **sequential** delegation (the default).
 :::
 
 ### Persistence & Fork Safety

--- a/docs/features/sub-agents.md
+++ b/docs/features/sub-agents.md
@@ -37,6 +37,31 @@ The parent model sees a single string parameter, `task`, which it fills with a c
 
 Each sub-agent invocation runs in isolation: its own instructions, model, and tools, starting from a fresh history. The parent's conversation history is **not** shared — pass everything the sub-agent needs in the `task`. Context you set with `withMeta()` (auth, tenant) **is** forwarded, so authorization still works.
 
+## Running sub-agents concurrently
+
+By default delegations run one at a time. If the parent agent enables [concurrent execution](/features/agents#concurrent-tool-execution) (via `concurrent()` or `->withConcurrent()`) and the model delegates to **several sub-agents in a single step**, those sub-agents run **at the same time** — each in its own forked process:
+
+```php
+class CoordinatorAgent extends Agent
+{
+    public function concurrent(): bool
+    {
+        return true; // fan out to sub-agents in parallel
+    }
+
+    public function tools(): array
+    {
+        return [ResearchAgent::class, PricingAgent::class, LegalAgent::class];
+    }
+}
+```
+
+The parent's tool loop waits for **all** of them to finish, then continues with the complete set of responses — so the parent always reasons over every sub-agent's result, exactly as it would sequentially. Only wall-clock time changes: three sub-agents that each take ~3s finish in ~3s instead of ~9s.
+
+Everything in this page still holds under concurrency. The full lineage tree, each sub-agent's own and rolled-up token usage, and the depth/cycle guards are all preserved across the fork boundary, and persistence tracking is automatically fork-safe (Atlas resets database connections before forking).
+
+One nuance to know: a concurrently-delegated sub-agent's **internal** real-time events (its own step and tool-call events) fire inside its forked process and are not delivered to in-process listeners in the parent — the delegation still surfaces as a parent tool-call event, and the full tree is still persisted for auditing. Requirements, the CLI/queue-only nature of fork-based parallelism, and this event caveat are covered in [Concurrent Tool Execution](/features/agents#concurrent-tool-execution).
+
 ## Guards
 
 Delegation is bounded to prevent runaway nesting:

--- a/docs/features/sub-agents.md
+++ b/docs/features/sub-agents.md
@@ -1,0 +1,75 @@
+# Sub-agents
+
+A sub-agent is an [agent](/features/agents) used as a [tool](/features/tools) by another agent. When the parent decides to call it, the sub-agent runs on its own — its own instructions, model, and tools — and returns its answer to the parent as the tool result.
+
+Use this to delegate specialised work: a support agent that hands billing questions to a billing agent, a coordinator that delegates research, and so on. Each sub-agent keeps its own focused instructions, so the parent's prompt stays small.
+
+Because a sub-agent is just a tool, it behaves like any other tool everywhere — it fires the same events, streams to your UI in real time, and is recorded in persistence the same way.
+
+> You could always hand-roll this — write a custom [tool](/features/tools) that runs another agent itself. The built-in sub-agent support does that wiring for you and adds context isolation, depth/cycle guards, and parent → child audit tracking automatically.
+
+## Declaring a sub-agent
+
+List an agent class in another agent's `tools()`. Atlas exposes it to the parent model as a delegation tool automatically:
+
+```php
+use Atlasphp\Atlas\Agent;
+
+class SupportAgent extends Agent
+{
+    public function tools(): array
+    {
+        return [
+            BillingAgent::class,   // delegated to as a sub-agent
+            SearchKnowledgeBase::class, // a normal tool
+        ];
+    }
+}
+```
+
+The tool's name and description come from the sub-agent's `key()` and `description()`.
+
+## What the parent passes
+
+The parent model sees a single string parameter, `task`, which it fills with a clear, self-contained instruction. That becomes the sub-agent's message, and the sub-agent's final text is returned as the tool result.
+
+## Context isolation
+
+Each sub-agent invocation runs in isolation: its own instructions, model, and tools, starting from a fresh history. The parent's conversation history is **not** shared — pass everything the sub-agent needs in the `task`. Context you set with `withMeta()` (auth, tenant) **is** forwarded, so authorization still works.
+
+## Guards
+
+Delegation is bounded to prevent runaway nesting:
+
+- **Depth** — `atlas.agents.max_delegation_depth` (default `5`) caps how deep agents may delegate; exceeding it throws `MaxDelegationDepthException`.
+- **Cycles** — delegating to an agent already in the chain (`A → B → A`) throws `DelegationCycleException`.
+
+`atlas.agents.delegation_errors` controls sub-agent failures: `throw` (default) surfaces a failed tool call; `return` hands the error message back to the parent model so it can recover.
+
+```php
+// config/atlas.php
+'agents' => [
+    'max_delegation_depth' => 5,
+    'delegation_errors' => 'throw',
+],
+```
+
+## Auditing the delegation tree
+
+With [persistence](/features/persistence) enabled, every delegation is recorded as an auditable tree. Each sub-agent run is its own `Execution`, linked to its parent by `parent_execution_id`, `parent_tool_call_id` (the delegating call, typed `agent`), and `depth` (`0` for the root, incremented per level):
+
+```php
+use Atlasphp\Atlas\Persistence\Models\Execution;
+
+$run = Execution::find($id);
+$run->parent;    // the execution that delegated to this one (null for a root)
+$run->children;  // sub-agent executions it spawned
+
+// Each agent's own token cost is stored on its own row.
+$run->usage; // ['input_tokens' => …, 'output_tokens' => …]
+
+// Total tokens for the whole chain (this run plus every sub-agent it called).
+$run->totalUsage(); // ['input_tokens' => …, 'output_tokens' => …, 'total_tokens' => …]
+```
+
+So you can report what each individual agent cost, as well as the cost of an entire delegation chain.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -48,14 +48,17 @@ return [
     | Agents
     |--------------------------------------------------------------------------
     |
-    | Auto-discovery path and namespace for agent classes. Agents found in
-    | the configured directory are automatically registered at boot time.
+    | Auto-discovery path and namespace for agent classes, plus sub-agent
+    | delegation limits. Agents found in the configured directory are
+    | automatically registered at boot time.
     |
     */
 
     'agents' => [
         'path' => null,
         'namespace' => null,
+        'max_delegation_depth' => env('ATLAS_MAX_DELEGATION_DEPTH', 5),
+        'delegation_errors' => env('ATLAS_DELEGATION_ERRORS', 'throw'),
     ],
 
     /*
@@ -611,6 +614,13 @@ Both values are `null` by default (auto-discovery disabled). Set them to enable 
 ```bash
 php artisan make:agent SupportAgent
 ```
+
+### Sub-agent Delegation
+
+When one agent delegates to another (see [Sub-agents](/features/sub-agents)):
+
+- `max_delegation_depth` (default `5`) — how deeply agents may nest before `MaxDelegationDepthException` is thrown. Cycles are always rejected.
+- `delegation_errors` (default `'throw'`) — what happens when a sub-agent fails: `'throw'` records a failed tool call; `'return'` hands the error message back to the parent model so it can recover.
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ features:
   - icon:
       src: /icons/agent.svg
       alt: Agents
-    title: Agents
-    details: Reusable agent classes that encapsulate provider, model, instructions, tools, and behavior. Define once, use anywhere.
+    title: Agents & Sub-agents
+    details: Reusable agent classes that encapsulate provider, model, instructions, tools, and behavior. Agents can delegate to specialist sub-agents. Define once, use anywhere.
     link: /features/agents
   - icon:
       src: /icons/tool.svg

--- a/sandbox/test-subagents-concurrent.php
+++ b/sandbox/test-subagents-concurrent.php
@@ -1,0 +1,628 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Concurrent Sub-Agents (Parallel Fan-Out) Integration Test — LIVE API
+ *
+ * Proves — or disproves — that a parent agent can fan out to multiple sub-agents
+ * that run AT THE SAME TIME, and that the parent gets ALL of their responses back
+ * correctly to continue its own tool loop and synthesize a final answer.
+ *
+ * Scenario: a `dispatcher` parent delegates to three independent data-source
+ * sub-agents (fetch_alpha / fetch_beta / fetch_gamma) in a SINGLE step. Each
+ * sub-agent runs a deliberately slow tool (sleeps ~2.5s — a stand-in for a real
+ * long-running process / provider call) so wall-clock cleanly separates parallel
+ * from sequential execution.
+ *
+ * The same orchestration runs TWICE — once with concurrent execution OFF, once
+ * with it ON — and the harness compares:
+ *   • peak simultaneous sub-agents + distinct PIDs, from a per-tool execution
+ *     log (microtime|pid|token|START/END) — forking yields different PIDs and
+ *     overlapping sleep windows prove genuine parallelism (intra-run, so it is
+ *     robust to the model fanning out in a different number of rounds per run)
+ *   • correctness: the parent's final answer must carry ALL THREE payload codes
+ *     (proof the parent received every sub-agent response and looped on them)
+ *   • persistence lineage: depth-1 child executions with correct parent FKs,
+ *     across however many parallel rounds the model issued
+ *
+ * EXPECTED RESULT: concurrent delegation IS implemented (AgentExecutor runs
+ * delegation batches through the fork driver and resets DB connections before
+ * forking), so the concurrency verdict reads ✓ DETECTED — the concurrent run
+ * overlaps multiple sub-agents on distinct forked processes while the sequential
+ * run peaks at one. Correctness + lineage pass in both modes.
+ *
+ * Usage: php test-subagents-concurrent.php
+ *
+ * Requires OPENAI_API_KEY in sandbox/.env and a migrated database.
+ * The fork driver needs the pcntl extension (CLI only).
+ */
+use Atlasphp\Atlas\Agent;
+use Atlasphp\Atlas\AgentRegistry;
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Events\AgentStarted;
+use Atlasphp\Atlas\Events\AgentToolCallCompleted;
+use Atlasphp\Atlas\Events\AgentToolCallStarted;
+use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
+use Atlasphp\Atlas\Persistence\Middleware\PersistConversation;
+use Atlasphp\Atlas\Persistence\Middleware\TrackExecution;
+use Atlasphp\Atlas\Persistence\Middleware\TrackProviderCall;
+use Atlasphp\Atlas\Persistence\Middleware\TrackStep;
+use Atlasphp\Atlas\Persistence\Middleware\TrackToolCall;
+use Atlasphp\Atlas\Persistence\Models\Execution;
+use Atlasphp\Atlas\Schema\Fields\StringField;
+use Atlasphp\Atlas\Tools\AgentTool;
+use Atlasphp\Atlas\Tools\Tool;
+use Illuminate\Support\Facades\Event;
+use Spatie\Fork\Fork;
+
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+]);
+
+$app['config']->set('atlas.persistence.enabled', true);
+$app['config']->set('atlas.middleware', [
+    PersistConversation::class,
+    TrackExecution::class,
+    TrackStep::class,
+    TrackToolCall::class,
+    TrackProviderCall::class,
+]);
+AtlasConfig::refresh();
+
+// Shared log file each slow tool appends START/END markers to, so we can
+// reconstruct execution intervals (and PIDs) across the fork boundary.
+const SLOW_TOOL_SLEEP = 2.5;
+$logFile = sys_get_temp_dir().'/atlas-concurrent-subagents.log';
+
+// ─── Slow tool: simulates a longer-running process ───────────────────────────
+
+class SlowFetchTool extends Tool
+{
+    public function __construct(
+        protected readonly string $token,
+        protected readonly float $seconds,
+        protected readonly string $logFile,
+    ) {}
+
+    public function name(): string
+    {
+        return 'slow_fetch';
+    }
+
+    public function description(): string
+    {
+        return 'Fetches the data payload from this source. Takes a few seconds.';
+    }
+
+    public function parameters(): array
+    {
+        return [new StringField('source', 'The source name to fetch from.')];
+    }
+
+    public function handle(array $args, array $context): string
+    {
+        $this->mark('START');
+        usleep((int) ($this->seconds * 1_000_000));
+        $this->mark('END');
+
+        return "Data payload: {$this->token}";
+    }
+
+    private function mark(string $phase): void
+    {
+        // O_APPEND keeps small writes atomic across concurrent (forked) processes.
+        file_put_contents(
+            $this->logFile,
+            sprintf("%.6f|%d|%s|%s\n", microtime(true), getmypid(), $this->token, $phase),
+            FILE_APPEND | LOCK_EX,
+        );
+    }
+}
+
+// ─── Worker sub-agents (one per data source) ─────────────────────────────────
+
+abstract class WorkerAgent extends Agent
+{
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+
+    public function maxSteps(): ?int
+    {
+        return 4;
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You fetch data from your assigned source. ALWAYS call the slow_fetch tool '
+            .'exactly once, then reply with EXACTLY the payload string it returns — nothing else.';
+    }
+
+    abstract protected function token(): string;
+
+    public function tools(): array
+    {
+        global $logFile;
+
+        return [new SlowFetchTool($this->token(), SLOW_TOOL_SLEEP, $logFile)];
+    }
+}
+
+class FetchAlphaAgent extends WorkerAgent
+{
+    public function key(): string
+    {
+        return 'fetch_alpha';
+    }
+
+    public function description(): ?string
+    {
+        return 'Fetches the data payload from source Alpha.';
+    }
+
+    protected function token(): string
+    {
+        return 'ALPHA-111';
+    }
+}
+
+class FetchBetaAgent extends WorkerAgent
+{
+    public function key(): string
+    {
+        return 'fetch_beta';
+    }
+
+    public function description(): ?string
+    {
+        return 'Fetches the data payload from source Beta.';
+    }
+
+    protected function token(): string
+    {
+        return 'BETA-222';
+    }
+}
+
+class FetchGammaAgent extends WorkerAgent
+{
+    public function key(): string
+    {
+        return 'fetch_gamma';
+    }
+
+    public function description(): ?string
+    {
+        return 'Fetches the data payload from source Gamma.';
+    }
+
+    protected function token(): string
+    {
+        return 'GAMMA-333';
+    }
+}
+
+// ─── Parent dispatcher: fans out to all three in one step ────────────────────
+
+class DispatcherAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'dispatcher';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You are a data dispatcher with three data-source sub-agents: fetch_alpha, '
+            .'fetch_beta, and fetch_gamma. Call ALL THREE sub-agent tools EXACTLY ONCE, '
+            .'TOGETHER IN A SINGLE STEP (in parallel) — never one at a time, and never call '
+            .'any sub-agent more than once. As soon as all three return, immediately reply '
+            .'with ONE line listing the three payload codes, comma-separated, e.g. '
+            .'"Codes: X, Y, Z". Do not fetch again to double-check.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+
+    public function maxSteps(): ?int
+    {
+        return 4;
+    }
+
+    // Default this agent to concurrent execution; the harness still overrides
+    // per-run via ->withConcurrent() to A/B the two paths.
+    public function concurrent(): bool
+    {
+        return true;
+    }
+
+    public function tools(): array
+    {
+        return [
+            AgentTool::for(new FetchAlphaAgent, 'fetch_alpha', 'Fetch the data payload from source Alpha.'),
+            AgentTool::for(new FetchBetaAgent, 'fetch_beta', 'Fetch the data payload from source Beta.'),
+            AgentTool::for(new FetchGammaAgent, 'fetch_gamma', 'Fetch the data payload from source Gamma.'),
+        ];
+    }
+}
+
+app(AgentRegistry::class)->register(FetchAlphaAgent::class);
+app(AgentRegistry::class)->register(FetchBetaAgent::class);
+app(AgentRegistry::class)->register(FetchGammaAgent::class);
+app(AgentRegistry::class)->register(DispatcherAgent::class);
+
+// ─── Real-time event capture (what a live UI would broadcast) ─────────────────
+//
+// Record, per run, the wall-clock ARRIVAL in THIS (parent) process of the events
+// a UI broadcasts on. This shows exactly which live updates the UI receives
+// during a concurrent batch — and which it does not. $GLOBALS['__mode'] tags each
+// captured event with the run it belongs to.
+
+$evt = ['sequential' => [], 'concurrent' => []];
+$workerStarted = ['sequential' => 0, 'concurrent' => 0];
+$GLOBALS['__mode'] = null;
+
+$record = function (string $kind, string $name) use (&$evt): void {
+    $mode = $GLOBALS['__mode'] ?? null;
+    if ($mode !== null && in_array($name, ['fetch_alpha', 'fetch_beta', 'fetch_gamma'], true)) {
+        $evt[$mode][] = ['kind' => $kind, 't' => microtime(true), 'name' => $name];
+    }
+};
+
+Event::listen(AgentToolCallStarted::class, fn ($e) => $record('started', $e->toolCall->name));
+Event::listen(AgentToolCallCompleted::class, fn ($e) => $record('completed', $e->toolCall->name));
+
+// A sub-agent's OWN AgentStarted fires in-process under sequential delegation,
+// but inside the forked child under concurrency — so it should be seen here for
+// sequential and NOT for concurrent. This pins the fork event boundary.
+Event::listen(AgentStarted::class, function ($e) use (&$workerStarted): void {
+    $mode = $GLOBALS['__mode'] ?? null;
+    if ($mode !== null && in_array($e->agentKey, ['fetch_alpha', 'fetch_beta', 'fetch_gamma'], true)) {
+        $workerStarted[$mode]++;
+    }
+});
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+$passed = 0;
+$failed = 0;
+$errors = [];
+
+function test(string $name, Closure $fn): void
+{
+    global $passed, $failed, $errors;
+
+    echo "\n  {$name} ";
+
+    try {
+        $fn();
+        echo '✓';
+        $passed++;
+    } catch (Throwable $e) {
+        echo '✗ FAIL';
+        $errors[] = "  {$name}: ".get_class($e).': '.$e->getMessage();
+        $failed++;
+    }
+}
+
+function assert_true(bool $condition, string $message): void
+{
+    if (! $condition) {
+        throw new RuntimeException("Assertion failed: {$message}");
+    }
+}
+
+$expectedCodes = ['ALPHA-111', 'BETA-222', 'GAMMA-333'];
+
+/**
+ * Run the dispatcher once in the given mode and return a structured result:
+ * wall-clock ms, final text, the parent Execution, and the parsed tool log.
+ *
+ * @return array{wallMs: float, text: string, parent: ?Execution, intervals: array<string, array{start: float, end: float, pid: int}>, pids: array<int, int>}
+ */
+function runDispatch(bool $concurrent, string $logFile): array
+{
+    // Fresh log per run so interval parsing only sees this run's markers.
+    file_put_contents($logFile, '');
+
+    $beforeId = (int) (Execution::max('id') ?? 0);
+
+    $start = microtime(true);
+
+    $response = Atlas::agent('dispatcher')
+        ->withConcurrent($concurrent)
+        ->message('Fetch the data payloads from all three sources and give me their codes.')
+        ->asText();
+
+    $wallMs = (microtime(true) - $start) * 1000;
+
+    $parent = Execution::where('id', '>', $beforeId)
+        ->whereNull('parent_execution_id')
+        ->orderByDesc('id')
+        ->first();
+
+    return [
+        'wallMs' => $wallMs,
+        'text' => $response->text,
+        'parent' => $parent,
+        ...parseToolLog($logFile),
+    ];
+}
+
+/**
+ * Parse the slow-tool log into per-token [start,end,pid] intervals + the set of
+ * distinct PIDs that ran them.
+ *
+ * @return array{intervals: array<string, array{start: float, end: float, pid: int}>, pids: array<int, int>}
+ */
+function parseToolLog(string $logFile): array
+{
+    $intervals = [];
+    $pids = [];
+
+    foreach (file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        [$ts, $pid, $token, $phase] = explode('|', $line);
+        $ts = (float) $ts;
+        $pid = (int) $pid;
+        $pids[$pid] = $pid;
+
+        if ($phase === 'START') {
+            $intervals[$token]['start'] = $ts;
+            $intervals[$token]['pid'] = $pid;
+        } else {
+            $intervals[$token]['end'] = $ts;
+        }
+    }
+
+    return ['intervals' => $intervals, 'pids' => array_values($pids)];
+}
+
+/**
+ * Peak number of slow-tool intervals active at the same instant — the hard proof
+ * of parallelism, and robust to the model fanning out across multiple rounds.
+ * Sequential execution peaks at 1; genuine parallel fan-out peaks at the batch
+ * size (3 here). Computed with a sweep line over interval start/end events.
+ *
+ * @param  array<string, array{start: float, end: float, pid: int}>  $intervals
+ */
+function peakConcurrency(array $intervals): int
+{
+    $events = [];
+
+    foreach ($intervals as $i) {
+        if (! isset($i['start'], $i['end'])) {
+            continue;
+        }
+        $events[] = [$i['start'], +1];
+        $events[] = [$i['end'], -1];
+    }
+
+    // Sort by time; on ties, process ENDs (-1) before STARTs (+1) so touching
+    // intervals are not miscounted as overlapping.
+    usort($events, fn ($a, $b) => $a[0] <=> $b[0] ?: $a[1] <=> $b[1]);
+
+    $active = 0;
+    $peak = 0;
+
+    foreach ($events as [, $delta]) {
+        $active += $delta;
+        $peak = max($peak, $active);
+    }
+
+    return $peak;
+}
+
+echo '╔══════════════════════════════════════════════╗';
+echo "\n║   Concurrent Sub-Agents (Parallel Fan-Out)   ║";
+echo "\n╚══════════════════════════════════════════════╝";
+
+echo "\n\nEnvironment:";
+echo "\n  pcntl extension : ".(extension_loaded('pcntl') ? 'loaded' : 'MISSING (fork → sync fallback)');
+echo "\n  spatie/fork     : ".(class_exists(Fork::class) ? 'available' : 'MISSING');
+echo "\n  per-tool sleep  : ".SLOW_TOOL_SLEEP.'s × 3 sub-agents';
+echo "\n  expectation     : sequential ≈ ".(SLOW_TOOL_SLEEP * 3).'s, parallel ≈ '.SLOW_TOOL_SLEEP."s\n";
+
+// ─── Run both modes ──────────────────────────────────────────────────────────
+
+$GLOBALS['__mode'] = 'sequential';
+echo "\n── Running SEQUENTIAL (concurrent: false) …";
+$seq = runDispatch(false, $logFile);
+echo ' done in '.round($seq['wallMs']).'ms';
+
+$GLOBALS['__mode'] = 'concurrent';
+echo "\n── Running CONCURRENT (concurrent: true) …";
+$con = runDispatch(true, $logFile);
+echo ' done in '.round($con['wallMs']).'ms';
+$GLOBALS['__mode'] = null;
+
+// ─── Correctness: the parent got every sub-agent response back ───────────────
+
+echo "\n\n── Correctness: parent receives ALL sub-agent responses";
+
+foreach (['sequential' => $seq, 'concurrent' => $con] as $mode => $run) {
+    test("[{$mode}] final answer carries all three payload codes", function () use ($run, $expectedCodes, $mode) {
+        foreach ($expectedCodes as $code) {
+            assert_true(
+                str_contains($run['text'], $code),
+                "[{$mode}] parent's final answer must contain {$code} (proves the response looped back); got: {$run['text']}",
+            );
+        }
+    });
+}
+
+echo "\n    sequential final: \"".trim($seq['text']).'"';
+echo "\n    concurrent final: \"".trim($con['text']).'"';
+
+// ─── Lineage: three depth-1 children with correct parent FKs ─────────────────
+
+echo "\n\n── Persistence lineage (parent → 3 children)";
+
+foreach (['sequential' => $seq, 'concurrent' => $con] as $mode => $run) {
+    test("[{$mode}] records correct parent → child lineage for every delegation", function () use ($run, $mode) {
+        $parent = $run['parent'];
+        assert_true($parent !== null && $parent->agent === 'dispatcher' && $parent->depth === 0, "[{$mode}] root dispatcher execution at depth 0");
+
+        // The model may fan out in one or more rounds (it is nondeterministic) —
+        // each round is a parallel batch of all three. Assert the structure holds
+        // regardless of how many rounds it chose: a positive multiple of three,
+        // every child depth-1 with correct parent FKs.
+        $children = $parent->children;
+        assert_true(
+            $children->count() >= 3 && $children->count() % 3 === 0,
+            "[{$mode}] expected a positive multiple of 3 child executions (rounds × 3), got {$children->count()}",
+        );
+
+        foreach ($children as $child) {
+            assert_true($child->depth === 1, "[{$mode}] child depth should be 1, got {$child->depth}");
+            assert_true($child->parent_execution_id === $parent->id, "[{$mode}] child links to parent execution");
+            assert_true($child->parent_tool_call_id !== null, "[{$mode}] child links to its delegating tool call");
+        }
+
+        // Each delegation round must be issued as ONE batched step fanning out to
+        // all three agents — that batching is what the executor parallelises.
+        $delegations = $parent->toolCalls->where('type', ToolCallType::Agent);
+        $byStep = $delegations->groupBy('step_id');
+
+        foreach ($byStep as $stepId => $calls) {
+            $names = $calls->pluck('name')->unique()->sort()->values()->all();
+            assert_true(
+                $names === ['fetch_alpha', 'fetch_beta', 'fetch_gamma'],
+                "[{$mode}] each delegation step must fan out to all three agents, step {$stepId} had: ".implode(',', $names),
+            );
+        }
+
+        $rounds = $byStep->count();
+        echo "\n    [{$mode}] {$rounds} parallel round(s) of 3 delegations, ".$children->count().' child executions, all depth-1 with correct FKs ✓';
+    });
+}
+
+// ─── Concurrency verdict ─────────────────────────────────────────────────────
+
+echo "\n\n── Concurrency verdict";
+
+// Peak simultaneous sub-agent activity is the hard, intra-run proof. Cross-run
+// wall-clock is unreliable on its own because the model is free to fan out in a
+// different number of rounds per run — so it is reported as context only.
+$seqPeak = peakConcurrency($seq['intervals']);
+$conPeak = peakConcurrency($con['intervals']);
+
+echo "\n    peak simultaneous sub-agents : sequential={$seqPeak}  concurrent={$conPeak}  (sequential→1, parallel→up to 3)";
+echo "\n    distinct PIDs                : sequential=".count($seq['pids']).'  concurrent='.count($con['pids']).'  (fork → >1)';
+echo "\n    wall-clock (context only)    : sequential=".round($seq['wallMs']).'ms  concurrent='.round($con['wallMs']).'ms';
+
+// Detected when the concurrent run genuinely overlapped ≥2 sub-agents in time on
+// distinct processes, while the sequential run did not.
+$concurrencyDetected = $conPeak >= 2 && count($con['pids']) > 1 && $seqPeak === 1;
+
+test('concurrent execution overlaps multiple sub-agents; sequential does not', function () use ($conPeak, $seqPeak, $con) {
+    assert_true($seqPeak === 1, "sequential run must NOT overlap (peak={$seqPeak}, expected 1)");
+    assert_true($conPeak >= 2, "concurrent run must overlap ≥2 sub-agents (peak={$conPeak})");
+    assert_true(count($con['pids']) > 1, 'concurrent run must fork into multiple processes');
+});
+
+echo "\n\n    ┌────────────────────────────────────────────────┐";
+echo "\n    │  CONCURRENT SUB-AGENT EXECUTION: ".str_pad($concurrencyDetected ? '✓ DETECTED' : '❌ NOT DETECTED', 14).'│';
+echo "\n    └────────────────────────────────────────────────┘";
+
+if ($concurrencyDetected) {
+    echo "\n    → {$conPeak} sub-agents ran AT THE SAME TIME across ".count($con['pids']).' forked processes,';
+    echo "\n      every response returned to the parent, and the parent looped to a";
+    echo "\n      correct final answer. Lineage stayed intact across the fork boundary.";
+} else {
+    echo "\n    → Sub-agents did NOT run in parallel. If pcntl/spatie-fork are present,";
+    echo "\n      check that AgentExecutor allows delegation batches through the";
+    echo "\n      concurrent path and resets DB connections before forking.";
+}
+
+// ─── Real-time broadcasting to the UI ────────────────────────────────────────
+//
+// What live updates does a UI actually receive during a concurrent batch?
+
+/**
+ * Summarise the timing of captured tool-call events for one run.
+ *
+ * @param  array<int, array{kind: string, t: float, name: string}>  $events
+ * @return array{started: int, completed: int, startedSpreadMs: float, completedSpreadMs: float, silentGapMs: float}
+ */
+function eventTimeline(array $events): array
+{
+    $st = array_column(array_filter($events, fn ($e) => $e['kind'] === 'started'), 't');
+    $ct = array_column(array_filter($events, fn ($e) => $e['kind'] === 'completed'), 't');
+
+    return [
+        'started' => count($st),
+        'completed' => count($ct),
+        // Spread within each cluster: small = all fired together.
+        'startedSpreadMs' => $st !== [] ? (max($st) - min($st)) * 1000 : 0.0,
+        'completedSpreadMs' => $ct !== [] ? (max($ct) - min($ct)) * 1000 : 0.0,
+        // Window between the last "started" and the first "completed". A large
+        // positive gap = the UI received NO updates while the tools ran (batched
+        // at the fork join). Negative = completions interleaved with starts
+        // (sequential streams each tool's progress in real time).
+        'silentGapMs' => ($st !== [] && $ct !== []) ? (min($ct) - max($st)) * 1000 : 0.0,
+    ];
+}
+
+$seqTl = eventTimeline($evt['sequential']);
+$conTl = eventTimeline($evt['concurrent']);
+
+echo "\n\n── Real-time broadcasting to the UI (live events the parent emits)";
+echo "\n    SEQUENTIAL: started spread=".round($seqTl['startedSpreadMs']).'ms, completed spread='.round($seqTl['completedSpreadMs']).'ms, start→complete gap='.round($seqTl['silentGapMs']).'ms';
+echo "\n                → each tool starts, runs, and completes in turn — fully streamed, one at a time";
+echo "\n    CONCURRENT: started spread=".round($conTl['startedSpreadMs']).'ms, completed spread='.round($conTl['completedSpreadMs']).'ms, start→complete gap='.round($conTl['silentGapMs']).'ms';
+echo "\n                → all 3 'started' broadcast together (UI shows 3 in progress at once),";
+echo "\n                  then a silent window while they run, then all 3 'completed' together at the join";
+echo "\n    sub-agent INTERNAL events delivered in-process: sequential={$workerStarted['sequential']}, concurrent={$workerStarted['concurrent']}";
+echo "\n                → 0 for concurrent confirms a sub-agent's own steps fire inside the fork (not broadcast live)";
+
+test('concurrent batch broadcasts all three tool-starts up front (UI can show 3 in progress at once)', function () use ($conTl) {
+    assert_true($conTl['started'] === 3, "expected 3 'started' events, got {$conTl['started']}");
+    assert_true($conTl['startedSpreadMs'] < 500, "all three 'started' should broadcast together, spread was {$conTl['startedSpreadMs']}ms");
+});
+
+test('concurrent tool completions arrive batched at the join, not streamed per tool', function () use ($conTl) {
+    assert_true($conTl['completed'] === 3, "expected 3 'completed' events, got {$conTl['completed']}");
+    assert_true($conTl['silentGapMs'] > 1500, "expected a silent window (~the parallel work) with no events, gap was {$conTl['silentGapMs']}ms");
+    assert_true($conTl['completedSpreadMs'] < 500, "the three 'completed' should arrive together at the join, spread was {$conTl['completedSpreadMs']}ms");
+});
+
+test("sub-agents' own internal events stream in-process sequentially but NOT across the fork", function () use ($workerStarted) {
+    assert_true($workerStarted['sequential'] >= 3, "sequential should deliver worker AgentStarted in-process, got {$workerStarted['sequential']}");
+    assert_true($workerStarted['concurrent'] === 0, "concurrent worker AgentStarted fire inside the fork and must NOT reach the parent, got {$workerStarted['concurrent']}");
+});
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo "\n\n══════════════════════════════════════════════";
+echo "\n  Results: {$passed} passed, {$failed} failed";
+echo "\n  Concurrency: ".($concurrencyDetected ? 'DETECTED ✓' : 'not yet (baseline)');
+echo "\n══════════════════════════════════════════════\n";
+
+if ($errors !== []) {
+    echo "\nFailures:\n".implode("\n", $errors)."\n";
+    exit(1);
+}
+
+exit(0);

--- a/sandbox/test-subagents-concurrent.php
+++ b/sandbox/test-subagents-concurrent.php
@@ -45,6 +45,7 @@ use Atlasphp\Atlas\Enums\Provider;
 use Atlasphp\Atlas\Events\AgentStarted;
 use Atlasphp\Atlas\Events\AgentToolCallCompleted;
 use Atlasphp\Atlas\Events\AgentToolCallStarted;
+use Atlasphp\Atlas\Persistence\Enums\ExecutionStatus;
 use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
 use Atlasphp\Atlas\Persistence\Middleware\PersistConversation;
 use Atlasphp\Atlas\Persistence\Middleware\TrackExecution;
@@ -612,6 +613,73 @@ test("sub-agents' own internal events stream in-process sequentially but NOT acr
     assert_true($workerStarted['sequential'] >= 3, "sequential should deliver worker AgentStarted in-process, got {$workerStarted['sequential']}");
     assert_true($workerStarted['concurrent'] === 0, "concurrent worker AgentStarted fire inside the fork and must NOT reach the parent, got {$workerStarted['concurrent']}");
 });
+
+// ─── Post-completion drill-down (what the UI shows when you open a call) ──────
+//
+// Live streaming of a concurrent sub-agent's internals is not delivered to the
+// parent (above). But its FULL result IS persisted from inside the fork. This is
+// exactly what a UI does when you click a COMPLETED delegation tool call: load
+// the sub-agent's response, the steps it took (with their text), and the tools
+// it ran (with arguments, results, and timing). Reconstructed from the database
+// for the concurrent run below — proving full after-the-fact visibility.
+
+echo "\n\n── Post-completion drill-down (concurrent run — full sub-agent visibility)";
+
+test('every concurrent sub-agent exposes its response, steps, and tools after completion', function () use ($con) {
+    $parent = $con['parent'];
+    $delegations = $parent->toolCalls->where('type', ToolCallType::Agent);
+    assert_true($delegations->isNotEmpty(), 'parent should have delegation tool calls to drill into');
+
+    foreach ($delegations as $tc) {
+        // 1. The sub-agent's RESPONSE — on the delegation tool call result.
+        assert_true(is_string($tc->result) && $tc->result !== '', "delegation '{$tc->name}' must carry the sub-agent response");
+
+        // 2. The linked child execution is fully recorded.
+        $child = Execution::where('parent_tool_call_id', $tc->id)->first();
+        assert_true($child !== null, "delegation '{$tc->name}' must link to a child execution");
+        assert_true($child->status === ExecutionStatus::Completed, "child '{$child->agent}' should be completed");
+        assert_true(($child->usage['output_tokens'] ?? 0) > 0, "child '{$child->agent}' should have recorded usage");
+
+        // 3. The sub-agent's STEPS — recorded with their text content.
+        $steps = $child->steps()->orderBy('sequence')->get();
+        assert_true($steps->isNotEmpty(), "child '{$child->agent}' should have recorded steps");
+        assert_true(
+            $steps->contains(fn ($s) => is_string($s->content) && $s->content !== ''),
+            "child '{$child->agent}' steps should include the response text",
+        );
+
+        // 4. The TOOLS the sub-agent ran — with arguments, result, and timing.
+        $ranTools = $child->toolCalls()->where('type', ToolCallType::Local)->get();
+        assert_true($ranTools->isNotEmpty(), "child '{$child->agent}' should record the tools it ran (slow_fetch)");
+        foreach ($ranTools as $ct) {
+            assert_true(is_string($ct->result) && $ct->result !== '', "tool '{$ct->name}' on '{$child->agent}' should record its result");
+            assert_true($ct->duration_ms !== null, "tool '{$ct->name}' on '{$child->agent}' should record its duration");
+        }
+    }
+});
+
+// Render the tree a UI would display when drilling into the concurrent run.
+foreach ($con['parent']->toolCalls->where('type', ToolCallType::Agent) as $tc) {
+    $child = Execution::where('parent_tool_call_id', $tc->id)->first();
+    echo "\n    ▸ tool call '{$tc->name}' → response: \"".trim((string) $tc->result).'"';
+
+    if ($child === null) {
+        continue;
+    }
+
+    $tokens = ($child->usage['input_tokens'] ?? 0).'in/'.($child->usage['output_tokens'] ?? 0).'out';
+    echo "\n        └ sub-agent execution #{$child->id} ({$child->agent}, {$child->status->value}, {$tokens})";
+
+    foreach ($child->steps()->orderBy('sequence')->get() as $s) {
+        $txt = ($s->content !== null && $s->content !== '') ? '"'.trim((string) $s->content).'"' : '(tool-call step)';
+        echo "\n            step {$s->sequence} [{$s->finish_reason}]: {$txt}";
+    }
+
+    foreach ($child->toolCalls()->where('type', ToolCallType::Local)->get() as $ct) {
+        echo "\n            ran tool {$ct->name}(".json_encode($ct->arguments).') → "'.trim((string) $ct->result)."\" ({$ct->duration_ms}ms)";
+    }
+}
+echo "\n    → full sub-agent responses, per-step text, and the tools they ran are all queryable after a concurrent run ✓";
 
 // ─── Summary ─────────────────────────────────────────────────────────────────
 

--- a/sandbox/test-subagents.php
+++ b/sandbox/test-subagents.php
@@ -1,0 +1,554 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Sub-Agents (Agent-as-Tool) Integration Test
+ *
+ * Validates agent delegation against the real OpenAI API: implicit + explicit
+ * wiring, isolated standalone runs, the auditable parent → child execution
+ * tree (persistence lineage), usage roll-up, and the depth/cycle guards.
+ *
+ * Usage: php test-subagents.php
+ *
+ * Requires OPENAI_API_KEY in sandbox/.env and a migrated database.
+ */
+use Atlasphp\Atlas\Agent;
+use Atlasphp\Atlas\AgentRegistry;
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Events\AgentToolCallCompleted;
+use Atlasphp\Atlas\Events\AgentToolCallStarted;
+use Atlasphp\Atlas\Exceptions\DelegationCycleException;
+use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
+use Atlasphp\Atlas\Persistence\Middleware\PersistConversation;
+use Atlasphp\Atlas\Persistence\Middleware\TrackExecution;
+use Atlasphp\Atlas\Persistence\Middleware\TrackProviderCall;
+use Atlasphp\Atlas\Persistence\Middleware\TrackStep;
+use Atlasphp\Atlas\Persistence\Middleware\TrackToolCall;
+use Atlasphp\Atlas\Persistence\Models\Execution;
+use Atlasphp\Atlas\Schema\Fields\IntegerField;
+use Atlasphp\Atlas\Tools\AgentTool;
+use Atlasphp\Atlas\Tools\Tool;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Support\Facades\Event;
+
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+]);
+
+// Guarantee execution tracking is wired (the testbench bootstrap enables
+// persistence after the provider registers, so the snapshot can be empty).
+$app['config']->set('atlas.persistence.enabled', true);
+$app['config']->set('atlas.middleware', [
+    PersistConversation::class,
+    TrackExecution::class,
+    TrackStep::class,
+    TrackToolCall::class,
+    TrackProviderCall::class,
+]);
+AtlasConfig::refresh();
+
+// ─── Agents ──────────────────────────────────────────────────────────────────
+
+class VaultSpecialistAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'vault';
+    }
+
+    public function description(): ?string
+    {
+        return 'Knows the secret project passphrase.';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You are the project vault. When asked for the project passphrase, reply with '
+            .'exactly: "The project passphrase is ZULU-7." Do not add anything else.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+}
+
+class RouterOrchestratorAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'router';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You are a router and do NOT know any secrets yourself. To answer ANY question '
+            .'about the project passphrase you MUST call the vault sub-agent tool with a clear '
+            .'task, then relay its exact answer to the user.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+
+    public function maxSteps(): ?int
+    {
+        return 4;
+    }
+
+    public function tools(): array
+    {
+        return [VaultSpecialistAgent::class];
+    }
+}
+
+class RouterExplicitAgent extends RouterOrchestratorAgent
+{
+    public function key(): string
+    {
+        return 'router-explicit';
+    }
+
+    public function tools(): array
+    {
+        return [AgentTool::for(new VaultSpecialistAgent, 'ask_vault', 'Ask the vault for the passphrase.')];
+    }
+}
+
+class AddNumbersTool extends Tool
+{
+    public function name(): string
+    {
+        return 'add_numbers';
+    }
+
+    public function description(): string
+    {
+        return 'Adds two integers and returns the sum.';
+    }
+
+    public function parameters(): array
+    {
+        return [
+            new IntegerField('a', 'First number.'),
+            new IntegerField('b', 'Second number.'),
+        ];
+    }
+
+    public function handle(array $args, array $context): mixed
+    {
+        return (int) ($args['a'] ?? 0) + (int) ($args['b'] ?? 0);
+    }
+}
+
+class RouterMixedAgent extends RouterOrchestratorAgent
+{
+    public function key(): string
+    {
+        return 'router-mixed';
+    }
+
+    public function tools(): array
+    {
+        return [VaultSpecialistAgent::class, AddNumbersTool::class];
+    }
+}
+
+// Multi-level chain: coordinator → researcher → vault (depths 0 → 1 → 2).
+
+class ResearcherAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'researcher';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You research answers but do NOT know secrets. To answer any question about the '
+            .'project passphrase you MUST call the vault sub-agent tool, then relay its exact answer.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+
+    public function maxSteps(): ?int
+    {
+        return 4;
+    }
+
+    public function tools(): array
+    {
+        return [VaultSpecialistAgent::class];
+    }
+}
+
+class CoordinatorAgent extends ResearcherAgent
+{
+    public function key(): string
+    {
+        return 'coordinator';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You coordinate work but do NOT know secrets. To answer any question about the '
+            .'project passphrase you MUST call the researcher sub-agent tool, then relay its exact answer.';
+    }
+
+    public function tools(): array
+    {
+        return [ResearcherAgent::class];
+    }
+}
+
+// Dynamic prompt injection: the sub-agent's instructions use a {user_name} macro.
+
+class GreeterSpecialistAgent extends VaultSpecialistAgent
+{
+    public function key(): string
+    {
+        return 'greeter';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You are speaking with {user_name}. When asked for the passphrase, reply with '
+            .'exactly: "{user_name}, the passphrase is ZULU-7." Use their real name, not the placeholder.';
+    }
+}
+
+class GreeterRouterAgent extends RouterOrchestratorAgent
+{
+    public function key(): string
+    {
+        return 'greeter-router';
+    }
+
+    public function tools(): array
+    {
+        return [GreeterSpecialistAgent::class];
+    }
+}
+
+app(AgentRegistry::class)->register(VaultSpecialistAgent::class);
+app(AgentRegistry::class)->register(RouterOrchestratorAgent::class);
+app(AgentRegistry::class)->register(RouterExplicitAgent::class);
+app(AgentRegistry::class)->register(RouterMixedAgent::class);
+app(AgentRegistry::class)->register(ResearcherAgent::class);
+app(AgentRegistry::class)->register(CoordinatorAgent::class);
+app(AgentRegistry::class)->register(GreeterSpecialistAgent::class);
+app(AgentRegistry::class)->register(GreeterRouterAgent::class);
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+$passed = 0;
+$failed = 0;
+$errors = [];
+
+function test(string $name, Closure $fn): void
+{
+    global $passed, $failed, $errors;
+
+    echo "\n  {$name} ";
+
+    try {
+        $fn();
+        echo '✓';
+        $passed++;
+    } catch (Throwable $e) {
+        echo '✗ FAIL';
+        $errors[] = "  {$name}: ".get_class($e).': '.$e->getMessage();
+        $failed++;
+    }
+}
+
+function assert_true(bool $condition, string $message): void
+{
+    if (! $condition) {
+        throw new RuntimeException("Assertion failed: {$message}");
+    }
+}
+
+/** Run an agent and return [response, parent execution for that run]. */
+function runAndCapture(string $key, string $message): array
+{
+    $beforeId = (int) (Execution::max('id') ?? 0);
+
+    $response = Atlas::agent($key)->message($message)->asText();
+
+    $parent = Execution::where('id', '>', $beforeId)
+        ->whereNull('parent_execution_id')
+        ->orderByDesc('id')
+        ->first();
+
+    return [$response, $parent];
+}
+
+echo '╔══════════════════════════════════════════════╗';
+echo "\n║   Sub-Agents (Agent-as-Tool) Integration     ║";
+echo "\n╚══════════════════════════════════════════════╝";
+
+// ─── 1. Implicit delegation ──────────────────────────────────────────────────
+
+echo "\n\n── Delegation";
+
+test('implicit delegation: orchestrator calls the sub-agent', function () {
+    [$response] = runAndCapture('router', 'What is the project passphrase?');
+
+    assert_true(str_contains($response->text, 'ZULU-7'), "Final answer should contain the vault's secret, got: {$response->text}");
+});
+
+test('explicit AgentTool::for delegation', function () {
+    [$response] = runAndCapture('router-explicit', 'What is the project passphrase?');
+
+    assert_true(str_contains($response->text, 'ZULU-7'), "Explicit delegation should relay the secret, got: {$response->text}");
+});
+
+test('standalone forInstance() executes a sub-agent in isolation', function () {
+    $response = Atlas::agent('vault')
+        ->forInstance(new VaultSpecialistAgent)
+        ->message('What is the project passphrase?')
+        ->asText();
+
+    assert_true(str_contains($response->text, 'ZULU-7'), "Standalone sub-agent should answer, got: {$response->text}");
+});
+
+test('multi-tool agent picks the sub-agent for the delegated task', function () {
+    [$response, $parent] = runAndCapture('router-mixed', 'What is the project passphrase?');
+
+    assert_true(str_contains($response->text, 'ZULU-7'), "Mixed agent should delegate to the vault, got: {$response->text}");
+    assert_true($parent !== null && $parent->children->where('agent', 'vault')->isNotEmpty(), 'A vault child execution should exist');
+});
+
+// ─── 2. Audit lineage ────────────────────────────────────────────────────────
+
+echo "\n\n── Audit lineage (persistence)";
+
+test('records a parent → child execution tree', function () {
+    [, $parent] = runAndCapture('router', 'What is the project passphrase?');
+
+    assert_true($parent !== null, 'Parent execution should exist');
+    assert_true($parent->agent === 'router' && $parent->depth === 0, 'Parent is the root router execution');
+
+    $child = $parent->children->first();
+    assert_true($child !== null, 'Child (sub-agent) execution should exist');
+    assert_true($child->agent === 'vault', "Child should be the vault agent, got: {$child->agent}");
+    assert_true($child->depth === 1, "Child depth should be 1, got: {$child->depth}");
+    assert_true($child->parent_execution_id === $parent->id, 'Child links to parent');
+    assert_true($child->parent_tool_call_id !== null, 'Child links to the delegating tool call');
+
+    // The delegating tool call is typed 'agent'.
+    $delegation = $parent->toolCalls->firstWhere('type', ToolCallType::Agent);
+    assert_true($delegation !== null && $delegation->name === 'vault', 'An agent-typed tool call named vault should exist');
+    assert_true($child->parent_tool_call_id === $delegation->id, 'Child parent_tool_call_id matches the delegation call');
+
+    // Print the reconstructed tree as visible proof.
+    echo "\n    tree: execution #{$parent->id} ({$parent->agent}, depth {$parent->depth})";
+    echo "\n      └─ via tool call #{$delegation->id} [{$delegation->type->value}] → execution #{$child->id} ({$child->agent}, depth {$child->depth})";
+
+    // Usage roll-up: tree total includes the child's tokens.
+    $own = ($parent->usage['input_tokens'] ?? 0) + ($parent->usage['output_tokens'] ?? 0);
+    $tree = $parent->totalUsage()['total_tokens'];
+    echo "\n    usage: parent-only={$own} tokens, tree-total={$tree} tokens";
+    assert_true($tree > $own, "Tree usage ({$tree}) should exceed parent-only ({$own})");
+});
+
+// ─── 3. Multi-level chain ────────────────────────────────────────────────────
+
+echo "\n\n── Multi-level chain (coordinator → researcher → vault)";
+
+test('a three-level chain delegates end to end', function () {
+    [$response] = runAndCapture('coordinator', 'What is the project passphrase?');
+
+    assert_true(str_contains($response->text, 'ZULU-7'), "The deepest sub-agent's answer should reach the top, got: {$response->text}");
+});
+
+test('records and audits the full three-level execution chain', function () {
+    [, $coordinator] = runAndCapture('coordinator', 'What is the project passphrase?');
+
+    assert_true($coordinator !== null && $coordinator->agent === 'coordinator' && $coordinator->depth === 0, 'Root is the coordinator at depth 0');
+
+    // Walk the chain top to bottom, verifying each link.
+    $expected = [
+        ['agent' => 'coordinator', 'depth' => 0],
+        ['agent' => 'researcher', 'depth' => 1],
+        ['agent' => 'vault', 'depth' => 2],
+    ];
+
+    $node = $coordinator;
+    $nodes = [];
+
+    foreach ($expected as $i => $want) {
+        assert_true($node !== null, "Chain level {$i} should exist");
+        assert_true($node->agent === $want['agent'], "Level {$i} should be {$want['agent']}, got: {$node->agent}");
+        assert_true($node->depth === $want['depth'], "Level {$i} depth should be {$want['depth']}, got: {$node->depth}");
+
+        if ($i > 0) {
+            assert_true($node->parent_tool_call_id !== null, "Level {$i} links to a delegating tool call");
+            $delegation = $node->parentToolCall;
+            assert_true($delegation !== null && $delegation->type === ToolCallType::Agent, "Level {$i} delegating call is typed agent");
+        }
+
+        $nodes[] = $node;
+
+        // Descend to the single sub-agent child for the next level.
+        $node = $node->children->firstWhere('agent', $expected[$i + 1]['agent'] ?? '__none__');
+    }
+
+    // Each agent records its OWN token usage on its own execution row — so the
+    // cost of every individual agent is known, not just the aggregate.
+    echo "\n    per-agent cost (individual rows):";
+    $sumIndividual = 0;
+
+    foreach ($nodes as $i => $n) {
+        $in = (int) ($n->usage['input_tokens'] ?? 0);
+        $out = (int) ($n->usage['output_tokens'] ?? 0);
+        $own = $in + $out;
+        assert_true($own > 0, "{$n->agent} must have its own recorded usage");
+        $sumIndividual += $own;
+        $indent = str_repeat('  ', $i);
+        echo "\n      {$indent}#{$n->id} {$n->agent} (depth {$n->depth}): in={$in}, out={$out}, own={$own}";
+    }
+
+    $tree = $coordinator->totalUsage()['total_tokens'];
+    echo "\n    full-chain total = {$tree} tokens (= sum of individual = {$sumIndividual})";
+    assert_true($tree === $sumIndividual, 'Tree total must equal the sum of each agent\'s own usage');
+    assert_true($tree > (($coordinator->usage['input_tokens'] ?? 0) + ($coordinator->usage['output_tokens'] ?? 0)), 'Full-chain total exceeds the root alone');
+});
+
+// ─── 4. Real-time UI events ──────────────────────────────────────────────────
+
+echo "\n\n── Real-time UI events (broadcasting)";
+
+test('delegation fires the same broadcast tool-call events the UI consumes', function () {
+    $started = [];
+    $completed = [];
+    Event::listen(AgentToolCallStarted::class, function ($e) use (&$started) {
+        $started[] = $e;
+    });
+    Event::listen(AgentToolCallCompleted::class, function ($e) use (&$completed) {
+        $completed[] = $e;
+    });
+
+    runAndCapture('router', 'What is the project passphrase?');
+
+    // The delegation surfaces to the UI as a tool call named after the sub-agent.
+    $vaultStarted = array_values(array_filter($started, fn ($e) => $e->toolCall->name === 'vault'));
+    $vaultDone = array_values(array_filter($completed, fn ($e) => $e->toolCall->name === 'vault'));
+    assert_true($vaultStarted !== [], 'An AgentToolCallStarted event should fire for the vault delegation');
+    assert_true($vaultDone !== [], 'An AgentToolCallCompleted event should fire for the vault delegation');
+
+    // Both are ShouldBroadcastNow → pushed to the UI in real time (same path as any tool).
+    assert_true($vaultStarted[0] instanceof ShouldBroadcastNow, 'Started event broadcasts in real time');
+    assert_true($vaultDone[0] instanceof ShouldBroadcastNow, 'Completed event broadcasts in real time');
+
+    // The completed payload carries the sub-agent's response back to the UI.
+    $payload = $vaultDone[0]->broadcastWith();
+    assert_true(str_contains((string) $payload['result'], 'ZULU-7'), "Broadcast result should carry the sub-agent response, got: {$payload['result']}");
+
+    $startPayload = $vaultStarted[0]->broadcastWith();
+    echo "\n    UI event 1: AgentToolCallStarted → toolName='{$startPayload['toolName']}', task='".($startPayload['arguments']['task'] ?? '')."'";
+    echo "\n    UI event 2: AgentToolCallCompleted → toolName='{$payload['toolName']}', result='{$payload['result']}'";
+});
+
+// ─── 5. Dynamic prompt injection ─────────────────────────────────────────────
+
+echo "\n\n── Dynamic prompt injection into sub-agents";
+
+test('parent variables are injected into the sub-agent prompt', function () {
+    // user_name is set ONLY on the parent call; the sub-agent's {user_name}
+    // macro must still resolve as if the sub-agent were called directly.
+    $beforeId = (int) (Execution::max('id') ?? 0);
+
+    Atlas::agent('greeter-router')
+        ->withVariables(['user_name' => 'Tim'])
+        ->message('What is the project passphrase?')
+        ->asText();
+
+    // Assert against the sub-agent's actual output (the delegation tool-call
+    // result), not the orchestrator's possibly re-phrased final answer.
+    $parent = Execution::where('id', '>', $beforeId)
+        ->whereNull('parent_execution_id')
+        ->orderByDesc('id')
+        ->first();
+    $delegation = $parent?->toolCalls->firstWhere('type', ToolCallType::Agent);
+
+    assert_true($delegation !== null, 'A delegation tool call should exist');
+    assert_true(str_contains((string) $delegation->result, 'Tim'), "Sub-agent output should contain the injected name 'Tim', got: {$delegation->result}");
+    echo "\n    sub-agent answered: \"{$delegation->result}\"";
+});
+
+// ─── 6. Guards ───────────────────────────────────────────────────────────────
+
+echo "\n\n── Guards";
+
+test('depth guard blocks delegation beyond the configured limit', function () {
+    config()->set('atlas.agents.max_delegation_depth', 0);
+
+    try {
+        [, $parent] = runAndCapture('router', 'What is the project passphrase?');
+
+        // With max depth 0, the very first delegation is blocked, so no child
+        // execution is created even though the model attempted the tool call.
+        assert_true($parent !== null, 'Parent execution should still be recorded');
+        assert_true($parent->children->isEmpty(), 'No child execution should be created when the depth guard blocks delegation');
+    } finally {
+        config()->set('atlas.agents.max_delegation_depth', 5);
+    }
+});
+
+test('cycle guard rejects delegating to an agent already in the chain', function () {
+    $threw = false;
+
+    try {
+        AgentTool::for(new VaultSpecialistAgent)->handle(
+            ['task' => 'anything'],
+            [AgentTool::CHAIN_META_KEY => ['vault']],
+        );
+    } catch (DelegationCycleException $e) {
+        $threw = true;
+    }
+
+    assert_true($threw, 'DelegationCycleException should be thrown for a repeated agent');
+});
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo "\n\n══════════════════════════════════════════════";
+echo "\n  Results: {$passed} passed, {$failed} failed";
+echo "\n══════════════════════════════════════════════\n";
+
+if ($errors !== []) {
+    echo "\nFailures:\n".implode("\n", $errors)."\n";
+    exit(1);
+}
+
+exit(0);

--- a/src/Exceptions/DelegationCycleException.php
+++ b/src/Exceptions/DelegationCycleException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+/**
+ * Thrown when sub-agent delegation forms a cycle.
+ *
+ * Detected when an agent already present in the active delegation chain is
+ * invoked again as a sub-agent (e.g. A → B → A), which would loop forever.
+ */
+class DelegationCycleException extends AtlasException
+{
+    /**
+     * @param  array<int, string>  $chain  The delegation chain up to the repeated agent.
+     */
+    public function __construct(
+        public readonly string $agent,
+        public readonly array $chain,
+    ) {
+        $path = implode(' → ', [...$chain, $agent]);
+
+        parent::__construct(
+            "Sub-agent delegation cycle detected: {$path}. An agent cannot delegate back to one already in the chain."
+        );
+    }
+}

--- a/src/Exceptions/MaxDelegationDepthException.php
+++ b/src/Exceptions/MaxDelegationDepthException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+/**
+ * Thrown when sub-agent delegation exceeds the configured maximum depth.
+ *
+ * Guards against runaway nesting where agents delegate to agents without
+ * bound. The limit is configurable via `atlas.agents.max_delegation_depth`.
+ */
+class MaxDelegationDepthException extends AtlasException
+{
+    public function __construct(
+        public readonly int $limit,
+        public readonly string $agent,
+    ) {
+        parent::__construct(
+            "Sub-agent delegation exceeded the maximum depth of {$limit} while delegating to '{$agent}'. "
+            .'Increase atlas.agents.max_delegation_depth or reduce nesting.'
+        );
+    }
+}

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -27,6 +27,7 @@ use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Tools\Tool;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\DB;
 use Spatie\Fork\Fork;
 
 /**
@@ -319,6 +320,23 @@ class AgentExecutor
      * The default process driver is not used because it serializes closures
      * into child PHP processes, which fails with dependency-injected tools.
      *
+     * Sub-agent delegations run concurrently too. Each fork inherits a copy of
+     * the parent's (scoped) ExecutionService, so every child computes its own
+     * parent_execution_id / parent_tool_call_id and persists correct lineage
+     * independently — nothing has to propagate back, and usage roll-up is read
+     * from the DB subtree afterwards. The one hazard is the inherited database
+     * connection, which is reset before forking (see disconnectDatabase).
+     *
+     * Event delivery caveat: the per-tool AgentToolCallStarted/Completed events
+     * are fired here in the parent and behave normally. But any orchestration
+     * events a delegated sub-agent fires *inside* its fork (its own AgentStarted/
+     * AgentCompleted, step and nested tool-call events) are dispatched to the
+     * child's in-process dispatcher and do NOT reach listeners in the parent
+     * process — there is no IPC back. Persistence is unaffected (the child writes
+     * the full execution/step/tool-call tree to the DB), so post-hoc auditing is
+     * complete; only real-time in-process listeners on a sub-agent's internals
+     * are missed. Use sequential delegation when that live observability matters.
+     *
      * Falls back to sequential if only one tool call is present.
      *
      * @param  array<int, ToolCall>  $toolCalls
@@ -329,17 +347,6 @@ class AgentExecutor
     {
         if (count($toolCalls) === 1) {
             return $this->executeToolsSequentially($toolCalls, $meta, $stepNumber);
-        }
-
-        // Sub-agent delegation runs nested executions through the shared (scoped)
-        // ExecutionService. Under fork-based concurrency the child's tracking state
-        // never propagates back to the parent process, which would corrupt the
-        // parent's execution context. Run the whole batch sequentially if any tool
-        // delegates, so lineage tracking stays correct.
-        foreach ($toolCalls as $toolCall) {
-            if ($this->toolExecutor->isDelegation($toolCall->name)) {
-                return $this->executeToolsSequentially($toolCalls, $meta, $stepNumber);
-            }
         }
 
         $toolCalls = array_values($toolCalls);
@@ -367,8 +374,23 @@ class AgentExecutor
             $toolCalls,
         );
 
+        $driver = $this->concurrencyDriver();
+
+        // Fork DB-safety: a forked child inherits the parent's database connection
+        // — a single, non-fork-safe socket. Delegating tools write heavily to the
+        // DB (nested executions, steps, tool calls), so concurrent children sharing
+        // one connection would corrupt the wire protocol. Closing the parent's
+        // resolved connections before forking forces each child to open its own;
+        // the parent reconnects lazily on its next query after the batch. Guarded
+        // to the fork driver + persistence so the in-process sync driver and
+        // non-persistent runs are untouched (and an in-memory SQLite test DB,
+        // which only exists for the life of its connection, is never dropped).
+        if ($driver === 'fork' && (bool) config('atlas.persistence.enabled', false)) {
+            $this->disconnectDatabase();
+        }
+
         /** @var array<int, ToolResult> $results */
-        $results = Concurrency::driver($this->concurrencyDriver())->run($tasks);
+        $results = Concurrency::driver($driver)->run($tasks);
 
         // Post-process: fire completion or error events
         foreach ($results as $result) {
@@ -399,6 +421,20 @@ class AgentExecutor
         }
 
         return 'sync';
+    }
+
+    /**
+     * Purge every resolved database connection so forked children each open
+     * their own. Laravel rebuilds connections lazily, so the parent and every
+     * child get a clean, fork-safe connection. Called in the parent right before
+     * forking — no live socket is shared across the fork boundary. No-op when no
+     * connection has been resolved yet.
+     */
+    protected function disconnectDatabase(): void
+    {
+        foreach (array_keys(DB::getConnections()) as $name) {
+            DB::purge($name);
+        }
     }
 
     /**

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -279,6 +279,7 @@ class AgentExecutor
             meta: $meta,
             stepNumber: $stepNumber,
             agentKey: $this->context->agentKey,
+            isDelegation: $this->toolExecutor->isDelegation($toolCall->name),
         );
 
         return $this->middlewareStack->run(
@@ -328,6 +329,17 @@ class AgentExecutor
     {
         if (count($toolCalls) === 1) {
             return $this->executeToolsSequentially($toolCalls, $meta, $stepNumber);
+        }
+
+        // Sub-agent delegation runs nested executions through the shared (scoped)
+        // ExecutionService. Under fork-based concurrency the child's tracking state
+        // never propagates back to the parent process, which would corrupt the
+        // parent's execution context. Run the whole batch sequentially if any tool
+        // delegates, so lineage tracking stays correct.
+        foreach ($toolCalls as $toolCall) {
+            if ($this->toolExecutor->isDelegation($toolCall->name)) {
+                return $this->executeToolsSequentially($toolCalls, $meta, $stepNumber);
+            }
         }
 
         $toolCalls = array_values($toolCalls);

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -390,7 +390,7 @@ class AgentExecutor
         }
 
         /** @var array<int, ToolResult> $results */
-        $results = Concurrency::driver($driver)->run($tasks);
+        $results = $this->runConcurrentTasks($driver, $tasks);
 
         // Post-process: fire completion or error events
         foreach ($results as $result) {
@@ -435,6 +435,20 @@ class AgentExecutor
         foreach (array_keys(DB::getConnections()) as $name) {
             DB::purge($name);
         }
+    }
+
+    /**
+     * Dispatch the prepared tool tasks on the resolved concurrency driver.
+     *
+     * Isolated from executeToolsConcurrently so the fork DB-safety guard and the
+     * driver dispatch can be exercised independently in tests without forking.
+     *
+     * @param  array<int, callable(): ToolResult>  $tasks
+     * @return array<int, ToolResult>
+     */
+    protected function runConcurrentTasks(string $driver, array $tasks): array
+    {
+        return Concurrency::driver($driver)->run($tasks);
     }
 
     /**

--- a/src/Executor/ToolExecutor.php
+++ b/src/Executor/ToolExecutor.php
@@ -36,4 +36,12 @@ class ToolExecutor
             content: ToolSerializer::serialize($result),
         );
     }
+
+    /**
+     * Whether the named tool delegates to a sub-agent.
+     */
+    public function isDelegation(string $name): bool
+    {
+        return $this->registry->has($name) && $this->registry->resolve($name)->isDelegation();
+    }
 }

--- a/src/Middleware/ToolContext.php
+++ b/src/Middleware/ToolContext.php
@@ -21,5 +21,6 @@ class ToolContext
         public array $meta = [],
         public readonly ?int $stepNumber = null,
         public readonly ?string $agentKey = null,
+        public readonly bool $isDelegation = false,
     ) {}
 }

--- a/src/Pending/AgentRequest.php
+++ b/src/Pending/AgentRequest.php
@@ -55,6 +55,7 @@ use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\VoiceSession;
 use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\AgentTool;
 use Atlasphp\Atlas\Tools\Tool;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -86,6 +87,12 @@ class AgentRequest implements QueueableRequest
     use NormalizesMessages;
 
     // ─── Runtime overrides ──────────────────────────────────────────
+
+    /**
+     * Pre-resolved agent instance. When set, resolveAgent() uses it instead
+     * of looking the agent up by key — used to run unregistered sub-agents.
+     */
+    protected ?Agent $agentInstance = null;
 
     protected ?string $instructionsOverride = null;
 
@@ -789,11 +796,34 @@ class AgentRequest implements QueueableRequest
     // ─── Internal: Resolution ───────────────────────────────────────
 
     /**
+     * Run a pre-resolved agent instance instead of resolving by key.
+     *
+     * Lets callers (e.g. AgentTool sub-agent delegation) execute an agent that
+     * may not be registered in the AgentRegistry.
+     */
+    public function forInstance(Agent $agent): static
+    {
+        $this->agentInstance = $agent;
+
+        return $this;
+    }
+
+    /**
+     * The target agent: a pre-resolved instance (via forInstance) or the
+     * registered agent for this request's key. Single source of truth so the
+     * instance-preference never diverges between resolution sites.
+     */
+    protected function lookupAgent(): Agent
+    {
+        return $this->agentInstance ?? $this->agentRegistry->resolve($this->key);
+    }
+
+    /**
      * Resolve the agent instance and transfer conversation state.
      */
     protected function resolveAgent(): Agent
     {
-        $agent = $this->agentRegistry->resolve($this->key);
+        $agent = $this->lookupAgent();
 
         $this->transferConversationState($agent);
 
@@ -866,7 +896,13 @@ class AgentRequest implements QueueableRequest
 
         foreach ($raw as $item) {
             if ($item instanceof Tool) {
+                // Includes an explicit AgentTool::for($agent).
                 $tools[] = $item;
+            } elseif ($item instanceof Agent) {
+                // Implicit: an agent listed in tools() becomes a delegation tool.
+                $tools[] = AgentTool::for($item);
+            } elseif (is_string($item) && is_subclass_of($item, Agent::class)) {
+                $tools[] = AgentTool::for($this->app->make($item));
             } elseif (is_string($item) && class_exists($item)) {
                 $tools[] = $this->app->make($item);
             } elseif (is_string($item)) {
@@ -896,6 +932,13 @@ class AgentRequest implements QueueableRequest
      */
     protected function buildRequest(Agent $agent, array $tools): TextRequest
     {
+        // Forward the consumer's own variables to any sub-agents, captured before
+        // this agent's identity is injected (identity is per-agent and must not
+        // leak downward). AgentTool reads this and re-applies via withVariables().
+        if ($this->variables !== []) {
+            $this->meta[AgentTool::VARIABLES_META_KEY] = $this->variables;
+        }
+
         // Inject agent identity variables
         $this->variables = array_merge([
             'NAME' => $agent->name(),
@@ -1252,7 +1295,7 @@ class AgentRequest implements QueueableRequest
             return Provider::normalize($this->providerOverride);
         }
 
-        $agent = $this->agentRegistry->resolve($this->key);
+        $agent = $this->lookupAgent();
         $provider = $agent->provider();
 
         if ($provider !== null) {
@@ -1271,8 +1314,6 @@ class AgentRequest implements QueueableRequest
             return $this->modelOverride;
         }
 
-        $agent = $this->agentRegistry->resolve($this->key);
-
-        return $agent->model() ?? (string) ($this->config->defaultFor('text')['model'] ?? '');
+        return $this->lookupAgent()->model() ?? (string) ($this->config->defaultFor('text')['model'] ?? '');
     }
 }

--- a/src/Persistence/Enums/ToolCallType.php
+++ b/src/Persistence/Enums/ToolCallType.php
@@ -12,4 +12,5 @@ enum ToolCallType: string
     case Local = 'local';
     case Mcp = 'mcp';
     case Provider = 'provider';
+    case Agent = 'agent';
 }

--- a/src/Persistence/Middleware/TrackToolCall.php
+++ b/src/Persistence/Middleware/TrackToolCall.php
@@ -7,6 +7,7 @@ namespace Atlasphp\Atlas\Persistence\Middleware;
 use Atlasphp\Atlas\Executor\ToolResult;
 use Atlasphp\Atlas\Middleware\Contracts\ToolMiddleware;
 use Atlasphp\Atlas\Middleware\ToolContext;
+use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
 use Atlasphp\Atlas\Persistence\Services\ExecutionService;
 use Closure;
 
@@ -31,7 +32,8 @@ class TrackToolCall implements ToolMiddleware
         }
 
         // ── Create tool call in pending, begin processing ────────
-        $record = $this->executionService->createToolCall($context->toolCall, meta: $context->meta);
+        $type = $context->isDelegation ? ToolCallType::Agent : ToolCallType::Local;
+        $record = $this->executionService->createToolCall($context->toolCall, $type, meta: $context->meta);
         $startTime = $this->executionService->beginToolCall($record);
 
         try {

--- a/src/Persistence/Models/Execution.php
+++ b/src/Persistence/Models/Execution.php
@@ -29,6 +29,9 @@ use Illuminate\Support\Str;
  *
  * @property int $id
  * @property int|null $conversation_id
+ * @property int|null $parent_execution_id
+ * @property int|null $parent_tool_call_id
+ * @property int $depth
  * @property string|null $agent
  * @property ExecutionType $type
  * @property string $provider
@@ -55,6 +58,9 @@ class Execution extends Model
 
     protected $fillable = [
         'conversation_id',
+        'parent_execution_id',
+        'parent_tool_call_id',
+        'depth',
         'agent',
         'type',
         'provider',
@@ -78,6 +84,7 @@ class Execution extends Model
             'started_at' => 'datetime',
             'completed_at' => 'datetime',
             'duration_ms' => 'integer',
+            'depth' => 'integer',
         ];
     }
 
@@ -135,6 +142,87 @@ class Execution extends Model
         $model = app(AtlasConfig::class)->model('asset', Asset::class);
 
         return $this->hasMany($model);
+    }
+
+    // ─── Delegation lineage ─────────────────────────────────────
+
+    /**
+     * The parent execution that delegated to this one (sub-agent runs).
+     *
+     * @return BelongsTo<Execution, $this>
+     */
+    public function parent(): BelongsTo
+    {
+        /** @var class-string<Execution> $model */
+        $model = app(AtlasConfig::class)->model('execution', self::class);
+
+        return $this->belongsTo($model, 'parent_execution_id');
+    }
+
+    /**
+     * Child executions spawned by this one via sub-agent delegation.
+     *
+     * @return HasMany<Execution, $this>
+     */
+    public function children(): HasMany
+    {
+        /** @var class-string<Execution> $model */
+        $model = app(AtlasConfig::class)->model('execution', self::class);
+
+        return $this->hasMany($model, 'parent_execution_id');
+    }
+
+    /**
+     * The delegating tool call that spawned this execution.
+     *
+     * @return BelongsTo<ExecutionToolCall, $this>
+     */
+    public function parentToolCall(): BelongsTo
+    {
+        /** @var class-string<ExecutionToolCall> $model */
+        $model = app(AtlasConfig::class)->model('execution_tool_call', ExecutionToolCall::class);
+
+        return $this->belongsTo($model, 'parent_tool_call_id');
+    }
+
+    /**
+     * Token usage for this execution plus all descendant (sub-agent) executions.
+     *
+     * Sums input/output/total tokens across the whole delegation subtree, so an
+     * orchestrator's true cost — including every sub-agent it delegated to — is
+     * available from the root. Sweeps the tree breadth-first, one query per
+     * depth level (bounded by max_delegation_depth), never one query per node.
+     *
+     * @return array{input_tokens: int, output_tokens: int, total_tokens: int}
+     */
+    public function totalUsage(): array
+    {
+        $usage = $this->usage ?? [];
+        $input = (int) ($usage['input_tokens'] ?? 0);
+        $output = (int) ($usage['output_tokens'] ?? 0);
+
+        $frontier = [$this->getKey()];
+
+        while ($frontier !== []) {
+            $children = static::query()
+                ->whereIn('parent_execution_id', $frontier)
+                ->get(['id', 'usage']);
+
+            $frontier = [];
+
+            foreach ($children as $child) {
+                $childUsage = $child->usage ?? [];
+                $input += (int) ($childUsage['input_tokens'] ?? 0);
+                $output += (int) ($childUsage['output_tokens'] ?? 0);
+                $frontier[] = $child->getKey();
+            }
+        }
+
+        return [
+            'input_tokens' => $input,
+            'output_tokens' => $output,
+            'total_tokens' => $input + $output,
+        ];
     }
 
     // ─── Lifecycle ──────────────────────────────────────────────

--- a/src/Persistence/Services/ExecutionService.php
+++ b/src/Persistence/Services/ExecutionService.php
@@ -48,6 +48,16 @@ class ExecutionService
     /** @var float Precise start time for current step duration */
     protected float $stepStartTime = 0;
 
+    /**
+     * Snapshots of the active execution context, pushed when a sub-agent run
+     * creates a nested execution and popped when it completes. Lets the single
+     * scoped service track a parent → child delegation tree without losing the
+     * parent's in-flight state.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected array $contextStack = [];
+
     /** @var class-string<Execution> */
     private readonly string $executionModel;
 
@@ -94,8 +104,22 @@ class ExecutionService
     ): Execution {
         $executionModel = $this->executionModel;
 
-        $this->execution = $executionModel::create([
+        // A new execution created while another is mid-tool-call is a nested
+        // (sub-agent) run: the sub-agent runs inside the parent's delegating
+        // tool call. Capture the parent link + a snapshot to restore on
+        // completion. (A merely-active-but-idle execution from a prior run is
+        // NOT nesting — gating on currentToolCall avoids that false positive.)
+        $nested = $this->execution !== null && $this->currentToolCall !== null;
+        $snapshot = $nested ? $this->snapshotContext() : null;
+        $parentExecutionId = $nested ? $this->execution->id : null;
+        $parentToolCallId = $nested ? $this->currentToolCall->id : null;
+        $depth = $nested ? $this->execution->depth + 1 : 0;
+
+        $execution = $executionModel::create([
             'conversation_id' => $conversationId,
+            'parent_execution_id' => $parentExecutionId,
+            'parent_tool_call_id' => $parentToolCallId,
+            'depth' => $depth,
             'agent' => $agent,
             'type' => $type ?? ExecutionType::Text,
             'provider' => $provider,
@@ -103,6 +127,14 @@ class ExecutionService
             'status' => ExecutionStatus::Pending,
             'metadata' => ! empty($meta) ? $this->filterMetaForStorage($meta) : null,
         ]);
+
+        // Only mutate service state once the child record exists, so a failed
+        // create leaves the parent context fully intact (no leaked snapshot).
+        if ($snapshot !== null) {
+            $this->contextStack[] = $snapshot;
+        }
+
+        $this->execution = $execution;
 
         // Link the trigger message to this execution (message owns the FK)
         if ($messageId !== null) {
@@ -186,6 +218,8 @@ class ExecutionService
         }
 
         $this->execution->markCompleted($this->elapsedMs($this->executionStartTime), $usage);
+
+        $this->restoreParentContext();
     }
 
     /**
@@ -208,6 +242,47 @@ class ExecutionService
             get_class($exception).': '.$exception->getMessage(),
             $durationMs,
         );
+
+        $this->restoreParentContext();
+    }
+
+    /**
+     * Capture the active execution context for later restoration.
+     *
+     * @return array<string, mixed>
+     */
+    protected function snapshotContext(): array
+    {
+        return [
+            'execution' => $this->execution,
+            'currentStep' => $this->currentStep,
+            'currentToolCall' => $this->currentToolCall,
+            'lastAsset' => $this->lastAsset,
+            'stepSequence' => $this->stepSequence,
+            'executionStartTime' => $this->executionStartTime,
+            'stepStartTime' => $this->stepStartTime,
+        ];
+    }
+
+    /**
+     * Restore the parent execution context after a nested sub-agent run.
+     * No-op when not nested (the stack is empty).
+     */
+    protected function restoreParentContext(): void
+    {
+        $snapshot = array_pop($this->contextStack);
+
+        if ($snapshot === null) {
+            return;
+        }
+
+        $this->execution = $snapshot['execution'] instanceof Execution ? $snapshot['execution'] : null;
+        $this->currentStep = $snapshot['currentStep'] instanceof ExecutionStep ? $snapshot['currentStep'] : null;
+        $this->currentToolCall = $snapshot['currentToolCall'] instanceof ExecutionToolCall ? $snapshot['currentToolCall'] : null;
+        $this->lastAsset = $snapshot['lastAsset'] instanceof Asset ? $snapshot['lastAsset'] : null;
+        $this->stepSequence = (int) $snapshot['stepSequence'];
+        $this->executionStartTime = (float) $snapshot['executionStartTime'];
+        $this->stepStartTime = (float) $snapshot['stepStartTime'];
     }
 
     // ─── Step Lifecycle ─────────────────────────────────────────
@@ -286,7 +361,7 @@ class ExecutionService
         }
 
         $toolCallModel = $this->toolCallModel;
-        $metadata = $this->toolCallMetadata($toolCall, $meta);
+        $metadata = $this->filterMetaForStorage($this->toolCallMetadata($toolCall, $meta));
 
         $this->currentToolCall = $toolCallModel::create([
             'execution_id' => $this->execution->id,
@@ -296,7 +371,7 @@ class ExecutionService
             'type' => $type,
             'status' => ExecutionStatus::Pending,
             'arguments' => $toolCall->arguments,
-            'metadata' => $metadata !== [] ? $metadata : null,
+            'metadata' => $metadata,
         ]);
 
         return $this->currentToolCall;
@@ -367,6 +442,10 @@ class ExecutionService
             'completed_at' => now(),
             'duration_ms' => $this->elapsedMs($this->executionStartTime),
         ]);
+
+        // Symmetry with complete/failExecution: pop any nested context. A no-op
+        // when not nested (empty stack), so the next run starts clean.
+        $this->restoreParentContext();
     }
 
     // ─── Asset Linking ──────────────────────────────────────────
@@ -490,6 +569,7 @@ class ExecutionService
         $this->stepSequence = 1;
         $this->executionStartTime = 0;
         $this->stepStartTime = 0;
+        $this->contextStack = [];
     }
 
     /**

--- a/src/Tools/AgentTool.php
+++ b/src/Tools/AgentTool.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Tools;
+
+use Atlasphp\Atlas\Agent;
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Exceptions\DelegationCycleException;
+use Atlasphp\Atlas\Exceptions\MaxDelegationDepthException;
+use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Schema\Fields\Field;
+use Atlasphp\Atlas\Schema\Fields\StringField;
+use Illuminate\Support\Arr;
+use Throwable;
+
+/**
+ * Wraps an Agent so it can be used as a tool by another agent (sub-agent delegation).
+ *
+ * The parent model sees a single tool taking one string argument, `task`. When
+ * called, the sub-agent runs in isolation — its own instructions, model, tools,
+ * and (empty) history — and its final text is returned to the parent as the tool
+ * result. Depth and cycle guards prevent runaway nesting; the delegation chain is
+ * threaded through tool-call meta so it survives across levels.
+ */
+class AgentTool extends Tool
+{
+    /** Meta key carrying the current delegation depth. */
+    public const DEPTH_META_KEY = '_atlas_delegation_depth';
+
+    /** Meta key carrying the chain of agent keys delegated through so far. */
+    public const CHAIN_META_KEY = '_atlas_delegation_chain';
+
+    /** Meta key carrying the consumer's variables to forward to sub-agents. */
+    public const VARIABLES_META_KEY = '_atlas_variables';
+
+    public function __construct(
+        protected readonly Agent $agent,
+        protected readonly ?string $nameOverride = null,
+        protected readonly ?string $descriptionOverride = null,
+    ) {}
+
+    /**
+     * Wrap an agent for use as a delegation tool.
+     */
+    public static function for(Agent $agent, ?string $name = null, ?string $description = null): self
+    {
+        return new self($agent, $name, $description);
+    }
+
+    public function name(): string
+    {
+        return $this->nameOverride ?? $this->agent->key();
+    }
+
+    public function description(): string
+    {
+        return $this->descriptionOverride
+            ?? $this->agent->description()
+            ?? sprintf(
+                'Delegates a task to the "%s" sub-agent and returns its response. It runs in '
+                .'isolation with no access to this conversation, so pass a clear, self-contained task.',
+                $this->name(),
+            );
+    }
+
+    /**
+     * @return array<int, Field>
+     */
+    public function parameters(): array
+    {
+        return [
+            new StringField('task', 'The self-contained task to delegate to this sub-agent.'),
+        ];
+    }
+
+    public function isDelegation(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $args
+     * @param  array<string, mixed>  $context
+     */
+    public function handle(array $args, array $context): string
+    {
+        $key = $this->agent->key();
+        $depth = (int) ($context[self::DEPTH_META_KEY] ?? 0);
+        /** @var array<int, string> $chain */
+        $chain = (array) ($context[self::CHAIN_META_KEY] ?? []);
+
+        // Guards run unconditionally — structural misuse should always surface.
+        if (in_array($key, $chain, true)) {
+            throw new DelegationCycleException($key, $chain);
+        }
+
+        $maxDepth = (int) config('atlas.agents.max_delegation_depth', 5);
+
+        if ($depth >= $maxDepth) {
+            throw new MaxDelegationDepthException($maxDepth, $key);
+        }
+
+        $task = isset($args['task']) && is_string($args['task']) ? $args['task'] : '';
+
+        // The parent's own variables, forwarded so the sub-agent's prompt gets
+        // the same dynamic injection (e.g. {user_name}) as if called directly.
+        /** @var array<string, mixed> $parentVariables */
+        $parentVariables = is_array($context[self::VARIABLES_META_KEY] ?? null)
+            ? $context[self::VARIABLES_META_KEY]
+            : [];
+
+        // Inherit caller context (auth/tenant/conversation) but never the parent's
+        // own persistence routing keys or the raw variables bag (applied below via
+        // withVariables), so the sub-agent gets its own execution + clean meta.
+        $childMeta = array_merge(
+            Arr::except($context, ['execution_id', 'trigger_message_id', 'execution_type', self::VARIABLES_META_KEY]),
+            [
+                self::DEPTH_META_KEY => $depth + 1,
+                self::CHAIN_META_KEY => [...$chain, $key],
+            ],
+        );
+
+        try {
+            // Run the sub-agent instance through the normal pipeline (forInstance
+            // bypasses the registry key lookup) so it gets full execution tracking.
+            $request = Atlas::agent($this->agent->key())
+                ->forInstance($this->agent)
+                ->withMeta($childMeta);
+
+            if ($parentVariables !== []) {
+                $request = $request->withVariables($parentVariables);
+            }
+
+            $response = $request->message($task)->asText();
+
+            return $response instanceof TextResponse ? $response->text : '';
+        } catch (Throwable $e) {
+            if (config('atlas.agents.delegation_errors', 'throw') === 'return') {
+                return "Sub-agent '{$key}' failed: ".$e->getMessage();
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Tools/Tool.php
+++ b/src/Tools/Tool.php
@@ -45,6 +45,17 @@ abstract class Tool
     }
 
     /**
+     * Whether this tool delegates to a sub-agent.
+     *
+     * Lets the persistence layer classify the resulting tool call without
+     * coupling the Tools layer to persistence enums. Overridden by AgentTool.
+     */
+    public function isDelegation(): bool
+    {
+        return false;
+    }
+
+    /**
      * Convert to a ToolDefinition for the driver layer.
      */
     public function toDefinition(): ToolDefinition

--- a/tests/Feature/Persistence/SubAgentDelegationTest.php
+++ b/tests/Feature/Persistence/SubAgentDelegationTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Agent;
+use Atlasphp\Atlas\AgentRegistry;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Messages\ToolCall;
+use Atlasphp\Atlas\Pending\AgentRequest;
+use Atlasphp\Atlas\Persistence\Enums\ExecutionStatus;
+use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
+use Atlasphp\Atlas\Persistence\Middleware\PersistConversation;
+use Atlasphp\Atlas\Persistence\Middleware\TrackExecution;
+use Atlasphp\Atlas\Persistence\Middleware\TrackProviderCall;
+use Atlasphp\Atlas\Persistence\Middleware\TrackStep;
+use Atlasphp\Atlas\Persistence\Middleware\TrackToolCall;
+use Atlasphp\Atlas\Persistence\Models\Execution;
+use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Responses\Usage;
+use Atlasphp\Atlas\Testing\AtlasFake;
+use Atlasphp\Atlas\Testing\TextResponseFake;
+use Illuminate\Contracts\Events\Dispatcher;
+
+// ─── Test agents ────────────────────────────────────────────────────────────
+
+class DelegateSpecialistAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'specialist-d';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You know secret codes.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+}
+
+class DelegateOrchestratorAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'orchestrator-d';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o';
+    }
+
+    public function maxSteps(): ?int
+    {
+        return 5;
+    }
+
+    public function tools(): array
+    {
+        return [DelegateSpecialistAgent::class];
+    }
+}
+
+class VarSpecialistAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'var-specialist';
+    }
+
+    public function instructions(): ?string
+    {
+        return 'You are speaking with {user_name}. Answer their question.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o-mini';
+    }
+}
+
+class VarOrchestratorAgent extends DelegateOrchestratorAgent
+{
+    public function key(): string
+    {
+        return 'var-orchestrator';
+    }
+
+    public function tools(): array
+    {
+        return [VarSpecialistAgent::class];
+    }
+}
+
+function makeDelegationRequest(string $key): AgentRequest
+{
+    return new AgentRequest(
+        key: $key,
+        agentRegistry: app(AgentRegistry::class),
+        providerRegistry: app(ProviderRegistryContract::class),
+        app: app(),
+        events: app(Dispatcher::class),
+        config: app(AtlasConfig::class),
+    );
+}
+
+/** Fake sequence: orchestrator delegates → specialist answers → orchestrator finalises. */
+function fakeDelegationConversation(): AtlasFake
+{
+    return new AtlasFake(app(ProviderRegistryContract::class), [
+        TextResponseFake::make()->withToolCalls([
+            new ToolCall(id: 'call_d1', name: 'specialist-d', arguments: ['task' => 'find the code']),
+        ]),
+        TextResponseFake::make()->withText('the code is ZULU')->withUsage(new Usage(inputTokens: 3, outputTokens: 4)),
+        TextResponseFake::make()->withText('Done. The code is ZULU.')->withUsage(new Usage(inputTokens: 10, outputTokens: 5)),
+    ]);
+}
+
+beforeEach(function () {
+    // PersistenceTestCase enables persistence after the provider registers, so the
+    // tracking middleware isn't in the AtlasConfig snapshot. Wire it up explicitly.
+    config(['atlas.middleware' => [
+        PersistConversation::class,
+        TrackExecution::class,
+        TrackStep::class,
+        TrackToolCall::class,
+        TrackProviderCall::class,
+    ]]);
+    AtlasConfig::refresh();
+
+    app(AgentRegistry::class)->register(DelegateSpecialistAgent::class);
+    app(AgentRegistry::class)->register(DelegateOrchestratorAgent::class);
+    app(AgentRegistry::class)->register(VarSpecialistAgent::class);
+    app(AgentRegistry::class)->register(VarOrchestratorAgent::class);
+});
+
+it('delegates to a sub-agent and returns its contribution', function () {
+    fakeDelegationConversation();
+
+    $response = makeDelegationRequest('orchestrator-d')->message('what is the code?')->asText();
+
+    expect($response->text)->toContain('ZULU');
+});
+
+it('records an auditable parent → child execution tree', function () {
+    fakeDelegationConversation();
+
+    makeDelegationRequest('orchestrator-d')->message('what is the code?')->asText();
+
+    expect(Execution::count())->toBe(2);
+
+    $parent = Execution::whereNull('parent_execution_id')->firstOrFail();
+    $child = Execution::whereNotNull('parent_execution_id')->firstOrFail();
+
+    // Lineage.
+    expect($parent->agent)->toBe('orchestrator-d')
+        ->and($parent->depth)->toBe(0)
+        ->and($child->agent)->toBe('specialist-d')
+        ->and($child->depth)->toBe(1)
+        ->and($child->parent_execution_id)->toBe($parent->id);
+
+    // The delegating tool call is typed 'agent', links the child, and its
+    // recorded result is exactly the sub-agent's answer handed back to the parent.
+    $delegation = ExecutionToolCall::where('type', ToolCallType::Agent->value)->firstOrFail();
+    expect($delegation->name)->toBe('specialist-d')
+        ->and($child->parent_tool_call_id)->toBe($delegation->id)
+        ->and($delegation->result)->toBe('the code is ZULU');
+
+    // Tree relations + usage roll-up.
+    expect($parent->children)->toHaveCount(1)
+        ->and($parent->children->first()->id)->toBe($child->id);
+
+    // Tree-summed usage rolls the child's tokens into the parent's own total.
+    $ownTotal = ($parent->usage['input_tokens'] ?? 0) + ($parent->usage['output_tokens'] ?? 0);
+    $childTotal = ($child->usage['input_tokens'] ?? 0) + ($child->usage['output_tokens'] ?? 0);
+    expect($childTotal)->toBeGreaterThan(0)
+        ->and($parent->totalUsage()['total_tokens'])->toBe($ownTotal + $childTotal)
+        ->and($parent->totalUsage()['total_tokens'])->toBeGreaterThan($ownTotal);
+});
+
+it('runs the sub-agent in isolation from the parent conversation', function () {
+    $fake = fakeDelegationConversation();
+
+    makeDelegationRequest('orchestrator-d')->message('what is the code?')->asText();
+
+    // The specialist request (gpt-4o-mini) carries only the delegated task,
+    // not the orchestrator's user message.
+    $specialistRequests = array_filter(
+        $fake->driver('openai')->recorded(),
+        fn ($r) => $r->model === 'gpt-4o-mini',
+    );
+
+    expect($specialistRequests)->toHaveCount(1);
+
+    $request = array_values($specialistRequests)[0]->request;
+    expect($request->message)->toBe('find the code')
+        ->and($request->message)->not->toContain('what is the code?');
+});
+
+it('lets the parent recover and still respond when a delegation fails', function () {
+    // Block delegation so the sub-agent call fails inside the tool.
+    config(['atlas.agents.max_delegation_depth' => 0]);
+
+    new AtlasFake(app(ProviderRegistryContract::class), [
+        TextResponseFake::make()->withToolCalls([
+            new ToolCall(id: 'call_f1', name: 'specialist-d', arguments: ['task' => 'find the code']),
+        ]),
+        TextResponseFake::make()->withText('Sorry, I could not reach the specialist.'),
+    ]);
+
+    $response = makeDelegationRequest('orchestrator-d')->message('what is the code?')->asText();
+
+    // The parent received the failure as a tool result and produced a final answer.
+    expect($response->text)->toContain('Sorry');
+
+    // No child execution was created; the delegating tool call is recorded as failed.
+    expect(Execution::whereNotNull('parent_execution_id')->count())->toBe(0);
+
+    $delegation = ExecutionToolCall::where('type', ToolCallType::Agent->value)->firstOrFail();
+    expect($delegation->status)->toBe(ExecutionStatus::Failed)
+        ->and($delegation->result)->toContain('maximum depth');
+});
+
+it('forwards parent per-call variables into the sub-agent prompt', function () {
+    $fake = new AtlasFake(app(ProviderRegistryContract::class), [
+        TextResponseFake::make()->withToolCalls([
+            new ToolCall(id: 'call_v1', name: 'var-specialist', arguments: ['task' => 'say hi']),
+        ]),
+        TextResponseFake::make()->withText('Hi!'),
+        TextResponseFake::make()->withText('Done.'),
+    ]);
+
+    // user_name is set ONLY via the parent's per-call withVariables() — it must
+    // still reach the sub-agent's prompt.
+    makeDelegationRequest('var-orchestrator')
+        ->withVariables(['user_name' => 'Tim'])
+        ->message('greet me')
+        ->asText();
+
+    // The sub-agent (gpt-4o-mini) received fully interpolated instructions,
+    // exactly as if it had been called as a top-level agent.
+    $specialistRequests = array_values(array_filter(
+        $fake->driver('openai')->recorded(),
+        fn ($r) => $r->model === 'gpt-4o-mini',
+    ));
+
+    expect($specialistRequests)->toHaveCount(1)
+        ->and($specialistRequests[0]->request->instructions)
+        ->toBe('You are speaking with Tim. Answer their question.');
+});

--- a/tests/Unit/Executor/AgentExecutorTest.php
+++ b/tests/Unit/Executor/AgentExecutorTest.php
@@ -28,6 +28,7 @@ use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Tools\Tool;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\DB;
 
 function makeTextRequest(): TextRequest
 {
@@ -1192,11 +1193,11 @@ it('executes a concurrent batch containing a delegation tool through the concurr
     expect($completed)->toHaveCount(2);
 });
 
-it('does not reset database connections in the concurrent path when persistence is disabled', function () {
-    // Safety guard: the fork DB-reset must NEVER fire when persistence is off, so
-    // an in-memory test database (which exists only for the life of its connection)
-    // is never dropped out from under a concurrent run. The fork+persistence path
-    // that does reset connections is covered end-to-end by the live sandbox harness.
+it('does not reset database connections through the real concurrency driver when persistence is disabled', function () {
+    // Integration guard over the real driver path: the fork DB-reset must NEVER
+    // fire when persistence is off, so an in-memory test database (which exists
+    // only for the life of its connection) is never dropped out from under a
+    // concurrent run. Uses the real concurrencyDriver()/Concurrency::run() path.
     config()->set('atlas.persistence.enabled', false);
 
     $driver = makeMockDriver([
@@ -1226,4 +1227,110 @@ it('does not reset database connections in the concurrent path when persistence 
     $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
 
     expect($executor->disconnectCalls)->toBe(0);
+});
+
+/**
+ * Build an AgentExecutor spy that records disconnectDatabase() calls, forces a
+ * concurrency driver, and runs the tool tasks in-process (no real fork) so the
+ * fork DB-safety guard can be asserted deterministically — independent of
+ * whether pcntl/spatie-fork are available in the test environment.
+ */
+function makeForkSafetySpy(string $forcedDriver): AgentExecutor
+{
+    $driver = makeMockDriver([
+        new TextResponse(
+            'working',
+            new Usage(10, 10),
+            FinishReason::ToolCalls,
+            toolCalls: [
+                new ToolCall('tc-1', 'echo', ['text' => 'a']),
+                new ToolCall('tc-2', 'echo', ['text' => 'b']),
+            ],
+        ),
+        new TextResponse('done', new Usage(5, 5), FinishReason::Stop),
+    ]);
+
+    return new class($driver, new ToolExecutor(new ToolRegistry([makeEchoTool()])), makeFakeDispatcher(), $forcedDriver) extends AgentExecutor
+    {
+        public int $disconnectCalls = 0;
+
+        public function __construct(Driver $driver, ToolExecutor $toolExecutor, Dispatcher $events, private readonly string $forcedDriver)
+        {
+            parent::__construct($driver, $toolExecutor, $events);
+        }
+
+        protected function concurrencyDriver(): string
+        {
+            return $this->forcedDriver;
+        }
+
+        protected function disconnectDatabase(): void
+        {
+            $this->disconnectCalls++;
+        }
+
+        /**
+         * @param  array<int, callable>  $tasks
+         * @return array<int, mixed>
+         */
+        protected function runConcurrentTasks(string $driver, array $tasks): array
+        {
+            // Run in-process so we assert the guard, never a real fork.
+            return array_map(fn ($task) => $task(), array_values($tasks));
+        }
+    };
+}
+
+it('resets database connections before forking when the fork driver is active and persistence is enabled', function () {
+    config()->set('atlas.persistence.enabled', true);
+
+    $executor = makeForkSafetySpy('fork');
+    $result = $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
+
+    // The guard fired exactly once, and the tasks still ran and returned results.
+    expect($executor->disconnectCalls)->toBe(1)
+        ->and($result->totalToolCalls())->toBe(2)
+        ->and($result->steps[0]->toolResults[0]->content)->toBe('a')
+        ->and($result->steps[0]->toolResults[1]->content)->toBe('b');
+});
+
+it('does not reset database connections on the sync driver even when persistence is enabled', function () {
+    config()->set('atlas.persistence.enabled', true);
+
+    $executor = makeForkSafetySpy('sync');
+    $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
+
+    // The in-process sync driver shares no fork boundary — resetting would needlessly
+    // drop the live connection (and an in-memory test DB with it).
+    expect($executor->disconnectCalls)->toBe(0);
+});
+
+it('does not reset database connections on the sync driver when persistence is disabled', function () {
+    config()->set('atlas.persistence.enabled', false);
+
+    $executor = makeForkSafetySpy('sync');
+    $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
+
+    expect($executor->disconnectCalls)->toBe(0);
+});
+
+it('disconnectDatabase purges every resolved database connection', function () {
+    // Verify the reset itself: each resolved connection is purged (so forked
+    // children rebuild their own), without depending on a real database.
+    DB::shouldReceive('getConnections')->once()->andReturn(['pgsql' => null, 'analytics' => null]);
+    DB::shouldReceive('purge')->once()->with('pgsql');
+    DB::shouldReceive('purge')->once()->with('analytics');
+
+    $executor = new class(makeMockDriver([new TextResponse('x', new Usage(1, 1), FinishReason::Stop)]), new ToolExecutor(new ToolRegistry([])), makeFakeDispatcher()) extends AgentExecutor
+    {
+        public function callDisconnect(): void
+        {
+            $this->disconnectDatabase();
+        }
+    };
+
+    $executor->callDisconnect();
+
+    // Mockery verifies the purge expectations on teardown.
+    expect(true)->toBeTrue();
 });

--- a/tests/Unit/Executor/AgentExecutorTest.php
+++ b/tests/Unit/Executor/AgentExecutorTest.php
@@ -1138,7 +1138,10 @@ it('creates a working executor via forTools factory', function () {
     expect($result->steps[0]->toolResults[0]->content)->toBe('hello');
 });
 
-it('falls back to sequential execution when a concurrent batch contains a delegation tool', function () {
+it('executes a concurrent batch containing a delegation tool through the concurrent path', function () {
+    // Sub-agent delegations are no longer forced sequential: a batch that mixes a
+    // delegation with a regular tool runs through the concurrent path, and every
+    // tool result still comes back correctly for the parent loop to continue on.
     $delegationTool = new class extends Tool
     {
         public function name(): string
@@ -1181,10 +1184,46 @@ it('falls back to sequential execution when a concurrent batch contains a delega
 
     $result = $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
 
-    // The whole batch still executes correctly via the sequential fallback.
+    // Both tools execute and their results are returned to the parent.
     expect($result->text)->toBe('done')
         ->and($result->totalToolCalls())->toBe(2);
 
     $completed = array_filter($dispatcher->dispatched, fn ($e) => $e instanceof AgentToolCallCompleted);
     expect($completed)->toHaveCount(2);
+});
+
+it('does not reset database connections in the concurrent path when persistence is disabled', function () {
+    // Safety guard: the fork DB-reset must NEVER fire when persistence is off, so
+    // an in-memory test database (which exists only for the life of its connection)
+    // is never dropped out from under a concurrent run. The fork+persistence path
+    // that does reset connections is covered end-to-end by the live sandbox harness.
+    config()->set('atlas.persistence.enabled', false);
+
+    $driver = makeMockDriver([
+        new TextResponse(
+            'working',
+            new Usage(10, 10),
+            FinishReason::ToolCalls,
+            toolCalls: [
+                new ToolCall('tc-1', 'echo', ['text' => 'a']),
+                new ToolCall('tc-2', 'echo', ['text' => 'b']),
+            ],
+        ),
+        new TextResponse('done', new Usage(5, 5), FinishReason::Stop),
+    ]);
+
+    $registry = new ToolRegistry([makeEchoTool()]);
+    $executor = new class($driver, new ToolExecutor($registry), makeFakeDispatcher()) extends AgentExecutor
+    {
+        public int $disconnectCalls = 0;
+
+        protected function disconnectDatabase(): void
+        {
+            $this->disconnectCalls++;
+        }
+    };
+
+    $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
+
+    expect($executor->disconnectCalls)->toBe(0);
 });

--- a/tests/Unit/Executor/AgentExecutorTest.php
+++ b/tests/Unit/Executor/AgentExecutorTest.php
@@ -1137,3 +1137,54 @@ it('creates a working executor via forTools factory', function () {
     expect($result->totalSteps())->toBe(2);
     expect($result->steps[0]->toolResults[0]->content)->toBe('hello');
 });
+
+it('falls back to sequential execution when a concurrent batch contains a delegation tool', function () {
+    $delegationTool = new class extends Tool
+    {
+        public function name(): string
+        {
+            return 'delegate';
+        }
+
+        public function description(): string
+        {
+            return 'Delegates to a sub-agent.';
+        }
+
+        public function isDelegation(): bool
+        {
+            return true;
+        }
+
+        public function handle(array $args, array $context): mixed
+        {
+            return 'delegated-result';
+        }
+    };
+
+    $driver = makeMockDriver([
+        new TextResponse(
+            'working',
+            new Usage(10, 10),
+            FinishReason::ToolCalls,
+            toolCalls: [
+                new ToolCall('tc-1', 'delegate', []),
+                new ToolCall('tc-2', 'echo', ['text' => 'hi']),
+            ],
+        ),
+        new TextResponse('done', new Usage(5, 5), FinishReason::Stop),
+    ]);
+
+    $dispatcher = makeFakeDispatcher();
+    $registry = new ToolRegistry([$delegationTool, makeEchoTool()]);
+    $executor = new AgentExecutor($driver, new ToolExecutor($registry), $dispatcher);
+
+    $result = $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
+
+    // The whole batch still executes correctly via the sequential fallback.
+    expect($result->text)->toBe('done')
+        ->and($result->totalToolCalls())->toBe(2);
+
+    $completed = array_filter($dispatcher->dispatched, fn ($e) => $e instanceof AgentToolCallCompleted);
+    expect($completed)->toHaveCount(2);
+});

--- a/tests/Unit/Executor/ToolExecutorTest.php
+++ b/tests/Unit/Executor/ToolExecutorTest.php
@@ -128,3 +128,52 @@ it('does not catch handle exceptions', function () {
 
     $executor->execute(new ToolCall('tc-1', 'exploder', []), []);
 })->throws(InvalidArgumentException::class, 'Boom!');
+
+it('reports whether a named tool is a delegation tool', function () {
+    $normal = new class extends Tool
+    {
+        public function name(): string
+        {
+            return 'normal';
+        }
+
+        public function description(): string
+        {
+            return 'A normal tool.';
+        }
+
+        public function handle(array $args, array $context): mixed
+        {
+            return 'ok';
+        }
+    };
+
+    $delegating = new class extends Tool
+    {
+        public function name(): string
+        {
+            return 'delegate';
+        }
+
+        public function description(): string
+        {
+            return 'A delegation tool.';
+        }
+
+        public function isDelegation(): bool
+        {
+            return true;
+        }
+
+        public function handle(array $args, array $context): mixed
+        {
+            return 'ok';
+        }
+    };
+
+    $executor = new ToolExecutor(new ToolRegistry([$normal, $delegating]));
+
+    expect($executor->isDelegation('delegate'))->toBeTrue()
+        ->and($executor->isDelegation('normal'))->toBeFalse()
+        ->and($executor->isDelegation('does-not-exist'))->toBeFalse();
+});

--- a/tests/Unit/Pending/AgentRequestSubAgentTest.php
+++ b/tests/Unit/Pending/AgentRequestSubAgentTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Agent;
+use Atlasphp\Atlas\AgentRegistry;
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Exceptions\AgentNotFoundException;
+use Atlasphp\Atlas\Pending\AgentRequest;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Testing\AtlasFake;
+use Atlasphp\Atlas\Testing\TextResponseFake;
+use Atlasphp\Atlas\Tools\AgentTool;
+use Atlasphp\Atlas\Tools\Tool;
+use Illuminate\Contracts\Events\Dispatcher;
+
+class WrapSpecialistAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'wrap-specialist';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o';
+    }
+}
+
+class WrapPlainSubAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'wrap-plain';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o';
+    }
+}
+
+class WrapEchoTool extends Tool
+{
+    public function name(): string
+    {
+        return 'echo';
+    }
+
+    public function description(): string
+    {
+        return 'Echoes input.';
+    }
+
+    public function handle(array $args, array $context): mixed
+    {
+        return 'echo';
+    }
+}
+
+function makeSubAgentRequest(string $key = 'host'): AgentRequest
+{
+    return new AgentRequest(
+        key: $key,
+        agentRegistry: app(AgentRegistry::class),
+        providerRegistry: app(ProviderRegistryContract::class),
+        app: app(),
+        events: app(Dispatcher::class),
+        config: app(AtlasConfig::class),
+    );
+}
+
+/**
+ * @return array<int, Tool>
+ */
+function resolveToolsFor(Agent $agent): array
+{
+    $request = makeSubAgentRequest();
+    $method = new ReflectionMethod($request, 'resolveTools');
+    $method->setAccessible(true);
+
+    /** @var array<int, Tool> $tools */
+    $tools = $method->invoke($request, $agent);
+
+    return $tools;
+}
+
+it('auto-wraps an Agent instance in tools() as an AgentTool', function () {
+    $agent = new class extends Agent
+    {
+        public function tools(): array
+        {
+            return [new WrapSpecialistAgent];
+        }
+    };
+
+    $tools = resolveToolsFor($agent);
+
+    expect($tools)->toHaveCount(1)
+        ->and($tools[0])->toBeInstanceOf(AgentTool::class)
+        ->and($tools[0]->name())->toBe('wrap-specialist')
+        ->and($tools[0]->isDelegation())->toBeTrue();
+});
+
+it('auto-wraps an Agent class-string in tools() as an AgentTool', function () {
+    $agent = new class extends Agent
+    {
+        public function tools(): array
+        {
+            return [WrapPlainSubAgent::class];
+        }
+    };
+
+    $tools = resolveToolsFor($agent);
+
+    expect($tools[0])->toBeInstanceOf(AgentTool::class)
+        ->and($tools[0]->name())->toBe('wrap-plain');
+});
+
+it('passes through an explicit AgentTool and normal tools unchanged', function () {
+    $agent = new class extends Agent
+    {
+        public function tools(): array
+        {
+            return [
+                AgentTool::for(new WrapPlainSubAgent, 'ask_plain'),
+                new WrapEchoTool,
+                WrapEchoTool::class,
+            ];
+        }
+    };
+
+    $tools = resolveToolsFor($agent);
+
+    expect($tools)->toHaveCount(3)
+        ->and($tools[0])->toBeInstanceOf(AgentTool::class)
+        ->and($tools[0]->name())->toBe('ask_plain')
+        ->and($tools[1])->toBeInstanceOf(WrapEchoTool::class)
+        ->and($tools[1]->isDelegation())->toBeFalse()
+        ->and($tools[2])->toBeInstanceOf(WrapEchoTool::class);
+});
+
+it('runs an unregistered agent instance via forInstance()', function () {
+    new AtlasFake(app(ProviderRegistryContract::class), [
+        TextResponseFake::make()->withText('ran via instance'),
+    ]);
+
+    // WrapSpecialistAgent is NOT registered in the AgentRegistry.
+    $response = Atlas::agent('wrap-specialist')
+        ->forInstance(new WrapSpecialistAgent)
+        ->message('hello')
+        ->asText();
+
+    expect($response->text)->toBe('ran via instance');
+});
+
+it('throws for an unregistered key without forInstance', function () {
+    makeSubAgentRequest('definitely-not-registered')->message('hi')->asText();
+})->throws(AgentNotFoundException::class);
+
+it('resolves provider and model from the instance, not the registry', function () {
+    // Key is not registered — only forInstance() can satisfy these.
+    $request = makeSubAgentRequest('definitely-not-registered')->forInstance(new WrapSpecialistAgent);
+
+    $providerKey = new ReflectionMethod($request, 'resolveProviderKey');
+    $providerKey->setAccessible(true);
+    $modelKey = new ReflectionMethod($request, 'resolveModelKey');
+    $modelKey->setAccessible(true);
+
+    expect($providerKey->invoke($request))->toBe('openai')
+        ->and($modelKey->invoke($request))->toBe('gpt-4o');
+});

--- a/tests/Unit/Persistence/ExecutionServiceNestedContextTest.php
+++ b/tests/Unit/Persistence/ExecutionServiceNestedContextTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Messages\ToolCall;
+use Atlasphp\Atlas\Persistence\Enums\ExecutionStatus;
+use Atlasphp\Atlas\Persistence\Enums\ExecutionType;
+use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
+use Atlasphp\Atlas\Persistence\Models\Execution;
+use Atlasphp\Atlas\Persistence\Services\ExecutionService;
+use Atlasphp\Atlas\Responses\Usage;
+
+beforeEach(function () {
+    $this->service = app(ExecutionService::class);
+});
+
+/** Drive a parent execution up to an active delegation tool call. */
+function startParentWithDelegationCall(ExecutionService $service): array
+{
+    $parent = $service->createExecution(provider: 'openai', model: 'gpt-4o', agent: 'orchestrator');
+    $service->beginExecution();
+    $service->createStep();
+    $service->beginStep();
+
+    $toolCall = new ToolCall(id: 'call_1', name: 'specialist', arguments: ['task' => 'do it']);
+    $delegation = $service->createToolCall($toolCall, ToolCallType::Agent);
+    $service->beginToolCall($delegation);
+
+    return [$parent, $delegation];
+}
+
+it('links a nested execution to its parent and delegating tool call', function () {
+    [$parent, $delegation] = startParentWithDelegationCall($this->service);
+
+    $child = $this->service->createExecution(provider: 'openai', model: 'gpt-4o-mini', agent: 'specialist');
+
+    expect($child->parent_execution_id)->toBe($parent->id)
+        ->and($child->parent_tool_call_id)->toBe($delegation->id)
+        ->and($child->depth)->toBe(1)
+        // The child is now the active execution.
+        ->and($this->service->getExecution()->id)->toBe($child->id);
+});
+
+it('restores the parent context after the child completes', function () {
+    [$parent, $delegation] = startParentWithDelegationCall($this->service);
+
+    $this->service->createExecution(provider: 'openai', model: 'gpt-4o-mini', agent: 'specialist');
+    $this->service->beginExecution();
+    $this->service->completeExecution(new Usage(inputTokens: 5, outputTokens: 7));
+
+    // Parent execution, step, and the delegating tool call are restored.
+    expect($this->service->getExecution()->id)->toBe($parent->id)
+        ->and($this->service->getCurrentToolCall()?->id)->toBe($delegation->id)
+        ->and($this->service->currentStep())->not->toBeNull();
+});
+
+it('restores the parent context when the child fails', function () {
+    [$parent] = startParentWithDelegationCall($this->service);
+
+    $this->service->createExecution(provider: 'openai', model: 'gpt-4o-mini', agent: 'specialist');
+    $this->service->beginExecution();
+    $this->service->failExecution(new RuntimeException('child boom'));
+
+    expect($this->service->getExecution()->id)->toBe($parent->id);
+});
+
+it('tracks multi-level nesting and unwinds in order', function () {
+    [$parent, $delegation] = startParentWithDelegationCall($this->service);
+
+    // Level 1 child, itself delegating.
+    $child = $this->service->createExecution(provider: 'openai', model: 'gpt-4o', agent: 'specialist');
+    $this->service->beginExecution();
+    $this->service->createStep();
+    $this->service->beginStep();
+    $childCall = $this->service->createToolCall(
+        new ToolCall(id: 'call_2', name: 'researcher', arguments: ['task' => 'dig']),
+        ToolCallType::Agent,
+    );
+    $this->service->beginToolCall($childCall);
+
+    // Level 2 grandchild.
+    $grandchild = $this->service->createExecution(provider: 'openai', model: 'gpt-4o-mini', agent: 'researcher');
+
+    expect($grandchild->parent_execution_id)->toBe($child->id)
+        ->and($grandchild->parent_tool_call_id)->toBe($childCall->id)
+        ->and($grandchild->depth)->toBe(2);
+
+    // Unwind grandchild → child restored.
+    $this->service->beginExecution();
+    $this->service->completeExecution();
+    expect($this->service->getExecution()->id)->toBe($child->id);
+
+    // Unwind child → parent restored.
+    $this->service->completeExecution();
+    expect($this->service->getExecution()->id)->toBe($parent->id)
+        ->and($this->service->getCurrentToolCall()?->id)->toBe($delegation->id);
+});
+
+it('totalUsage sums the whole subtree across multiple children and grandchildren', function () {
+    $make = function (array $usage, ?int $parentId, int $depth): Execution {
+        return Execution::create([
+            'parent_execution_id' => $parentId,
+            'depth' => $depth,
+            'type' => ExecutionType::Text,
+            'provider' => 'openai',
+            'model' => 'gpt-4o',
+            'status' => ExecutionStatus::Completed,
+            'usage' => $usage,
+        ]);
+    };
+
+    $root = $make(['input_tokens' => 10, 'output_tokens' => 5], null, 0);
+    $childA = $make(['input_tokens' => 3, 'output_tokens' => 2], $root->id, 1);
+    $make(['input_tokens' => 4, 'output_tokens' => 1], $root->id, 1);       // childB
+    $make(['input_tokens' => 2, 'output_tokens' => 2], $childA->id, 2);     // grandchild under A
+
+    $total = $root->fresh()->totalUsage();
+
+    // input: 10+3+4+2 = 19 · output: 5+2+1+2 = 10 · total: 29
+    expect($total['input_tokens'])->toBe(19)
+        ->and($total['output_tokens'])->toBe(10)
+        ->and($total['total_tokens'])->toBe(29);
+});
+
+it('strips internal _-prefixed meta keys from stored execution metadata', function () {
+    $execution = $this->service->createExecution(
+        provider: 'openai',
+        model: 'gpt-4o',
+        meta: ['_atlas_delegation_depth' => 2, '_atlas_delegation_chain' => ['a'], 'tenant_id' => 7],
+    );
+
+    expect($execution->metadata)->toBe(['tenant_id' => 7]);
+});
+
+it('restores the parent context after a nested completeDirectExecution', function () {
+    [$parent, $delegation] = startParentWithDelegationCall($this->service);
+
+    // A nested direct-mode call (e.g. a sub-agent image/embed) finalises via completeDirectExecution.
+    $this->service->createExecution(provider: 'openai', model: 'gpt-image-1', agent: 'image-sub');
+    $this->service->completeDirectExecution(new Usage(inputTokens: 1, outputTokens: 1));
+
+    expect($this->service->getExecution()->id)->toBe($parent->id)
+        ->and($this->service->getCurrentToolCall()?->id)->toBe($delegation->id);
+});

--- a/tests/Unit/Persistence/Middleware/TrackToolCallTest.php
+++ b/tests/Unit/Persistence/Middleware/TrackToolCallTest.php
@@ -7,6 +7,7 @@ use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Middleware\ToolContext;
 use Atlasphp\Atlas\Persistence\Enums\ExecutionStatus;
 use Atlasphp\Atlas\Persistence\Enums\ExecutionType;
+use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
 use Atlasphp\Atlas\Persistence\Middleware\TrackToolCall;
 use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
 use Atlasphp\Atlas\Persistence\Services\ExecutionService;
@@ -145,4 +146,23 @@ it('records duration', function () {
 
     expect($record->duration_ms)->not->toBeNull();
     expect($record->duration_ms)->toBeGreaterThanOrEqual(0);
+});
+
+it('types a delegation tool call as agent', function () {
+    $service = makeServiceWithExecutionAndStep();
+    $middleware = new TrackToolCall($service);
+
+    $context = new ToolContext(toolCall: makeToolCall(), meta: [], isDelegation: true);
+    $middleware->handle($context, fn () => makeToolResult());
+
+    expect(ExecutionToolCall::firstOrFail()->type)->toBe(ToolCallType::Agent);
+});
+
+it('types a normal tool call as local', function () {
+    $service = makeServiceWithExecutionAndStep();
+    $middleware = new TrackToolCall($service);
+
+    $middleware->handle(makeToolContext(), fn () => makeToolResult());
+
+    expect(ExecutionToolCall::firstOrFail()->type)->toBe(ToolCallType::Local);
 });

--- a/tests/Unit/Persistence/Models/ExecutionTest.php
+++ b/tests/Unit/Persistence/Models/ExecutionTest.php
@@ -185,3 +185,29 @@ it('message relationship returns the linked message', function () {
     expect($execution->message)->toBeInstanceOf(ConversationMessage::class)
         ->and($execution->message->id)->toBe($message->id);
 });
+
+it('parent and children relations link sub-agent executions', function () {
+    $parent = Execution::factory()->create();
+    $child = Execution::factory()->create(['parent_execution_id' => $parent->id, 'depth' => 1]);
+    Execution::factory()->create(); // unrelated root execution
+
+    expect($child->parent)->not->toBeNull()
+        ->and($child->parent->id)->toBe($parent->id)
+        ->and($parent->parent)->toBeNull()
+        ->and($parent->children)->toHaveCount(1)
+        ->and($parent->children->first()->id)->toBe($child->id);
+});
+
+it('parentToolCall links to the delegating tool call', function () {
+    $parentExec = Execution::factory()->create();
+    $toolCall = ExecutionToolCall::factory()->create(['execution_id' => $parentExec->id]);
+    $child = Execution::factory()->create([
+        'parent_execution_id' => $parentExec->id,
+        'parent_tool_call_id' => $toolCall->id,
+        'depth' => 1,
+    ]);
+
+    expect($child->parentToolCall)->toBeInstanceOf(ExecutionToolCall::class)
+        ->and($child->parentToolCall->id)->toBe($toolCall->id)
+        ->and($parentExec->parentToolCall)->toBeNull();
+});

--- a/tests/Unit/Tools/AgentToolTest.php
+++ b/tests/Unit/Tools/AgentToolTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Agent;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Exceptions\DelegationCycleException;
+use Atlasphp\Atlas\Exceptions\MaxDelegationDepthException;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Providers\ProviderCapabilities;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Testing\AtlasFake;
+use Atlasphp\Atlas\Testing\TextResponseFake;
+use Atlasphp\Atlas\Tools\AgentTool;
+
+// ─── Test agents ────────────────────────────────────────────────────────────
+
+class SpecialistTestAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'specialist';
+    }
+
+    public function description(): ?string
+    {
+        return 'Answers domain questions.';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o';
+    }
+}
+
+class PlainSubAgent extends Agent
+{
+    public function key(): string
+    {
+        return 'plain-sub';
+    }
+
+    public function provider(): Provider|string|null
+    {
+        return Provider::OpenAI;
+    }
+
+    public function model(): ?string
+    {
+        return 'gpt-4o';
+    }
+}
+
+/** Installs a fake driver that returns the given text for any provider call. */
+function fakeSubAgentText(string $text): void
+{
+    new AtlasFake(app(ProviderRegistryContract::class), [
+        TextResponseFake::make()->withText($text),
+    ]);
+}
+
+/** Registers a driver whose text() always throws, for error-path tests. */
+function installThrowingDriver(): void
+{
+    app(ProviderRegistryContract::class)->register('openai', fn () => new class extends Driver
+    {
+        public function __construct() {}
+
+        public function text(TextRequest $request): TextResponse
+        {
+            throw new RuntimeException('boom');
+        }
+
+        public function capabilities(): ProviderCapabilities
+        {
+            throw new RuntimeException('n/a');
+        }
+
+        public function name(): string
+        {
+            return 'openai';
+        }
+    });
+}
+
+// ─── name / description ──────────────────────────────────────────────────────
+
+it('uses the agent key as the tool name by default', function () {
+    expect(AgentTool::for(new SpecialistTestAgent)->name())->toBe('specialist');
+});
+
+it('allows overriding the tool name', function () {
+    expect(AgentTool::for(new SpecialistTestAgent, 'ask_specialist')->name())->toBe('ask_specialist');
+});
+
+it('uses the agent description when present', function () {
+    expect(AgentTool::for(new SpecialistTestAgent)->description())->toBe('Answers domain questions.');
+});
+
+it('falls back to a generic delegation description', function () {
+    $description = AgentTool::for(new PlainSubAgent)->description();
+
+    expect($description)->toContain('plain-sub')
+        ->and($description)->toContain('isolation');
+});
+
+it('allows overriding the description', function () {
+    expect(AgentTool::for(new PlainSubAgent, null, 'Custom.')->description())->toBe('Custom.');
+});
+
+// ─── parameters / schema ─────────────────────────────────────────────────────
+
+it('exposes a single required task string parameter', function () {
+    $tool = AgentTool::for(new SpecialistTestAgent);
+    $params = $tool->parameters();
+
+    expect($params)->toHaveCount(1)
+        ->and($params[0]->name())->toBe('task')
+        ->and($params[0]->isRequired())->toBeTrue();
+
+    $schema = $tool->toDefinition()->parameters;
+    expect($schema['type'])->toBe('object')
+        ->and($schema['properties'])->toHaveKey('task')
+        ->and($schema['properties']['task']['type'])->toBe('string')
+        ->and($schema['required'])->toBe(['task']);
+});
+
+it('is flagged as a delegation tool', function () {
+    expect(AgentTool::for(new SpecialistTestAgent)->isDelegation())->toBeTrue();
+});
+
+// ─── handle: happy path ──────────────────────────────────────────────────────
+
+it('runs the sub-agent with the task and returns its text', function () {
+    fakeSubAgentText('the secret is 42');
+
+    $result = AgentTool::for(new SpecialistTestAgent)->handle(['task' => 'reveal the secret'], []);
+
+    expect($result)->toBe('the secret is 42');
+});
+
+it('handles a missing task argument without crashing', function () {
+    fakeSubAgentText('handled empty');
+
+    $result = AgentTool::for(new SpecialistTestAgent)->handle([], []);
+
+    expect($result)->toBe('handled empty');
+});
+
+// ─── handle: depth + cycle guards ────────────────────────────────────────────
+
+it('throws when the delegation depth limit is reached', function () {
+    config()->set('atlas.agents.max_delegation_depth', 2);
+
+    AgentTool::for(new SpecialistTestAgent)->handle(
+        ['task' => 'x'],
+        [AgentTool::DEPTH_META_KEY => 2],
+    );
+})->throws(MaxDelegationDepthException::class);
+
+it('runs when below the depth limit', function () {
+    config()->set('atlas.agents.max_delegation_depth', 2);
+    fakeSubAgentText('ok');
+
+    $result = AgentTool::for(new SpecialistTestAgent)->handle(
+        ['task' => 'x'],
+        [AgentTool::DEPTH_META_KEY => 1],
+    );
+
+    expect($result)->toBe('ok');
+});
+
+it('throws when the agent is already in the delegation chain', function () {
+    AgentTool::for(new SpecialistTestAgent)->handle(
+        ['task' => 'x'],
+        [AgentTool::CHAIN_META_KEY => ['orchestrator', 'specialist']],
+    );
+})->throws(DelegationCycleException::class);
+
+// ─── handle: error modes ─────────────────────────────────────────────────────
+
+it('propagates sub-agent errors when delegation_errors is throw', function () {
+    config()->set('atlas.agents.delegation_errors', 'throw');
+    installThrowingDriver();
+
+    AgentTool::for(new SpecialistTestAgent)->handle(['task' => 'x'], []);
+})->throws(RuntimeException::class, 'boom');
+
+it('returns the error as a string when delegation_errors is return', function () {
+    config()->set('atlas.agents.delegation_errors', 'return');
+    installThrowingDriver();
+
+    $result = AgentTool::for(new SpecialistTestAgent)->handle(['task' => 'x'], []);
+
+    expect($result)->toContain("Sub-agent 'specialist' failed")
+        ->and($result)->toContain('boom');
+});


### PR DESCRIPTION
This pull request introduces a major new feature: sub-agent delegation. Agents can now delegate tasks to other agents by listing them in their `tools()` method, enabling modular, specialized workflows. The implementation includes new configuration options, database schema changes for tracking delegation, runtime and middleware support, and comprehensive documentation. Additionally, two new exceptions guard against runaway or cyclic delegation.

**Sub-agent delegation and tracking:**

* Agents can now delegate tasks to other agents by including them in their `tools()` array. Delegation is tracked, and each sub-agent run is isolated with its own context. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R23)], [[2]](diffhunk://#diff-3265ca69f2382418c0cdb1c99b8ba77d9ea36d8486ba55e697ef80f6a40dd02aR1-R75)], [[3]](diffhunk://#diff-0547b8abb0d1b756bd782300755c54f2f74633554fa48ae70413cc0cef6157a9R43-R55)], [[4]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fL51-R61)], [[5]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fR618-R624)], [[6]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L23-R24)], [[7]](diffhunk://#diff-03c35fec162d74ac3ebb3e9c8f98813cf544aacef9b86cf6b0bab2977d4c1004R273-R276)], [[8]](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deR45)])
* Persistence schema updated: new migration adds `parent_execution_id`, `parent_tool_call_id`, and `depth` columns to the `executions` table to track delegation chains and nesting depth. [[1]](diffhunk://#diff-1a2f8693ca05b6e0520e64615a8d03003d7912919bcf1508ddd970041d6b02b0R1-R49)], [[2]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268R102-R104)], [[3]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268R240-R242)])
* Tool calls now support a new type: `agent`, for sub-agent delegation. ([[docs/advanced/persistence.mdL153-R156](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268L153-R156)])

**Configuration and safeguards:**

* New configuration options in `atlas.php`: `max_delegation_depth` (default 5) limits nesting depth, and `delegation_errors` controls error handling strategy (`throw` or `return`). [[1]](diffhunk://#diff-0547b8abb0d1b756bd782300755c54f2f74633554fa48ae70413cc0cef6157a9R43-R55)], [[2]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fL51-R61)], [[3]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fR618-R624)])
* Two new exceptions: `MaxDelegationDepthException` and `DelegationCycleException`, thrown when delegation exceeds limits or forms a cycle. [[1]](diffhunk://#diff-3a531c805facfe88300622f90d9b2c69b9a8fe0d9e35fde3734fef3e60e4fe3eR1-R24)], [[2]](diffhunk://#diff-2d37f229359e659b9092405b265c8ea99dc968c7a593da155081c3f6b8915428R1-R28)])

**Runtime and middleware support:**

* `AgentExecutor` and `ToolExecutor` updated to detect and handle delegation, including running delegated tool calls sequentially to ensure correct tracking. [[1]](diffhunk://#diff-04898a3a0b543c8b0b410e0a0c80a502f9c717f2c4cf7b44c8a27838361ff7a7R282)], [[2]](diffhunk://#diff-04898a3a0b543c8b0b410e0a0c80a502f9c717f2c4cf7b44c8a27838361ff7a7R334-R344)], [[3]](diffhunk://#diff-f863d41b5f4f3282e947321913beabe5c082672333c202abb582ec5c39819739R39-R46)])
* `AgentRequest` supports running pre-resolved agent instances (for unregistered sub-agents), and middleware/context classes updated to indicate when a tool call is a delegation. [[1]](diffhunk://#diff-1668325ecfaf9dfb0e9831a0bd5145ee595d13b66f9cb715f382ebfbd0c995abR58)], [[2]](diffhunk://#diff-1668325ecfaf9dfb0e9831a0bd5145ee595d13b66f9cb715f382ebfbd0c995abR91-R96)], [[3]](diffhunk://#diff-1668325ecfaf9dfb0e9831a0bd5145ee595d13b66f9cb715f382ebfbd0c995abR798-R826)], [[4]](diffhunk://#diff-0ef944d60d9e3f3baa69f5e088ca491984c37b122b22d1686bee33a8cdd4e38dR24)])

**Documentation:**

* New and updated documentation for sub-agents, configuration, persistence, and agent usage. [[1]](diffhunk://#diff-3265ca69f2382418c0cdb1c99b8ba77d9ea36d8486ba55e697ef80f6a40dd02aR1-R75)], [[2]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268R102-R104)], [[3]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268L153-R156)], [[4]](diffhunk://#diff-f56fb762ea4bc33e102eef3732d0894753a202771243d58024b2274741c4f268R240-R242)], [[5]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fL51-R61)], [[6]](diffhunk://#diff-a963c0223701fa7ab03bf8d72556120682ffb93e806a62a18c60daeef8da4c6fR618-R624)], [[7]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L23-R24)], [[8]](diffhunk://#diff-03c35fec162d74ac3ebb3e9c8f98813cf544aacef9b86cf6b0bab2977d4c1004R273-R276)], [[9]](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deR45)])

**Other:**

* Minor doc fix: updated copyright in footer. ([[docs/.vitepress/config.mtsL106-R107](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deL106-R107)])

This release is a drop-in upgrade, but you must run `php artisan migrate` to add the new tracking columns.