### PR TITLE
Add provider-native tools support and mapping options

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,47 +4,80 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Last full run: 2026-06-02**
+**Last full run: 2026-06-02** · **Provider-tools run: 2026-06-06**
 
-Reproduce: `cd sandbox && php test-{provider}-provider.php` (requires the provider's API key in `sandbox/.env`).
+Reproduce:
+- Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
+- Provider-native tools (web search / fetch / file search / code / domain scoping):
+  `cd sandbox && php test-provider-tools-live.php`
+
+Both require the provider's API key in `sandbox/.env`.
 
 ### Legend
 
 - ✅ — passed live on the date below
 - — — not part of this provider's offering / not in its live suite
-- ⚠️ — supported but **not** exercised live (see notes)
+- ⚠️ — supported but **not** fully exercised live, or works but with a gap (see notes)
 - ❌ — could not verify live (blocked — see notes)
 
 ## Modality matrix
 
-| Provider    | Text | Stream | Structured | Tools | Vision | Image | TTS | STT | Embeddings | Moderation | Rerank | Video | Voice | Last live pass |
-|-------------|:----:|:------:|:----------:|:-----:|:------:|:-----:|:---:|:---:|:----------:|:----------:|:------:|:-----:|:-----:|:--------------:|
-| OpenAI      | ✅   | ✅     | ✅         | ✅    | ✅     | ✅    | ✅  | ✅  | ✅         | ✅         | —      | ✅    | ⚠️    | 2026-06-02     |
-| Anthropic   | ✅   | ✅     | ✅         | ✅    | ✅     | —     | —   | —   | —          | —          | —      | —     | —     | 2026-06-02     |
-| Google      | ✅   | ✅     | ✅         | ✅    | ✅     | ✅    | —   | —   | ✅         | —          | —      | —     | —     | 2026-06-02     |
-| xAI         | ✅   | ✅     | ✅         | ✅    | —      | ✅    | ✅  | —   | —          | —          | —      | ✅    | ⚠️    | 2026-06-02     |
-| ElevenLabs  | —    | —      | —          | —     | —      | —     | ❌  | ❌  | —          | —          | —      | —     | ⚠️    | —              |
-| Cohere      | —    | —      | —          | —     | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
-| Jina        | —    | —      | —          | —     | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
-| Ollama¹     | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
-| LM Studio¹  | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
+| Provider    | Text | Stream | Structured | Tools | Prov.Tools | Vision | Image | TTS | STT | Embeddings | Moderation | Rerank | Video | Voice | Last live pass |
+|-------------|:----:|:------:|:----------:|:-----:|:----------:|:------:|:-----:|:---:|:---:|:----------:|:----------:|:------:|:-----:|:-----:|:--------------:|
+| OpenAI      | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | ✅    | ✅  | ✅  | ✅         | ✅         | —      | ✅    | ⚠️    | 2026-06-06     |
+| Anthropic   | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | —     | —   | —   | —          | —          | —      | —     | —     | 2026-06-06     |
+| Google      | ✅   | ✅     | ✅         | ✅    | ⚠️         | ✅     | ✅    | —   | —   | ✅         | —          | —      | —     | —     | 2026-06-06     |
+| xAI         | ✅   | ✅     | ✅         | ✅    | ✅         | —      | ✅    | ✅  | —   | —          | —          | —      | ✅    | ⚠️    | 2026-06-06     |
+| ElevenLabs  | —    | —      | —          | —     | —          | —      | —     | ❌  | ❌  | —          | —          | —      | —     | ⚠️    | —              |
+| Cohere      | —    | —      | —          | —     | —          | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
+| Jina        | —    | —      | —          | —     | —          | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
+| Ollama¹     | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —          | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
+| LM Studio¹  | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —          | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
 
 ¹ OpenAI-compatible endpoints via the shared `chat_completions` driver.
 
-## Per-provider results (2026-06-02)
+## Provider tools (live, 2026-06-06)
 
-| Provider   | Live suite        | Notes |
-|------------|-------------------|-------|
-| OpenAI     | **35/35 passed**  | Vision verified with a live image-input call (`gpt-4o-mini`). Image generation uses `gpt-image-1` (base64/`b64_json`); generation, store/storeAs, `contents()`, and auto-persist all verified. Also passed: provider tools (web search), media storage. Realtime **Voice** not exercised live. |
-| Anthropic  | **17/17 passed**  | Text, streaming, structured, tools, vision (image-from-base64). |
-| Google     | **22/22 passed**  | Vision verified with a live image-input call (`gemini-2.5-flash`). Includes Google Search grounding (provider tool), embeddings, image generation. |
-| xAI        | **20/20 passed**  | Includes web search + X search (provider tools), image, TTS, video. Realtime Voice not exercised live. |
-| ElevenLabs | **not verified**  | Blocked: sandbox `config/atlas.php` has no `elevenlabs` provider block, so the base URL is empty. Package URL resolution is correct — purely a sandbox config gap. TTS / STT / SFX / Music unverified live. |
-| Cohere     | **not verified**  | No `COHERE_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
-| Jina       | **not verified**  | No `JINA_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
-| Ollama     | **not run**       | Points at a LAN host (`OLLAMA_URL`); not exercised in this run. |
-| LM Studio  | **not run**       | Requires a local LM Studio instance; not exercised in this run. |
+Provider-native tools each provider executes server-side. Verified end-to-end **through Atlas**
+(`Atlas::text(...)->withProviderTools([...])`) via `sandbox/test-provider-tools-live.php`, plus
+raw-API shape probes for tools that need external resources (a vector store, a container).
 
-## Package checks (2026-06-02)
+- ✅ — full end-to-end pass: the model **used the tool and based its answer on the live results**, and Atlas captured the calls/citations (`providerToolCalls` / `annotations`).
+- ◐ — native request shape verified live (HTTP 200), not run end-to-end (needs an external resource like a vector store or container).
+- ⚠️ — the model uses the tool and the answer is correctly grounded, but Atlas does not yet surface it as `providerToolCalls`/`annotations`.
 
-`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 2768 Pest tests ✓**.
+| Provider  | web_search | web_fetch | file_search | code_interpreter | google_search | code_execution | x_search |
+|-----------|:----------:|:---------:|:-----------:|:----------------:|:-------------:|:--------------:|:--------:|
+| OpenAI    | ✅          | —         | ◐           | ◐                | —             | —              | —        |
+| Anthropic | ✅          | ✅         | —           | —                | —             | —              | —        |
+| Google    | —          | —         | —           | —                | ⚠️            | ⚠️             | —        |
+| xAI       | ✅          | —         | —           | —                | —             | —              | ◐        |
+
+Notes:
+- **Domain scoping** (`allowedDomains` / `blockedDomains`) verified live on OpenAI/xAI (`filters`)
+  and Anthropic (top-level). Anthropic returns citations as `annotations`.
+- **OpenAI** `file_search` requires `vector_store_ids` and `code_interpreter` requires a
+  `container` — both confirmed via live 400/200 shape probes; not run end-to-end (no live
+  vector store / sandboxed container in the harness).
+- **Google** `google_search` (grounding) and `code_execution` fire and ground answers correctly
+  live (returned current, beyond-cutoff data), but Atlas's Google `ResponseParser` does not yet
+  map `groundingMetadata` / `codeExecutionResult` into `providerToolCalls` / `annotations` —
+  observability gap, functional path works. **Follow-up:** wire Google grounding observability.
+
+## Per-provider results
+
+| Provider   | Live suite (2026-06-06)    | Notes |
+|------------|----------------------------|-------|
+| OpenAI     | **33/35 passed**           | 2 unrelated failures this run: Sora-2 video blocked by content moderation, and a TTS `audio/speech` cURL timeout — both external/transient, not code. Provider tools: `web_search` (+ domain filters) verified end-to-end. |
+| Anthropic  | **17/17 passed**           | Text, streaming, structured, tools, vision. Provider tools: `web_search` + `web_fetch` verified end-to-end with citations (newly supported in v3.3.0). |
+| Google     | **provider tools checked** | Full modality suite last run 2026-06-02 (22/22). Provider tools `google_search` + `code_execution` exercised live 2026-06-06 — functional, observability gap (above). |
+| xAI        | **20/20 passed**           | Provider tools: `web_search` (+ domain filters) end-to-end; `x_search` shape-verified. |
+| ElevenLabs | **not verified**           | Blocked: sandbox `config/atlas.php` has no `elevenlabs` provider block, so the base URL is empty. Package URL resolution is correct — purely a sandbox config gap. |
+| Cohere     | **not verified**           | No `COHERE_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
+| Jina       | **not verified**           | No `JINA_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
+| Ollama     | **not run**                | Points at a LAN host (`OLLAMA_URL`); not exercised in this run. |
+| LM Studio  | **not run**                | Requires a local LM Studio instance; not exercised in this run. |
+
+## Package checks (2026-06-06)
+
+`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 2828 Pest tests ✓**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Migration
 
-Run `php artisan migrate` — adds one column to store web-search citations. Nothing else changes.
+This release adds one column (to store web-search citations). Atlas migrations are
+publish-based, so pull the new file in first, then migrate:
+
+```bash
+php artisan vendor:publish --tag=atlas-migrations
+php artisan migrate
+```
+
+Publish the new migration and run your migration to add the new column. No other breaking changes.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.3.0](https://github.com/atlas-php/atlas/releases/tag/v3.3.0) - 2026-06-06
+
+### Added
+
+- **Web search now works on Claude (Anthropic)** — with citations, alongside OpenAI, Google, and xAI.
+- **Web fetch on Claude** — have it read a specific page.
+- **Limit web search to specific sites** (or block sites).
+- **Ask which tools a provider supports** — `ProviderToolRegistry::forProvider('openai')`.
+- Pass any extra provider option straight to a tool — even ones not listed yet.
+
+### Fixed
+
+- Web search on OpenAI/xAI was sending unsupported fields and failing — fixed.
+- Code interpreter on OpenAI now works out of the box.
+
+### Migration
+
+Drop-in upgrade — nothing to change.
+
+---
+
 ## [v3.2.0](https://github.com/atlas-php/atlas/releases/tag/v3.2.0) - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - **Web search now works on Claude (Anthropic)** — with citations, alongside OpenAI, Google, and xAI.
 - **Web fetch on Claude** — have it read a specific page.
 - **Limit web search to specific sites** (or block sites).
+- **Web search sources are saved** — citations are stored on the action that produced them (with persistence enabled).
 - **Ask which tools a provider supports** — `ProviderToolRegistry::forProvider('openai')`.
 - Pass any extra provider option straight to a tool — even ones not listed yet.
 
@@ -22,10 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Web search on OpenAI/xAI was sending unsupported fields and failing — fixed.
 - Code interpreter on OpenAI now works out of the box.
+- Agents no longer stall when a provider keeps searching server-side mid-reply.
 
 ### Migration
 
-Drop-in upgrade — nothing to change.
+Run `php artisan migrate` — adds one column to store web-search citations. Nothing else changes.
 
 ---
 

--- a/database/migrations/0016_add_annotations_to_atlas_execution_tool_calls_table.php
+++ b/database/migrations/0016_add_annotations_to_atlas_execution_tool_calls_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function tableName(string $name): string
+    {
+        return config('atlas.persistence.table_prefix', 'atlas_').$name;
+    }
+
+    public function up(): void
+    {
+        Schema::table($this->tableName('execution_tool_calls'), function (Blueprint $table) {
+            // Citations (url_citation / web_search_result_location, etc.) the
+            // provider returned for this provider-tool action. Attached to the
+            // search/fetch action that produced them.
+            $table->json('annotations')->nullable()->after('result');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->tableName('execution_tool_calls'), function (Blueprint $table) {
+            $table->dropColumn('annotations');
+        });
+    }
+};

--- a/docs/advanced/persistence.md
+++ b/docs/advanced/persistence.md
@@ -388,12 +388,20 @@ A single round trip in the agent's tool call loop — one provider call and its 
 
 `Atlasphp\Atlas\Persistence\Models\ExecutionToolCall`
 
-An individual tool invocation with arguments, result, and timing.
+An individual tool invocation with arguments, result, and timing. Client tools
+have `type = local`; provider-native tools (web search, etc.) have `type = provider`.
 
 | Relationship | Type | Description |
 |-------------|------|-------------|
 | `execution()` | `BelongsTo → Execution` | Parent execution |
 | `step()` | `BelongsTo → ExecutionStep` | The step that triggered this call |
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool_call_id` | `string` | Provider's id for this call — identifies the action |
+| `name` / `type` | `string` / `ToolCallType` | Tool name and `local` vs `provider` |
+| `arguments` / `result` | `array` / `string` | Inputs and serialized output |
+| `annotations` | `array\|null` | Citations the provider returned (web search/fetch), e.g. `url_citation` / `web_search_result_location` — stored on the search/fetch action that produced them |
 
 | Method | Description |
 |--------|-------------|
@@ -404,6 +412,28 @@ An individual tool invocation with arguments, result, and timing.
 |-------|-------------|
 | `pending()` / `processing()` / `completed()` / `failed()` | Filter by `ExecutionStatus` (from `HasExecutionStatus` trait) |
 | `forTool(string $name)` | Filter by tool name |
+
+**Reading provider tool calls and their citations:**
+
+```php
+use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
+
+// All provider-tool actions in an execution, with their cited sources.
+$execution->toolCalls()
+    ->where('type', 'provider')
+    ->get()
+    ->each(function (ExecutionToolCall $call) {
+        $call->name;          // e.g. 'web_search', 'web_search_call'
+        $call->tool_call_id;  // which provider action produced these
+        foreach ($call->annotations ?? [] as $citation) {
+            $citation['url'];   // the cited source
+            $citation['title'] ?? null;
+        }
+    });
+
+// Or just the calls that produced citations:
+ExecutionToolCall::whereNotNull('annotations')->get();
+```
 
 ### Asset
 

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -371,7 +371,21 @@ $response->providerToolCalls;
 $response->annotations;
 ```
 
-When [persistence](/advanced/persistence) is enabled, provider tool calls are automatically logged as `ExecutionToolCall` records with `type = provider`.
+When [persistence](/advanced/persistence) is enabled, provider tool calls are automatically
+logged as `ExecutionToolCall` records with `type = provider`, and the citations are stored on
+the search/fetch action that produced them — so the "sources" trail survives the turn:
+
+```php
+use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
+
+ExecutionToolCall::whereNotNull('annotations')->get()->each(function ($call) {
+    $call->tool_call_id;   // which provider action produced the citations
+    $call->annotations;    // the cited url_citation / web_search_result_location entries
+});
+```
+
+See [Persistence → ExecutionToolCall](/advanced/persistence#executiontoolcall) for the full field
+and relationship reference.
 
 ## Built-in Tools
 

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -255,17 +255,17 @@ for Gemini function declarations and preserves Gemini continuation metadata when
 
 ## Provider Tools
 
-Provider tools are native capabilities offered by AI providers (not your PHP code). They run server-side at the provider level. Atlas includes configuration objects for common provider tools:
+Provider tools are native capabilities offered by AI providers (not your PHP code). They run server-side at the provider level. Atlas includes configuration objects for common provider tools and translates each to the provider's native request shape:
 
 ```php
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
 use Atlasphp\Atlas\Providers\Tools\FileSearch;
 use Atlasphp\Atlas\Providers\Tools\CodeInterpreter;
 
-// Add to a direct request
+// Add to a direct request — restrict ("include") search to specific sites
 $response = Atlas::text('openai', 'gpt-4o')
     ->withProviderTools([
-        new WebSearch(maxResults: 5, locale: 'en-US'),
+        new WebSearch(allowedDomains: ['laravel.com', 'php.net']),
     ])
     ->message('What are the latest Laravel releases?')
     ->asText();
@@ -276,28 +276,82 @@ class ResearchAgent extends Agent
     public function providerTools(): array
     {
         return [
-            new WebSearch,
+            new WebSearch(allowedDomains: ['laravel.com']),
             new CodeInterpreter,
-            new FileSearch(stores: ['vs_abc123'], maxResults: 10),
+            new FileSearch(stores: ['vs_abc123']),
         ];
     }
 }
 ```
 
+### Domain scoping (site inclusion)
+
+`WebSearch` accepts `allowedDomains` / `blockedDomains`. Atlas places them where each
+provider expects: nested under `filters` for OpenAI/xAI, top-level for Anthropic.
+
+```php
+new WebSearch(
+    allowedDomains: ['laravel.com', 'php.net'], // only these sites
+    blockedDomains: ['example-spam.com'],       // never these
+);
+```
+
+### Custom attributes (forward-compatible)
+
+Well-known attributes have typed constructor parameters, but every provider tool also
+accepts an `options` bag that is merged verbatim into the native request. Use it for any
+attribute a provider supports that Atlas doesn't model yet — nothing to wait on:
+
+```php
+// Anthropic web_search: max_uses + user_location pass straight through.
+new WebSearch(
+    allowedDomains: ['laravel.com'],
+    options: ['max_uses' => 5, 'user_location' => ['type' => 'approximate', 'country' => 'US']],
+);
+
+// OpenAI web_search: search_context_size passes straight through.
+new WebSearch(options: ['search_context_size' => 'high']);
+```
+
 ### Available Provider Tools
 
-| Class | Type | Providers | Description |
-|-------|------|-----------|-------------|
-| `WebSearch` | `web_search` | OpenAI, Google | Search the web. Options: `maxResults`, `locale` |
-| `WebFetch` | `web_fetch` | OpenAI | Fetch and read web page content |
-| `FileSearch` | `file_search` | OpenAI | Search vector stores. Options: `stores`, `maxResults` |
-| `CodeInterpreter` | `code_interpreter` | OpenAI | Execute code in a sandbox |
-| `GoogleSearch` | `google_search` | Google | Google Search grounding for Gemini |
-| `CodeExecution` | `code_execution` | Google | Code execution for Gemini |
-| `XSearch` | `x_search` | xAI | Search X/Twitter posts. Options: `fromDate`, `toDate`, `allowedXHandles`, `enableImageUnderstanding`, `enableVideoUnderstanding` |
+Support is verified against each provider's live API. Some tools need their own attributes to
+run (e.g. `FileSearch` needs `stores`; `CodeInterpreter` auto-provisions a `container`).
+
+| Class | Type | Providers | Notes |
+|-------|------|-----------|-------|
+| `WebSearch` | `web_search` | OpenAI, Anthropic, xAI | Web search. `allowedDomains` / `blockedDomains` for site scoping. |
+| `WebFetch` | `web_fetch` | Anthropic | Fetch and read a web page. |
+| `FileSearch` | `file_search` | OpenAI | Search vector stores. Requires `stores` (`vector_store_ids`). |
+| `CodeInterpreter` | `code_interpreter` | OpenAI | Run code in a sandbox container. |
+| `GoogleSearch` | `google_search` | Google | Google Search grounding for Gemini. |
+| `CodeExecution` | `code_execution` | Google | Code execution for Gemini. |
+| `XSearch` | `x_search` | xAI | Search X/Twitter posts. `fromDate`, `toDate`, `allowedXHandles`, `enableImageUnderstanding`, `enableVideoUnderstanding`. |
+
+Provider docs for the native attributes each tool accepts:
+[OpenAI web search](https://developers.openai.com/api/docs/guides/tools-web-search) ·
+[Anthropic web search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool) ·
+[Anthropic web fetch](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool) ·
+[Gemini grounding](https://ai.google.dev/gemini-api/docs/grounding) ·
+[xAI live search](https://docs.x.ai/docs/guides/live-search).
+
+### Querying support per provider
+
+Build provider-aware UI and validation without hardcoding the matrix — query the registry,
+which is the single source of truth above:
+
+```php
+use Atlasphp\Atlas\Providers\Tools\ProviderToolRegistry;
+
+ProviderToolRegistry::forProvider('anthropic');   // ['web_search', 'web_fetch']
+ProviderToolRegistry::supports('openai', 'web_fetch'); // false
+ProviderToolRegistry::all();                       // full provider → tool-type map
+```
 
 ::: warning Provider Compatibility
-Provider tools are only supported on OpenAI, Google, and xAI. Passing provider tools to Anthropic or Chat Completions providers will log a warning and the tools will be ignored.
+Provider tools run on OpenAI, Anthropic, Google, and xAI. A tool a given provider can't run
+(per the table above) is dropped with a logged warning. Chat Completions providers ignore
+provider tools entirely.
 :::
 
 ### Observability

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,17 @@ parameters:
         - database/factories
     level: 6
     ignoreErrors:
+        # Defensive `property_exists($this, 'meta')` guard in a trait: every
+        # current consumer declares `meta`, so newer phpstan calls it redundant
+        # — but the guard keeps the trait safe for future consumers that don't.
+        -
+            identifier: function.alreadyNarrowedType
+            path: src/Pending/Concerns/HasVariables.php
+        # `(bool) $this->option('all')` — larastan infers the option as always
+        # falsy; the --all flag is genuinely functional at runtime.
+        -
+            identifier: booleanOr.rightAlwaysFalse
+            path: src/Console/RechunkCommand.php
         -
             identifier: trait.unused
             path: src/Persistence/Concerns/HasConversations.php

--- a/sandbox/test-provider-tools-live.php
+++ b/sandbox/test-provider-tools-live.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Provider-native tools — live API test (typed ProviderTool classes).
+ *
+ * Exercises the WebSearch/WebFetch tools through each provider's ToolMapper
+ * against the real API: domain scoping (allowed_domains), the options merge bag,
+ * and that provider-executed tools are captured as providerToolCalls/annotations
+ * rather than entering the client tool loop.
+ *
+ * Usage: php test-provider-tools-live.php
+ * Requires OPENAI_API_KEY / ANTHROPIC_API_KEY / XAI_API_KEY in sandbox/.env
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => ['api_key' => env('OPENAI_API_KEY'), 'url' => env('OPENAI_URL', 'https://api.openai.com/v1')],
+    'anthropic' => ['api_key' => env('ANTHROPIC_API_KEY'), 'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1')],
+    'xai' => ['api_key' => env('XAI_API_KEY'), 'url' => env('XAI_URL', 'https://api.x.ai/v1')],
+]);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Providers\Tools\WebFetch;
+use Atlasphp\Atlas\Providers\Tools\WebSearch;
+
+$pass = 0;
+$fail = 0;
+function check(string $label, bool $ok, string $detail = ''): void
+{
+    global $pass, $fail;
+    $ok ? $pass++ : $fail++;
+    echo '  '.($ok ? '✓' : '✗')."  {$label}".($detail !== '' ? "  — {$detail}" : '')."\n";
+}
+
+/**
+ * @param  array<int, ProviderTool>  $tools
+ */
+function runWebSearch(Provider $provider, string $model, array $tools, string $prompt): void
+{
+    $label = $provider->value;
+    try {
+        $r = Atlas::text($provider, $model)
+            ->instructions('Use the available web tools to answer. Be brief.')
+            ->message($prompt)
+            ->withProviderTools($tools)
+            ->asText();
+
+        check("{$label}: returned text", $r->text !== '', mb_substr($r->text, 0, 70));
+        check(
+            "{$label}: provider tool executed (providerToolCalls or annotations captured)",
+            $r->providerToolCalls !== [] || $r->annotations !== [],
+            'calls='.count($r->providerToolCalls).' annotations='.count($r->annotations),
+        );
+        check("{$label}: no client tool calls leaked from server tools", $r->toolCalls === []);
+    } catch (Throwable $e) {
+        check("{$label}: web search live call", false, get_class($e).': '.$e->getMessage());
+    }
+}
+
+echo "── OpenAI (web_search + allowed_domains via filters)\n";
+runWebSearch(Provider::OpenAI, 'gpt-4o', [new WebSearch(allowedDomains: ['php.net'])], 'What is the latest PHP version? Search php.net.');
+
+echo "\n── Anthropic (web_search_20250305 + allowed_domains, top-level)\n";
+runWebSearch(Provider::Anthropic, 'claude-sonnet-4-5', [new WebSearch(allowedDomains: ['php.net'], options: ['max_uses' => 3])], 'What is the latest PHP version? Search php.net.');
+
+echo "\n── Anthropic (web_fetch_20250910)\n";
+runWebSearch(Provider::Anthropic, 'claude-sonnet-4-5', [new WebFetch(['max_uses' => 2])], 'Fetch https://www.php.net and tell me the current stable PHP version shown.');
+
+echo "\n── xAI (web_search + allowed_domains via filters)\n";
+runWebSearch(Provider::xAI, 'grok-3', [new WebSearch(allowedDomains: ['php.net'])], 'What is the latest PHP version? Search php.net.');
+
+echo "\n══════════════════════════════════════════════\n";
+echo "  Results: {$pass} passed, {$fail} failed\n";
+echo "══════════════════════════════════════════════\n";
+exit($fail === 0 ? 0 : 1);

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -151,6 +151,22 @@ class AgentExecutor
                     break;
                 }
 
+                // A ToolCalls finish with no CLIENT tool calls means the provider
+                // is doing server-side work (e.g. Anthropic web search returning
+                // `pause_turn`). There's nothing for us to execute, and re-POSTing
+                // an empty assistant turn would loop until maxSteps. Surface what
+                // we have and stop cleanly.
+                if ($response->toolCalls === []) {
+                    $steps[] = new Step(
+                        text: $response->text,
+                        toolCalls: [],
+                        toolResults: [],
+                        usage: $response->usage,
+                    );
+
+                    break;
+                }
+
                 $toolResults = $concurrent
                     ? $this->executeToolsConcurrently($response->toolCalls, $meta, $stepCount)
                     : $this->executeToolsSequentially($response->toolCalls, $meta, $stepCount);

--- a/src/Pending/Concerns/HasVariables.php
+++ b/src/Pending/Concerns/HasVariables.php
@@ -91,7 +91,8 @@ trait HasVariables
         /** @var VariableRegistry $registry */
         $registry = app(VariableRegistry::class);
 
-        /** @phpstan-ignore-next-line */
+        // Guard kept for trait safety even though every current consumer
+        // declares `meta` (phpstan ignore configured in phpstan.neon).
         $meta = property_exists($this, 'meta') ? $this->meta : [];
 
         return $registry->merge($this->variables, $meta);

--- a/src/Persistence/Middleware/TrackStep.php
+++ b/src/Persistence/Middleware/TrackStep.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Middleware\Contracts\StepMiddleware;
 use Atlasphp\Atlas\Middleware\StepContext;
 use Atlasphp\Atlas\Persistence\Enums\ToolCallType;
+use Atlasphp\Atlas\Persistence\Models\ExecutionToolCall;
 use Atlasphp\Atlas\Persistence\Services\ExecutionService;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Closure;
@@ -76,6 +77,9 @@ class TrackStep implements StepMiddleware
             return;
         }
 
+        /** @var array<int, ExecutionToolCall> $records */
+        $records = [];
+
         foreach ($response->providerToolCalls as $providerTool) {
             try {
                 $record = $this->executionService->createToolCall(
@@ -95,10 +99,35 @@ class TrackStep implements StepMiddleware
                 } else {
                     $this->executionService->completeToolCall($record, $startTime, $reportedStatus);
                 }
+
+                $records[] = $record;
             } catch (\Throwable) {
                 // Don't let provider tool logging failures break the response flow
                 continue;
             }
+        }
+
+        $this->attachAnnotations($response, $records);
+    }
+
+    /**
+     * Attach the step's citations to the action that produced them — the first
+     * provider-tool call (the search/fetch). Providers report citations at the
+     * response level, so this ties the whole set to the originating action; the
+     * `tool_call_id` on that record is the action identifier.
+     *
+     * @param  array<int, ExecutionToolCall>  $records
+     */
+    private function attachAnnotations(TextResponse $response, array $records): void
+    {
+        if ($response->annotations === [] || $records === []) {
+            return;
+        }
+
+        try {
+            $records[0]->update(['annotations' => $response->annotations]);
+        } catch (\Throwable) {
+            // Observability only — never break the response flow.
         }
     }
 }

--- a/src/Persistence/Models/ExecutionToolCall.php
+++ b/src/Persistence/Models/ExecutionToolCall.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Carbon;
  * @property ExecutionStatus $status
  * @property array<mixed>|null $arguments
  * @property string|null $result
+ * @property array<mixed>|null $annotations
  * @property Carbon|null $started_at
  * @property Carbon|null $completed_at
  * @property int|null $duration_ms
@@ -58,6 +59,7 @@ class ExecutionToolCall extends Model
         'status',
         'arguments',
         'result',
+        'annotations',
         'started_at',
         'completed_at',
         'duration_ms',
@@ -70,6 +72,7 @@ class ExecutionToolCall extends Model
             'type' => ToolCallType::class,
             'status' => ExecutionStatus::class,
             'arguments' => 'array',
+            'annotations' => 'array',
             'started_at' => 'datetime',
             'completed_at' => 'datetime',
             'duration_ms' => 'integer',

--- a/src/Providers/Anthropic/AnthropicDriver.php
+++ b/src/Providers/Anthropic/AnthropicDriver.php
@@ -30,6 +30,7 @@ class AnthropicDriver extends Driver
                 structured: true,
                 vision: true,
                 toolCalling: true,
+                providerTools: true,
                 models: true,
             ),
             $this->config->capabilityOverrides,

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -71,6 +71,9 @@ class Text implements TextHandler
         $body = $this->buildBody($request);
 
         if ($request->schema !== null) {
+            // Note: tool_choice is forced to the schema tool below, so any
+            // provider tools on this request are present but won't be invoked
+            // during a structured turn. Use a plain text turn for grounding.
             $body['tools'] = array_merge($body['tools'] ?? [], [
                 [
                     'name' => $request->schema->name(),
@@ -125,8 +128,20 @@ class Text implements TextHandler
             $body['temperature'] = $request->temperature;
         }
 
+        // Client tools and provider-native (server-side) tools share one
+        // `tools` array on the Anthropic Messages API.
+        $tools = [];
+
         if ($request->tools !== []) {
-            $body['tools'] = $this->tools->mapTools($request->tools);
+            $tools = $this->tools->mapTools($request->tools);
+        }
+
+        if ($request->providerTools !== []) {
+            $tools = array_merge($tools, $this->tools->mapProviderTools($request->providerTools));
+        }
+
+        if ($tools !== []) {
+            $body['tools'] = $tools;
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/Anthropic/ResponseParser.php
+++ b/src/Providers/Anthropic/ResponseParser.php
@@ -30,19 +30,37 @@ class ResponseParser implements ResponseParserContract
         $text = '';
         $reasoning = null;
         $toolUseBlocks = [];
+        $providerToolCalls = [];
+        $annotations = [];
 
         foreach ($content as $block) {
-            if (($block['type'] ?? '') === 'text') {
+            $blockType = $block['type'] ?? '';
+
+            if ($blockType === 'text') {
                 $text .= $block['text'] ?? '';
+
+                // Web-search/fetch citations ride on text blocks.
+                foreach ($block['citations'] ?? [] as $citation) {
+                    $annotations[] = $citation;
+                }
             }
 
-            if (($block['type'] ?? '') === 'thinking') {
+            if ($blockType === 'thinking') {
                 $reasoning = ($reasoning ?? '').($block['thinking'] ?? '');
             }
 
-            $blockType = $block['type'] ?? '';
-            if ($blockType === 'tool_use' || $blockType === 'server_tool_use') {
+            // Client tools the executor must run.
+            if ($blockType === 'tool_use') {
                 $toolUseBlocks[] = $block;
+            }
+
+            // Provider-executed (server-side) tools and their result blocks are
+            // observability only — they must NOT enter the client tool loop, or
+            // the executor would try to resolve a PHP handler for `web_search`.
+            if ($blockType === 'server_tool_use'
+                || $blockType === 'web_search_tool_result'
+                || $blockType === 'web_fetch_tool_result') {
+                $providerToolCalls[] = $block;
             }
         }
 
@@ -60,6 +78,8 @@ class ResponseParser implements ResponseParserContract
                 'id' => $data['id'] ?? null,
                 'model' => $data['model'] ?? null,
             ],
+            providerToolCalls: $providerToolCalls,
+            annotations: $annotations,
         );
     }
 

--- a/src/Providers/Anthropic/ToolMapper.php
+++ b/src/Providers/Anthropic/ToolMapper.php
@@ -16,6 +16,21 @@ use Illuminate\Support\Facades\Log;
 class ToolMapper implements ToolMapperContract
 {
     /**
+     * Neutral provider-tool type → Anthropic's versioned server-tool identity.
+     *
+     * Anthropic names server tools with a dated `type` plus a stable `name`.
+     * Tool-specific attributes (max_uses, allowed_domains, blocked_domains,
+     * user_location, …) sit top-level on the tool object and pass through
+     * untouched from the tool's options bag.
+     *
+     * @var array<string, array{type: string, name: string}>
+     */
+    private const SUPPORTED = [
+        'web_search' => ['type' => 'web_search_20250305', 'name' => 'web_search'],
+        'web_fetch' => ['type' => 'web_fetch_20250910', 'name' => 'web_fetch'],
+    ];
+
+    /**
      * Map Atlas ToolDefinitions to Anthropic tool format.
      *
      * @param  array<int, ToolDefinition>  $tools
@@ -38,14 +53,34 @@ class ToolMapper implements ToolMapperContract
      */
     public function mapProviderTools(array $providerTools): array
     {
-        if ($providerTools !== []) {
-            Log::warning('Provider tools are not supported on Anthropic and will be ignored.', [
-                'provider' => 'anthropic',
-                'tools' => array_map(fn (ProviderTool $t) => $t->type(), $providerTools),
+        $mapped = [];
+        $unsupported = [];
+
+        foreach ($providerTools as $tool) {
+            $native = self::SUPPORTED[$tool->type()] ?? null;
+
+            if ($native === null) {
+                $unsupported[] = $tool->type();
+
+                continue;
+            }
+
+            // Start from the neutral payload (top-level attributes + options
+            // bag), then swap in Anthropic's versioned type and stable name.
+            $mapped[] = array_merge($tool->toArray(), [
+                'type' => $native['type'],
+                'name' => $native['name'],
             ]);
         }
 
-        return [];
+        if ($unsupported !== []) {
+            Log::warning('Some provider tools are not supported on Anthropic and were ignored.', [
+                'provider' => 'anthropic',
+                'tools' => $unsupported,
+            ]);
+        }
+
+        return $mapped;
     }
 
     /**

--- a/src/Providers/OpenAi/ToolMapper.php
+++ b/src/Providers/OpenAi/ToolMapper.php
@@ -74,7 +74,55 @@ class ToolMapper implements ToolMapperContract
      */
     public function mapProviderTools(array $providerTools): array
     {
-        return array_map(fn (ProviderTool $tool) => $tool->toArray(), $providerTools);
+        return array_map(fn (ProviderTool $tool): array => $this->mapProviderTool($tool), $providerTools);
+    }
+
+    /**
+     * Translate one provider tool to its Responses API shape.
+     *
+     * The base shape is the tool's provider-neutral `toArray()`; per-type tweaks
+     * adapt it to OpenAI's request format without altering tools that already work.
+     *
+     * @return array<string, mixed>
+     */
+    protected function mapProviderTool(ProviderTool $tool): array
+    {
+        $payload = $tool->toArray();
+
+        // OpenAI's web_search nests domain restrictions under `filters`. Tools
+        // without domain scoping are emitted byte-for-byte as before.
+        if ($tool->type() === 'web_search') {
+            return $this->nestWebSearchFilters($payload);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Move neutral `allowed_domains` / `blocked_domains` into OpenAI's
+     * `filters` object (Responses API web_search). All other attributes —
+     * `search_context_size`, `user_location`, and anything passed through the
+     * tool's options bag — are left untouched so future options pass through.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    protected function nestWebSearchFilters(array $payload): array
+    {
+        $filters = [];
+
+        foreach (['allowed_domains', 'blocked_domains'] as $key) {
+            if (isset($payload[$key])) {
+                $filters[$key] = $payload[$key];
+                unset($payload[$key]);
+            }
+        }
+
+        if ($filters !== []) {
+            $payload['filters'] = $filters;
+        }
+
+        return $payload;
     }
 
     /**

--- a/src/Providers/Tools/CodeInterpreter.php
+++ b/src/Providers/Tools/CodeInterpreter.php
@@ -5,12 +5,27 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Providers\Tools;
 
 /**
- * Code interpreter provider tool configuration.
+ * Code interpreter provider tool configuration (OpenAI Responses API).
+ *
+ * OpenAI requires a `container` on this tool; it defaults to an auto-provisioned
+ * container so the tool works out of the box. Pass `container` in the options
+ * bag to pin a specific container id or other settings.
  */
 class CodeInterpreter extends ProviderTool
 {
     public function type(): string
     {
         return 'code_interpreter';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function config(): array
+    {
+        return array_merge(
+            ['container' => ['type' => 'auto']],
+            $this->options,
+        );
     }
 }

--- a/src/Providers/Tools/FileSearch.php
+++ b/src/Providers/Tools/FileSearch.php
@@ -11,11 +11,15 @@ class FileSearch extends ProviderTool
 {
     /**
      * @param  array<int, string>  $stores
+     * @param  array<string, mixed>  $options  Extra provider-native attributes merged verbatim
      */
     public function __construct(
         protected readonly array $stores = [],
         protected readonly ?int $maxResults = null,
-    ) {}
+        array $options = [],
+    ) {
+        parent::__construct($options);
+    }
 
     public function type(): string
     {
@@ -27,9 +31,12 @@ class FileSearch extends ProviderTool
      */
     public function config(): array
     {
-        return array_filter([
-            'vector_store_ids' => $this->stores ?: null,
-            'max_num_results' => $this->maxResults,
-        ]);
+        return array_merge(
+            array_filter([
+                'vector_store_ids' => $this->stores ?: null,
+                'max_num_results' => $this->maxResults,
+            ]),
+            $this->options,
+        );
     }
 }

--- a/src/Providers/Tools/ProviderTool.php
+++ b/src/Providers/Tools/ProviderTool.php
@@ -9,22 +9,36 @@ namespace Atlasphp\Atlas\Providers\Tools;
  *
  * Provider tools are configuration objects — not Atlas tools. They have no handle() method.
  * The provider executes them natively; ToolMapper converts them to provider format.
+ *
+ * Every provider tool accepts an open `$options` bag that is merged into the
+ * native request verbatim. Well-known attributes have typed constructor
+ * parameters on the concrete tools (correct + documented), but the bag means a
+ * provider attribute we don't model yet — anything the provider allows now or
+ * adds later — can still be passed through without changing Atlas.
  */
 abstract class ProviderTool
 {
+    /**
+     * @param  array<string, mixed>  $options  Extra provider-native attributes merged into the request verbatim.
+     */
+    public function __construct(
+        protected readonly array $options = [],
+    ) {}
+
     /**
      * Provider tool type identifier (e.g. 'web_search', 'code_interpreter').
      */
     abstract public function type(): string;
 
     /**
-     * Tool-specific configuration.
+     * Tool-specific configuration. Defaults to the pass-through options bag;
+     * concrete tools override to fold their typed attributes in first.
      *
      * @return array<string, mixed>
      */
     public function config(): array
     {
-        return [];
+        return $this->options;
     }
 
     /**

--- a/src/Providers/Tools/ProviderToolRegistry.php
+++ b/src/Providers/Tools/ProviderToolRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Tools;
+
+/**
+ * Which provider-native tools each provider can execute.
+ *
+ * This is the single source of truth a consuming application can query to build
+ * provider-aware UI and validation without hardcoding (or drifting from) the
+ * support matrix. Every entry below is verified against the live provider API.
+ *
+ * Note: support is by tool *type*. Some tools still need their own attributes to
+ * run (e.g. OpenAI `file_search` needs `vector_store_ids`); the tool classes carry
+ * those, while this registry only answers "can provider X run tool type Y?".
+ */
+class ProviderToolRegistry
+{
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private const SUPPORT = [
+        'openai' => ['web_search', 'file_search', 'code_interpreter'],
+        'anthropic' => ['web_search', 'web_fetch'],
+        'google' => ['google_search', 'code_execution'],
+        'xai' => ['web_search', 'x_search'],
+    ];
+
+    /**
+     * The full provider → supported tool-type map.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public static function all(): array
+    {
+        return self::SUPPORT;
+    }
+
+    /**
+     * Tool types the given provider can execute.
+     *
+     * @return array<int, string>
+     */
+    public static function forProvider(string $provider): array
+    {
+        return self::SUPPORT[$provider] ?? [];
+    }
+
+    /**
+     * Whether the provider can execute the given provider-tool type.
+     */
+    public static function supports(string $provider, string $type): bool
+    {
+        return in_array($type, self::forProvider($provider), true);
+    }
+}

--- a/src/Providers/Tools/WebSearch.php
+++ b/src/Providers/Tools/WebSearch.php
@@ -6,13 +6,35 @@ namespace Atlasphp\Atlas\Providers\Tools;
 
 /**
  * Web search provider tool configuration.
+ *
+ * Options are provider-neutral; each provider's ToolMapper translates them to
+ * that provider's native request shape (OpenAI/xAI nest domain filters under
+ * `filters`; Anthropic emits a versioned `web_search_*` type with top-level
+ * `allowed_domains`). Domain scoping lets an agent restrict ("include") or
+ * exclude specific sites.
+ *
+ * `allowedDomains` / `blockedDomains` are the modelled, verified attributes;
+ * pass anything else a provider supports (e.g. `search_context_size`,
+ * `user_location`, `max_uses`) through the `$options` bag and it is merged in.
  */
 class WebSearch extends ProviderTool
 {
+    /**
+     * @param  array<int, string>|null  $allowedDomains  Restrict results to these domains (site inclusion)
+     * @param  array<int, string>|null  $blockedDomains  Exclude results from these domains
+     * @param  array<string, mixed>  $options  Extra provider-native attributes merged verbatim
+     * @param  int|null  $maxResults  @deprecated No web_search API accepts this; kept for BC, never emitted.
+     * @param  string|null  $locale  @deprecated No web_search API accepts this; kept for BC, never emitted.
+     */
     public function __construct(
+        protected readonly ?array $allowedDomains = null,
+        protected readonly ?array $blockedDomains = null,
+        array $options = [],
         protected readonly ?int $maxResults = null,
         protected readonly ?string $locale = null,
-    ) {}
+    ) {
+        parent::__construct($options);
+    }
 
     public function type(): string
     {
@@ -24,9 +46,12 @@ class WebSearch extends ProviderTool
      */
     public function config(): array
     {
-        return array_filter([
-            'max_results' => $this->maxResults,
-            'locale' => $this->locale,
-        ]);
+        return array_merge(
+            array_filter([
+                'allowed_domains' => $this->allowedDomains ?: null,
+                'blocked_domains' => $this->blockedDomains ?: null,
+            ]),
+            $this->options,
+        );
     }
 }

--- a/src/Providers/Tools/XSearch.php
+++ b/src/Providers/Tools/XSearch.php
@@ -16,6 +16,7 @@ class XSearch extends ProviderTool
      * @param  string|null  $fromDate  ISO-8601 date string (e.g. "2025-01-01")
      * @param  string|null  $toDate  ISO-8601 date string (e.g. "2025-12-31")
      * @param  array<int, string>|null  $allowedXHandles
+     * @param  array<string, mixed>  $options  Extra provider-native attributes merged verbatim
      */
     public function __construct(
         protected readonly ?string $fromDate = null,
@@ -23,7 +24,10 @@ class XSearch extends ProviderTool
         protected readonly ?array $allowedXHandles = null,
         protected readonly bool $enableImageUnderstanding = false,
         protected readonly bool $enableVideoUnderstanding = false,
-    ) {}
+        array $options = [],
+    ) {
+        parent::__construct($options);
+    }
 
     public function type(): string
     {
@@ -53,6 +57,6 @@ class XSearch extends ProviderTool
             $config['enable_video_understanding'] = true;
         }
 
-        return $config;
+        return array_merge($config, $this->options);
     }
 }

--- a/tests/Unit/Executor/AgentExecutorTest.php
+++ b/tests/Unit/Executor/AgentExecutorTest.php
@@ -214,6 +214,36 @@ it('flows provider tool calls and annotations from final response', function () 
     expect($result->annotations[0]['url'])->toBe('https://php.net');
 });
 
+it('does not loop on a ToolCalls finish with no client tools (pause_turn / server-side tools)', function () {
+    // Only ONE response is provided. A server-side pause (ToolCalls finish, no
+    // client toolCalls) must break cleanly — if the executor re-POSTed, the mock
+    // would run out of responses and error. This guards the pause_turn loop.
+    $driver = makeMockDriver([
+        new TextResponse(
+            'Let me search for that.',
+            new Usage(10, 20),
+            FinishReason::ToolCalls,
+            toolCalls: [],
+            providerToolCalls: [
+                ['type' => 'server_tool_use', 'id' => 'srvtoolu_1', 'name' => 'web_search'],
+            ],
+        ),
+    ]);
+
+    $dispatcher = makeFakeDispatcher();
+    $registry = new ToolRegistry([]);
+    $toolExecutor = new ToolExecutor($registry);
+    $executor = new AgentExecutor($driver, $toolExecutor, $dispatcher);
+
+    $result = $executor->execute(makeTextRequest(), maxSteps: 10, concurrent: true, meta: []);
+
+    expect($result->text)->toBe('Let me search for that.');
+    expect($result->totalSteps())->toBe(1);
+    expect($result->totalToolCalls())->toBe(0);
+    expect($result->providerToolCalls)->toHaveCount(1);
+    expect($driver->receivedRequests)->toHaveCount(1); // no re-POST loop
+});
+
 it('accumulates provider tool calls across multi-step runs', function () {
     $driver = makeMockDriver([
         new TextResponse(

--- a/tests/Unit/Persistence/Middleware/TrackStepTest.php
+++ b/tests/Unit/Persistence/Middleware/TrackStepTest.php
@@ -252,6 +252,72 @@ it('leaves annotations null when the response has none', function () {
     expect(ExecutionToolCall::firstOrFail()->annotations)->toBeNull();
 });
 
+it('swallows a provider-tool logging failure without breaking the response', function () {
+    // createToolCall throws — the per-record catch must continue, not propagate.
+    $service = new class extends ExecutionService
+    {
+        public function createToolCall(ToolCall $toolCall, ToolCallType $type = ToolCallType::Local, array $meta = []): ExecutionToolCall
+        {
+            throw new RuntimeException('tool-call logging failed');
+        }
+    };
+    $service->createExecution(provider: 'openai', model: 'gpt-5', type: ExecutionType::Text);
+    $service->beginExecution();
+
+    $response = new TextResponse(
+        text: 'ok',
+        usage: new Usage(1, 1),
+        finishReason: FinishReason::Stop,
+        providerToolCalls: [['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed']],
+        annotations: [['type' => 'url_citation', 'url' => 'https://php.net']],
+    );
+
+    $result = (new TrackStep($service))->handle(makeStepContext(), fn () => $response);
+
+    // Response flows through untouched; nothing persisted.
+    expect($result)->toBe($response);
+    expect(ExecutionToolCall::count())->toBe(0);
+});
+
+it('swallows an annotation-write failure without breaking the response', function () {
+    // The provider tool logs fine, but writing annotations throws — the
+    // attachAnnotations catch must swallow it (observability only).
+    $service = new class extends ExecutionService
+    {
+        public function createToolCall(ToolCall $toolCall, ToolCallType $type = ToolCallType::Local, array $meta = []): ExecutionToolCall
+        {
+            return new class extends ExecutionToolCall
+            {
+                public function update(array $attributes = [], array $options = []): bool
+                {
+                    throw new RuntimeException('annotations write failed');
+                }
+            };
+        }
+
+        public function beginToolCall(ExecutionToolCall $record): float
+        {
+            return microtime(true);
+        }
+
+        public function completeToolCall(ExecutionToolCall $record, float $startTime, string $result): void {}
+    };
+    $service->createExecution(provider: 'openai', model: 'gpt-5', type: ExecutionType::Text);
+    $service->beginExecution();
+
+    $response = new TextResponse(
+        text: 'ok',
+        usage: new Usage(1, 1),
+        finishReason: FinishReason::Stop,
+        providerToolCalls: [['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed']],
+        annotations: [['type' => 'url_citation', 'url' => 'https://php.net']],
+    );
+
+    $result = (new TrackStep($service))->handle(makeStepContext(), fn () => $response);
+
+    expect($result)->toBe($response);
+});
+
 it('marks failed provider tool calls as failed', function () {
     $service = makeServiceWithExecution();
     $middleware = new TrackStep($service);

--- a/tests/Unit/Persistence/Middleware/TrackStepTest.php
+++ b/tests/Unit/Persistence/Middleware/TrackStepTest.php
@@ -205,6 +205,53 @@ it('logs provider tool calls from response', function () {
     expect($toolCalls[1]->status)->toBe(ExecutionStatus::Completed);
 });
 
+it('persists response annotations onto the search action and ties them to its tool_call_id', function () {
+    $service = makeServiceWithExecution();
+    $middleware = new TrackStep($service);
+
+    $context = makeStepContext();
+    $annotations = [
+        ['type' => 'url_citation', 'url' => 'https://www.php.net/releases/8_4_22.php', 'title' => 'PHP 8.4.22'],
+    ];
+    $response = new TextResponse(
+        text: 'The latest PHP version is 8.4.22.',
+        usage: new Usage(10, 5),
+        finishReason: FinishReason::Stop,
+        providerToolCalls: [
+            ['type' => 'web_search_call', 'id' => 'ws_1', 'status' => 'completed'],
+        ],
+        annotations: $annotations,
+    );
+
+    $middleware->handle($context, fn () => $response);
+
+    $toolCall = ExecutionToolCall::firstOrFail();
+
+    // Stored as JSON on the action, retrievable, and the action is identified
+    // by its tool_call_id.
+    expect($toolCall->annotations)->toBe($annotations);
+    expect($toolCall->tool_call_id)->toBe('ws_1');
+    expect($toolCall->name)->toBe('web_search_call');
+});
+
+it('leaves annotations null when the response has none', function () {
+    $service = makeServiceWithExecution();
+    $middleware = new TrackStep($service);
+
+    $response = new TextResponse(
+        text: 'No search needed.',
+        usage: new Usage(5, 5),
+        finishReason: FinishReason::Stop,
+        providerToolCalls: [
+            ['type' => 'code_interpreter_call', 'id' => 'ci_1', 'status' => 'completed'],
+        ],
+    );
+
+    $middleware->handle(makeStepContext(), fn () => $response);
+
+    expect(ExecutionToolCall::firstOrFail()->annotations)->toBeNull();
+});
+
 it('marks failed provider tool calls as failed', function () {
     $service = makeServiceWithExecution();
     $middleware = new TrackStep($service);

--- a/tests/Unit/Providers/Anthropic/AnthropicDriverTest.php
+++ b/tests/Unit/Providers/Anthropic/AnthropicDriverTest.php
@@ -52,7 +52,7 @@ it('returns correct capabilities matrix', function () {
     expect($capabilities->rerank)->toBeFalse();
     expect($capabilities->vision)->toBeTrue();
     expect($capabilities->toolCalling)->toBeTrue();
-    expect($capabilities->providerTools)->toBeFalse();
+    expect($capabilities->providerTools)->toBeTrue();
     expect($capabilities->models)->toBeTrue();
     expect($capabilities->voices)->toBeFalse();
 });

--- a/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
@@ -9,6 +9,7 @@ use Atlasphp\Atlas\Providers\Anthropic\MessageFactory;
 use Atlasphp\Atlas\Providers\Anthropic\ResponseParser;
 use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
 use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Providers\Tools\WebSearch;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
@@ -63,6 +64,28 @@ function fakeAnthropicTextResponse(array $overrides = []): array
         ],
     ];
 }
+
+it('sends client and provider tools together in the tools array', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(fakeAnthropicTextResponse()),
+    ]);
+
+    $handler = makeAnthropicTextHandler();
+    $handler->text(makeAnthropicTextRequest([
+        'tools' => [new ToolDefinition('search', 'Search', ['type' => 'object'])],
+        'providerTools' => [new WebSearch(allowedDomains: ['laravel.com'])],
+    ]));
+
+    Http::assertSent(function ($request) {
+        $tools = $request['tools'];
+
+        return count($tools) === 2
+            && $tools[0]['name'] === 'search'
+            && $tools[1]['type'] === 'web_search_20250305'
+            && $tools[1]['name'] === 'web_search'
+            && $tools[1]['allowed_domains'] === ['laravel.com'];
+    });
+});
 
 it('sends text request to messages endpoint', function () {
     Http::fake([

--- a/tests/Unit/Providers/Anthropic/ResponseParserTest.php
+++ b/tests/Unit/Providers/Anthropic/ResponseParserTest.php
@@ -32,6 +32,35 @@ it('parses text from content blocks', function () {
     expect($result->text)->toBe('Hello!');
 });
 
+it('routes server_tool_use and result blocks to providerToolCalls, not the tool loop', function () {
+    $parser = makeAnthropicResponseParser();
+
+    $result = $parser->parseText([
+        'id' => 'msg_123',
+        'model' => 'claude-sonnet-4-5-20250514',
+        'content' => [
+            ['type' => 'text', 'text' => 'Claude Shannon was born in 1916.', 'citations' => [
+                ['type' => 'web_search_result_location', 'url' => 'https://en.wikipedia.org/wiki/Claude_Shannon', 'title' => 'Claude Shannon'],
+            ]],
+            ['type' => 'server_tool_use', 'id' => 'srvtoolu_1', 'name' => 'web_search', 'input' => ['query' => 'claude shannon']],
+            ['type' => 'web_search_tool_result', 'tool_use_id' => 'srvtoolu_1', 'content' => [['type' => 'web_search_result', 'url' => 'https://en.wikipedia.org/wiki/Claude_Shannon']]],
+        ],
+        'stop_reason' => 'end_turn',
+        'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+    ]);
+
+    // Server-side tools must NOT enter the client tool loop.
+    expect($result->toolCalls)->toBe([]);
+    expect($result->hasToolCalls())->toBeFalse();
+    // They surface as observability instead.
+    expect($result->providerToolCalls)->toHaveCount(2);
+    expect($result->providerToolCalls[0]['type'])->toBe('server_tool_use');
+    expect($result->providerToolCalls[1]['type'])->toBe('web_search_tool_result');
+    // Citations on text blocks become annotations.
+    expect($result->annotations)->toHaveCount(1);
+    expect($result->annotations[0]['url'])->toBe('https://en.wikipedia.org/wiki/Claude_Shannon');
+});
+
 it('parses tool_use blocks as tool calls', function () {
     $parser = makeAnthropicResponseParser();
 
@@ -196,7 +225,7 @@ it('includes meta with id and model', function () {
     expect($result->meta['model'])->toBe('claude-sonnet-4-5-20250514');
 });
 
-it('parses server_tool_use blocks as tool calls', function () {
+it('keeps server_tool_use out of the client tool loop (provider-executed)', function () {
     $parser = makeAnthropicResponseParser();
 
     $result = $parser->parseText([
@@ -209,13 +238,14 @@ it('parses server_tool_use blocks as tool calls', function () {
         'usage' => ['input_tokens' => 12, 'output_tokens' => 6],
     ]);
 
-    expect($result->toolCalls)->toHaveCount(1);
-    expect($result->toolCalls[0]->name)->toBe('web_search');
-    expect($result->toolCalls[0]->id)->toBe('srvtoolu_1');
-    expect($result->toolCalls[0]->arguments)->toBe(['query' => 'php 8.3 release notes']);
+    // The provider runs web_search server-side; it must not become a client ToolCall.
+    expect($result->toolCalls)->toBe([]);
+    expect($result->providerToolCalls)->toHaveCount(1);
+    expect($result->providerToolCalls[0]['name'])->toBe('web_search');
+    expect($result->providerToolCalls[0]['id'])->toBe('srvtoolu_1');
 });
 
-it('collects both tool_use and server_tool_use blocks together', function () {
+it('separates client tool_use from provider server_tool_use', function () {
     $parser = makeAnthropicResponseParser();
 
     $result = $parser->parseText([
@@ -229,9 +259,11 @@ it('collects both tool_use and server_tool_use blocks together', function () {
         'usage' => ['input_tokens' => 8, 'output_tokens' => 4],
     ]);
 
-    expect($result->toolCalls)->toHaveCount(2);
-    expect($result->toolCalls[0]->name)->toBe('web_search');
-    expect($result->toolCalls[1]->name)->toBe('user_tool');
+    // Only the client tool enters the loop; the server tool is observability.
+    expect($result->toolCalls)->toHaveCount(1);
+    expect($result->toolCalls[0]->name)->toBe('user_tool');
+    expect($result->providerToolCalls)->toHaveCount(1);
+    expect($result->providerToolCalls[0]['name'])->toBe('web_search');
 });
 
 it('maps pause_turn stop reason to ToolCalls', function () {

--- a/tests/Unit/Providers/Anthropic/ToolMapperTest.php
+++ b/tests/Unit/Providers/Anthropic/ToolMapperTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
+use Atlasphp\Atlas\Providers\Tools\CodeInterpreter;
+use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Providers\Tools\ProviderToolRegistry;
+use Atlasphp\Atlas\Providers\Tools\WebFetch;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Log;
@@ -53,12 +57,64 @@ it('maps empty tools returns empty', function () {
     expect($result)->toBe([]);
 });
 
-it('returns empty array for provider tools', function () {
+it('returns empty array for no provider tools', function () {
     $mapper = new ToolMapper;
 
     $result = $mapper->mapProviderTools([]);
 
     expect($result)->toBe([]);
+});
+
+it('maps web_search to Anthropic versioned server tool, preserving attributes', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->mapProviderTools([
+        new WebSearch(allowedDomains: ['laravel.com'], options: ['max_uses' => 3]),
+    ]);
+
+    expect($result[0])->toBe([
+        'type' => 'web_search_20250305',
+        'allowed_domains' => ['laravel.com'],
+        'max_uses' => 3,
+        'name' => 'web_search',
+    ]);
+});
+
+it('maps web_fetch to Anthropic versioned server tool', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->mapProviderTools([new WebFetch(['max_uses' => 2])]);
+
+    expect($result[0])->toBe([
+        'type' => 'web_fetch_20250910',
+        'max_uses' => 2,
+        'name' => 'web_fetch',
+    ]);
+});
+
+it('maps every provider tool the registry advertises for Anthropic', function () {
+    $mapper = new ToolMapper;
+
+    // Drift guard: anything the registry says Anthropic supports must actually map.
+    foreach (ProviderToolRegistry::forProvider('anthropic') as $type) {
+        $tool = new class($type) extends ProviderTool
+        {
+            public function __construct(private string $t)
+            {
+                parent::__construct();
+            }
+
+            public function type(): string
+            {
+                return $this->t;
+            }
+        };
+
+        $result = $mapper->mapProviderTools([$tool]);
+
+        expect($result)->toHaveCount(1);
+        expect($result[0]['name'])->not->toBeEmpty();
+    }
 });
 
 it('parses empty tool calls returns empty', function () {
@@ -69,19 +125,21 @@ it('parses empty tool calls returns empty', function () {
     expect($result)->toBe([]);
 });
 
-it('logs warning when provider tools are passed', function () {
+it('logs a warning and drops provider tools Anthropic does not support', function () {
     Log::shouldReceive('warning')
         ->once()
         ->withArgs(function (string $message, array $context) {
             return str_contains($message, 'not supported')
                 && $context['provider'] === 'anthropic'
-                && $context['tools'] === ['web_search'];
+                && $context['tools'] === ['code_interpreter'];
         });
 
     $mapper = new ToolMapper;
-    $result = $mapper->mapProviderTools([new WebSearch]);
+    // web_search is supported (kept); code_interpreter is not (dropped + warned).
+    $result = $mapper->mapProviderTools([new WebSearch, new CodeInterpreter]);
 
-    expect($result)->toBe([]);
+    expect($result)->toHaveCount(1);
+    expect($result[0]['type'])->toBe('web_search_20250305');
 });
 
 it('uses fallback for missing keys in tool_use blocks', function () {

--- a/tests/Unit/Providers/Google/ToolMapperTest.php
+++ b/tests/Unit/Providers/Google/ToolMapperTest.php
@@ -187,9 +187,9 @@ it('maps CodeExecution to gemini format via mapper', function () {
 it('maps non-gemini provider tools via toArray', function () {
     $mapper = new ToolMapper;
 
-    $result = $mapper->mapProviderTools([new WebSearch(maxResults: 3)]);
+    $result = $mapper->mapProviderTools([new WebSearch(allowedDomains: ['laravel.com'])]);
 
     expect($result)->toHaveCount(1);
     expect($result[0]['type'])->toBe('web_search');
-    expect($result[0]['max_results'])->toBe(3);
+    expect($result[0]['allowed_domains'])->toBe(['laravel.com']);
 });

--- a/tests/Unit/Providers/OpenAi/ToolMapperTest.php
+++ b/tests/Unit/Providers/OpenAi/ToolMapperTest.php
@@ -37,12 +37,45 @@ it('maps empty parameters to empty object', function () {
 it('maps provider tools via toArray', function () {
     $mapper = new ToolMapper;
 
-    $tools = [new WebSearch(maxResults: 5)];
+    $tools = [new WebSearch];
 
     $result = $mapper->mapProviderTools($tools);
 
     expect($result)->toHaveCount(1);
     expect($result[0]['type'])->toBe('web_search');
+    expect($result[0])->not->toHaveKey('filters');
+});
+
+it('passes web_search options through while nesting domain filters', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->mapProviderTools([
+        new WebSearch(allowedDomains: ['laravel.com'], options: ['search_context_size' => 'high']),
+    ]);
+
+    // Domain scoping is nested under `filters`; other attributes pass through.
+    expect($result[0])->toBe([
+        'type' => 'web_search',
+        'search_context_size' => 'high',
+        'filters' => ['allowed_domains' => ['laravel.com']],
+    ]);
+});
+
+it('nests web_search allowed domains under filters', function () {
+    $mapper = new ToolMapper;
+
+    $result = $mapper->mapProviderTools([
+        new WebSearch(allowedDomains: ['laravel.com'], blockedDomains: ['spam.example']),
+    ]);
+
+    expect($result[0]['type'])->toBe('web_search');
+    // Both domain lists nest under `filters` (Responses API supports each).
+    expect($result[0]['filters'])->toBe([
+        'allowed_domains' => ['laravel.com'],
+        'blocked_domains' => ['spam.example'],
+    ]);
+    expect($result[0])->not->toHaveKey('allowed_domains');
+    expect($result[0])->not->toHaveKey('blocked_domains');
 });
 
 it('parses function call items into ToolCall objects', function () {

--- a/tests/Unit/Providers/OpenAi/ToolMapperTest.php
+++ b/tests/Unit/Providers/OpenAi/ToolMapperTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\OpenAi\ToolMapper;
+use Atlasphp\Atlas\Providers\Tools\CodeInterpreter;
+use Atlasphp\Atlas\Providers\Tools\FileSearch;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 
@@ -44,6 +46,30 @@ it('maps provider tools via toArray', function () {
     expect($result)->toHaveCount(1);
     expect($result[0]['type'])->toBe('web_search');
     expect($result[0])->not->toHaveKey('filters');
+});
+
+it('returns non-web_search provider tools unchanged (mapProviderTool passthrough)', function () {
+    $mapper = new ToolMapper;
+
+    // file_search and code_interpreter are NOT web_search, so they hit the
+    // `return $payload` branch — emitted verbatim from toArray(), no `filters`.
+    $result = $mapper->mapProviderTools([
+        new FileSearch(stores: ['vs_1'], maxResults: 5),
+        new CodeInterpreter,
+    ]);
+
+    expect($result[0])->toBe([
+        'type' => 'file_search',
+        'vector_store_ids' => ['vs_1'],
+        'max_num_results' => 5,
+    ]);
+    expect($result[0])->not->toHaveKey('filters');
+
+    expect($result[1])->toBe([
+        'type' => 'code_interpreter',
+        'container' => ['type' => 'auto'],
+    ]);
+    expect($result[1])->not->toHaveKey('filters');
 });
 
 it('passes web_search options through while nesting domain filters', function () {

--- a/tests/Unit/Providers/Tools/ProviderToolRegistryTest.php
+++ b/tests/Unit/Providers/Tools/ProviderToolRegistryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Providers\Tools\ProviderToolRegistry;
+
+it('exposes the full provider support map', function () {
+    expect(ProviderToolRegistry::all())->toBe([
+        'openai' => ['web_search', 'file_search', 'code_interpreter'],
+        'anthropic' => ['web_search', 'web_fetch'],
+        'google' => ['google_search', 'code_execution'],
+        'xai' => ['web_search', 'x_search'],
+    ]);
+});
+
+it('returns supported tool types per provider', function () {
+    expect(ProviderToolRegistry::forProvider('anthropic'))->toBe(['web_search', 'web_fetch']);
+    expect(ProviderToolRegistry::forProvider('openai'))->toContain('file_search');
+});
+
+it('returns an empty list for an unknown provider', function () {
+    expect(ProviderToolRegistry::forProvider('nope'))->toBe([]);
+});
+
+it('answers whether a provider supports a tool type', function () {
+    expect(ProviderToolRegistry::supports('anthropic', 'web_search'))->toBeTrue();
+    expect(ProviderToolRegistry::supports('anthropic', 'web_fetch'))->toBeTrue();
+    // web_fetch is Anthropic-only — OpenAI has no such tool.
+    expect(ProviderToolRegistry::supports('openai', 'web_fetch'))->toBeFalse();
+    expect(ProviderToolRegistry::supports('xai', 'x_search'))->toBeTrue();
+    expect(ProviderToolRegistry::supports('google', 'google_search'))->toBeTrue();
+});

--- a/tests/Unit/Providers/Tools/ProviderToolTest.php
+++ b/tests/Unit/Providers/Tools/ProviderToolTest.php
@@ -23,18 +23,50 @@ it('WebSearch has correct type', function () {
     expect((new WebSearch)->type())->toBe('web_search');
 });
 
-it('WebSearch includes config when provided', function () {
-    $tool = new WebSearch(maxResults: 5, locale: 'en-US');
+it('WebSearch omits config when empty', function () {
+    expect((new WebSearch)->toArray())->toBe(['type' => 'web_search']);
+});
+
+it('WebSearch includes domain scoping when provided', function () {
+    $tool = new WebSearch(
+        allowedDomains: ['laravel.com', 'php.net'],
+        blockedDomains: ['spam.example'],
+    );
 
     expect($tool->toArray())->toBe([
         'type' => 'web_search',
-        'max_results' => 5,
-        'locale' => 'en-US',
+        'allowed_domains' => ['laravel.com', 'php.net'],
+        'blocked_domains' => ['spam.example'],
     ]);
 });
 
-it('WebSearch omits config when empty', function () {
-    expect((new WebSearch)->toArray())->toBe(['type' => 'web_search']);
+it('WebSearch omits empty domain arrays', function () {
+    $tool = new WebSearch(allowedDomains: [], blockedDomains: []);
+
+    expect($tool->toArray())->toBe(['type' => 'web_search']);
+});
+
+it('WebSearch accepts but ignores the deprecated maxResults/locale (no provider accepts them)', function () {
+    $tool = new WebSearch(allowedDomains: ['laravel.com'], maxResults: 5, locale: 'en-US');
+
+    expect($tool->toArray())->toBe([
+        'type' => 'web_search',
+        'allowed_domains' => ['laravel.com'],
+    ]);
+});
+
+it('WebSearch merges custom options bag (forward-compatible attributes)', function () {
+    $tool = new WebSearch(
+        allowedDomains: ['laravel.com'],
+        options: ['max_uses' => 5, 'search_context_size' => 'high'],
+    );
+
+    expect($tool->toArray())->toBe([
+        'type' => 'web_search',
+        'allowed_domains' => ['laravel.com'],
+        'max_uses' => 5,
+        'search_context_size' => 'high',
+    ]);
 });
 
 it('WebFetch has correct type and minimal output', function () {
@@ -57,11 +89,40 @@ it('FileSearch omits config when empty', function () {
     expect((new FileSearch)->toArray())->toBe(['type' => 'file_search']);
 });
 
-it('CodeInterpreter has correct type and minimal output', function () {
+it('FileSearch merges custom options bag', function () {
+    $tool = new FileSearch(stores: ['vs_1'], options: ['ranking_options' => ['ranker' => 'auto']]);
+
+    expect($tool->toArray())->toBe([
+        'type' => 'file_search',
+        'vector_store_ids' => ['vs_1'],
+        'ranking_options' => ['ranker' => 'auto'],
+    ]);
+});
+
+it('no-arg provider tools accept a custom options bag via the base constructor', function () {
+    expect((new WebFetch(['max_uses' => 4]))->toArray())->toBe([
+        'type' => 'web_fetch',
+        'max_uses' => 4,
+    ]);
+});
+
+it('CodeInterpreter defaults the container OpenAI requires', function () {
     $tool = new CodeInterpreter;
 
     expect($tool->type())->toBe('code_interpreter');
-    expect($tool->toArray())->toBe(['type' => 'code_interpreter']);
+    expect($tool->toArray())->toBe([
+        'type' => 'code_interpreter',
+        'container' => ['type' => 'auto'],
+    ]);
+});
+
+it('CodeInterpreter container can be overridden via the options bag', function () {
+    $tool = new CodeInterpreter(['container' => 'cntr_123']);
+
+    expect($tool->toArray())->toBe([
+        'type' => 'code_interpreter',
+        'container' => 'cntr_123',
+    ]);
 });
 
 // ─── Google Provider Tools ──────────────────────────────────────────────────


### PR DESCRIPTION
This pull request introduces comprehensive support for provider-native tools ("provider tools") across all major providers, with a focus on Anthropic (Claude) and improvements to OpenAI, Google, and xAI. It enables features like web search and web fetch on Anthropic, adds domain scoping (site inclusion/exclusion) for web search tools, and allows passing arbitrary provider options. The documentation and audit matrix are updated to reflect these capabilities, and a dedicated live test harness is added to verify provider tool support end-to-end.

**Provider tool support and API enhancements:**

- Anthropic (Claude) now fully supports provider-native tools, including web search (with citations) and web fetch, with correct mapping of domain scoping parameters and passthrough of extra options. The Anthropic driver, handler, and response parser are updated to merge client and provider tools, capture citations as annotations, and ensure provider tool calls are observable but not executed client-side. [[1]](diffhunk://#diff-a54c44d7107a40719614bf938e0085651ba903d6e280d937a12a1a5bccee68b4R33) [[2]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R74-R76) [[3]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R131-R144) [[4]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bR33-R64) [[5]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bR81-R82)
- OpenAI and xAI web search tools now correctly handle domain filters and provider-specific attributes, with fixes for previously unsupported fields. [[1]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L258-R268) [[2]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L279-R354)

**Testing and verification:**

- Adds a new `sandbox/test-provider-tools-live.php` script to exercise provider-native tools (web search, web fetch) through each provider's live API, verifying domain scoping, passthrough options, and observability of tool calls and citations.
- Updates the audit matrix in `AUDIT.md` to track provider tool support and live verification status, including a new matrix for provider-native tools and detailed per-provider notes.

**Documentation and developer experience:**

- Expands documentation on provider tools, domain scoping (site inclusion/exclusion), and the new `options` bag for forward-compatible custom attributes. Documents how to query provider tool support per provider for UI/validation. Updates the provider tool compatibility matrix and links to official provider docs. [[1]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L258-R268) [[2]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L279-R354)
- Updates the changelog for v3.3.0 with all new features, fixes, and migration notes.

**Summary of most important changes:**

**Provider tool support and API enhancements**
- Anthropic (Claude) now supports web search and web fetch provider tools, including domain scoping and passthrough options, with proper merging and observability of provider tool calls and citations. [[1]](diffhunk://#diff-a54c44d7107a40719614bf938e0085651ba903d6e280d937a12a1a5bccee68b4R33) [[2]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R74-R76) [[3]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R131-R144) [[4]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bR33-R64) [[5]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bR81-R82)
- OpenAI/xAI provider tools now correctly handle domain filters and custom attributes. [[1]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L258-R268) [[2]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L279-R354)

**Testing and verification**
- Adds `sandbox/test-provider-tools-live.php` for live end-to-end verification of provider tool support and observability.
- Updates `AUDIT.md` with a new provider tools matrix and detailed verification results.

**Documentation and developer experience**
- Expands documentation on provider tools, domain scoping, custom attributes, and querying support per provider. Updates the provider tool compatibility matrix and links to provider docs. [[1]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L258-R268) [[2]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373L279-R354)
- Updates `CHANGELOG.md` with a new release entry for v3.3.0, summarizing all new features and fixes.