### PR TITLE
Introduce configurable broadcast caps and normalized tool choice support

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Last full run: 2026-06-08** (Google/OpenAI/xAI) · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
+**Last full run: 2026-06-09** (all 4 providers — 2 transient infra failures: OpenAI TTS timeout, xAI voices 500) · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
 
 Reproduce:
 - Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
@@ -24,10 +24,10 @@ Both require the provider's API key in `sandbox/.env`.
 
 | Provider    | Text | Stream | Structured | Tools | Prov.Tools | Vision | Image | TTS | STT | Embeddings | Moderation | Rerank | Video | Voice | Last live pass |
 |-------------|:----:|:------:|:----------:|:-----:|:----------:|:------:|:-----:|:---:|:---:|:----------:|:----------:|:------:|:-----:|:-----:|:--------------:|
-| OpenAI      | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | ✅    | ✅  | ✅  | ✅         | ✅         | —      | ✅    | ⚠️    | 2026-06-06     |
-| Anthropic   | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | —     | —   | —   | —          | —          | —      | —     | —     | 2026-06-07     |
-| Google      | ✅   | ✅     | ✅         | ✅    | ⚠️         | ✅     | ✅    | —   | —   | ✅         | —          | —      | —     | —     | 2026-06-07     |
-| xAI         | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | ✅    | ✅  | —   | —          | —          | —      | ✅    | ⚠️    | 2026-06-07     |
+| OpenAI      | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | ✅    | ⚠️  | ✅  | ✅         | ✅         | —      | ✅    | ⚠️    | 2026-06-09     |
+| Anthropic   | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | —     | —   | —   | —          | —          | —      | —     | —     | 2026-06-09     |
+| Google      | ✅   | ✅     | ✅         | ✅    | ⚠️         | ✅     | ✅    | —   | —   | ✅         | —          | —      | —     | —     | 2026-06-09     |
+| xAI         | ✅   | ✅     | ✅         | ✅    | ✅         | ✅     | ✅    | ✅  | —   | —          | —          | —      | ✅    | ⚠️    | 2026-06-09     |
 | ElevenLabs  | —    | —      | —          | —     | —          | —      | —     | ❌  | ❌  | —          | —          | —      | —     | ⚠️    | —              |
 | Cohere      | —    | —      | —          | —     | —          | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
 | Jina        | —    | —      | —          | —     | —          | —      | —     | —   | —   | —          | —          | ❌     | —     | —     | —              |
@@ -120,10 +120,10 @@ Provider-normalized `tool_choice` verified end-to-end through Atlas (`sandbox/te
 
 | Provider   | Live suite                 | Notes |
 |------------|----------------------------|-------|
-| Anthropic  | **17/17 passed** (06-07)   | Text, streaming, structured, tools, vision. Prompt caching (cache_control) + media-replay vision verified live (above). |
-| Google     | **23/23 passed** (06-08)   | Full modality suite green, incl. the new image-to-image test. Prompt caching (implicit) + media-replay vision verified live. Provider-tools observability gap unchanged (`google_search`/`code_execution` ground correctly but aren't mapped to `providerToolCalls`). |
-| OpenAI     | **36/36 passed** (06-08)   | Full suite green, incl. image-to-image edits. (The STT round-trip that aborted earlier runs completed this time.) |
-| xAI        | **21/21 passed** (06-08)   | Full suite green, incl. image-to-image (own JSON edits handler). Prompt caching (automatic) + media-replay vision (`grok-4.3`) verified live. Note: `grok-2-vision-1212` retired → use `grok-4.3` for vision. |
+| Anthropic  | **17/17 passed** (06-09)   | Text, streaming, structured, tools, vision — all green. Prompt caching (cache_control) + media-replay vision verified live (above). |
+| Google     | **23/23 passed** (06-09)   | Full modality suite green, incl. image-to-image. Provider-tools observability gap unchanged (`google_search`/`code_execution` ground correctly but aren't mapped to `providerToolCalls`). |
+| OpenAI     | **35/36 passed** (06-09)   | Text/tools/streaming/structured/vision/image/STT/video all green. **1 transient failure:** text-to-speech hit a cURL-28 120s timeout on `/audio/speech` (provider/network, not a code regression) — re-run to confirm. |
+| xAI        | **20/21 passed** (06-09)   | Full suite green incl. image-to-image. **1 transient failure:** `voices` list returned HTTP 500 from xAI (server-side, unrelated to this change). Note: `grok-2-vision-1212` retired → use `grok-4.3` for vision. |
 | ElevenLabs | **not verified**           | Blocked: sandbox `config/atlas.php` has no `elevenlabs` provider block, so the base URL is empty. Package URL resolution is correct — purely a sandbox config gap. |
 | Cohere     | **not verified**           | No `COHERE_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |
 | Jina       | **not verified**           | No `JINA_API_KEY` in `sandbox/.env`. Rerank handler covered by unit tests only. |

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Last full run: 2026-06-08** (Google/OpenAI/xAI) · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
+**Last full run: 2026-06-08** (Google/OpenAI/xAI) · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
 
 Reproduce:
 - Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
@@ -103,6 +103,19 @@ Reference image input to **image generation** — `Atlas::image(...)->withMedia(
 
 Each provider's image handler owns its own request shape — xAI does **not** accept OpenAI's multipart edits (it returns HTTP 415; it requires JSON), so it has a dedicated handler. Saved outputs: `sandbox/storage/providers/{google,openai,xai}/image-*-edit.png`. **Future image audits must re-run the reference-media test in each provider suite.**
 
+## Forced tool choice (live, 2026-06-09)
+
+Provider-normalized `tool_choice` verified end-to-end through Atlas (`sandbox/test-force-tools-live.php`). `->forceTools()` (tool_choice = required) is sent to each provider in its own shape (OpenAI/xAI string `required`, Anthropic `{type:any}`, Google `tool_config.mode=ANY`); the executor then relaxes the choice to `auto` after the opening step so the model still produces a final reply. Each test forces the model to call a probe tool on a trivial "just say hello" prompt it would otherwise answer in plain text.
+
+| Provider  | Model              | Forced tool called | Final reply after relaxation |
+|-----------|--------------------|:------------------:|:----------------------------:|
+| OpenAI    | gpt-4o-mini        | ✅                  | ✅ "Hello! How are you today?" |
+| Anthropic | claude-sonnet-4-5  | ✅                  | ✅ "Hello! 👋"                 |
+| Google    | gemini-2.5-flash   | ✅                  | ✅ "Hello back to you!"        |
+| xAI       | grok-4.3           | ✅                  | ✅ "Hello!"                    |
+
+**Specific named tool** (`->toolChoice(ToolChoice::tool('log_mood'))`) verified live on **all four providers**: with two tools available (`get_time` + `log_mood`), the forced tool is the one that opens the turn (not the other) — proving the choice targets the named tool, not just "some tool". Result: **16/16 live checks passed** (4 forceTools + 4 specific-tool, ×2 assertions). (Note: forcing a tool on OpenAI requires a valid strict-mode function schema — Atlas tools with `parameters()` already emit `additionalProperties:false`.)
+
 ## Per-provider results
 
 | Provider   | Live suite                 | Notes |
@@ -117,6 +130,6 @@ Each provider's image handler owns its own request shape — xAI does **not** ac
 | Ollama     | **not run**                | Points at a LAN host (`OLLAMA_URL`); not exercised in this run. |
 | LM Studio  | **not run**                | Requires a local LM Studio instance; not exercised in this run. |
 
-## Package checks (2026-06-08)
+## Package checks (2026-06-09)
 
-`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 2881 Pest tests ✓**.
+`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 2929 Pest tests ✓** (incl. the provider-normalized `tool_choice` suite + the broadcast payload-cap default fix).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Tool-call orchestration events (`AgentToolCallStarted` / `AgentToolCallCompleted` / `AgentToolCallFailed`) now broadcast the call's **full** arguments, result, and error by default, instead of hard-truncating to 200/500 characters — so a live trace consumer (e.g. an admin tool panel) sees the complete payload. A new `atlas.broadcast.max_tool_payload_length` config (env `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`, default `null` = no cap) re-introduces a per-string character cap for deployments whose socket transport (Reverb / Pusher) limits message size.
+
+### Migration
+
+No code changes required. If you relied on the old 200/500-char broadcast caps to stay under a socket message-size limit, set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD` (e.g. `8000`).
+
+---
+
 ## [v3.4.0](https://github.com/atlas-php/atlas/releases/tag/v3.4.0) - 2026-06-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
-## [Unreleased]
+## [v3.4.0](https://github.com/atlas-php/atlas/releases/tag/v3.4.0) - 2026-06-09
+
+### Added
+
+- Force tool calls with `->forceTools()` or `->toolChoice(...)` — require any tool, a specific tool, `auto`, or `none`. Atlas sends the right format for every provider; in agent loops it forces the first step then relaxes so the model still replies.
 
 ### Changed
 
-- Tool-call orchestration events (`AgentToolCallStarted` / `AgentToolCallCompleted` / `AgentToolCallFailed`) now broadcast the call's **full** arguments, result, and error by default, instead of hard-truncating to 200/500 characters — so a live trace consumer (e.g. an admin tool panel) sees the complete payload. A new `atlas.broadcast.max_tool_payload_length` config (env `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`, default `null` = no cap) re-introduces a per-string character cap for deployments whose socket transport (Reverb / Pusher) limits message size.
+- Broadcasted tool-call events now send the full arguments/result/error by default (previously truncated). Set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD` to cap the length if your socket transport limits message size.
 
 ### Migration
 
-No code changes required. If you relied on the old 200/500-char broadcast caps to stay under a socket message-size limit, set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD` (e.g. `8000`).
+No breaking changes. If you relied on the old broadcast truncation to stay under a socket size limit, set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD` (e.g. `8000`).
 
 ---
 
-## [v3.4.0](https://github.com/atlas-php/atlas/releases/tag/v3.4.0) - 2026-06-08
+## [v3.3.2](https://github.com/atlas-php/atlas/releases/tag/v3.3.2) - 2026-06-08
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Changed
 
-- Broadcasted tool-call events now send the full arguments/result/error by default (previously truncated). Set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD` to cap the length if your socket transport limits message size.
+- Broadcasted tool-call events now cap each argument/result/error to **2048 bytes** by default (configurable via `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`; set `0` for uncapped), so large tool payloads stay under socket transport limits (Pusher/Reverb) instead of silently dropping the event or closing the connection.
 
 ### Migration
 
-No breaking changes. If you relied on the old broadcast truncation to stay under a socket size limit, set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD` (e.g. `8000`).
+No breaking changes. Broadcast tool payloads are capped to 2048 bytes by default — set `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD=0` to broadcast uncapped, or a higher byte value to suit your transport.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ $response = Atlas::agent('support')
         'customer_name' => 'Sarah',
         'account_tier' => 'Premium',
     ])
+    ->withTools([
+        HelpDeskSearchTool::class,
+        OrderStatusTool::class,
+    ])
     ->message('Where is my order #12345?')
     ->asText();
 

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -232,13 +232,17 @@ return [
     | Failed) broadcast the call's arguments, result, and error to live consumers
     | such as an admin trace panel. By default the full payload is broadcast so
     | nothing is hidden from view. If your socket transport (Reverb / Pusher)
-    | limits message size, set a per-string character cap to truncate large
-    | payloads before they are broadcast. null (default) = no cap.
+    | limits message size, set a per-string cap to truncate large payloads
+    | before they are broadcast.
+    |
+    | The cap counts characters (mb_substr), not bytes — for multibyte content
+    | set it below your transport's byte limit accordingly. null / 0 / negative
+    | (the default) = no cap.
     |
     */
 
     'broadcast' => [
-        'max_tool_payload_length' => env('ATLAS_BROADCAST_MAX_TOOL_PAYLOAD', 512),
+        'max_tool_payload_length' => env('ATLAS_BROADCAST_MAX_TOOL_PAYLOAD'),
     ],
 
     /*

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -225,6 +225,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Broadcasting
+    |--------------------------------------------------------------------------
+    |
+    | The tool-call orchestration events (AgentToolCallStarted / Completed /
+    | Failed) broadcast the call's arguments, result, and error to live consumers
+    | such as an admin trace panel. By default the full payload is broadcast so
+    | nothing is hidden from view. If your socket transport (Reverb / Pusher)
+    | limits message size, set a per-string character cap to truncate large
+    | payloads before they are broadcast. null (default) = no cap.
+    |
+    */
+
+    'broadcast' => [
+        'max_tool_payload_length' => env('ATLAS_BROADCAST_MAX_TOOL_PAYLOAD', 512),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Middleware
     |--------------------------------------------------------------------------
     |

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -230,19 +230,18 @@ return [
     |
     | The tool-call orchestration events (AgentToolCallStarted / Completed /
     | Failed) broadcast the call's arguments, result, and error to live consumers
-    | such as an admin trace panel. By default the full payload is broadcast so
-    | nothing is hidden from view. If your socket transport (Reverb / Pusher)
-    | limits message size, set a per-string cap to truncate large payloads
-    | before they are broadcast.
+    | such as an admin trace panel. Each broadcast string is capped to this many
+    | **bytes** (mb_strcut) so a large tool result/argument/error can't exceed the
+    | socket transport's per-message limit (Pusher ~10KB; Reverb configurable) —
+    | which would otherwise silently drop the event or close the connection.
     |
-    | The cap counts characters (mb_substr), not bytes — for multibyte content
-    | set it below your transport's byte limit accordingly. null / 0 / negative
-    | (the default) = no cap.
+    | Default 2048 bytes is safe for any UTF-8 content under a 10KB transport limit
+    | with envelope overhead. Set 0 (or null / negative) to broadcast uncapped.
     |
     */
 
     'broadcast' => [
-        'max_tool_payload_length' => env('ATLAS_BROADCAST_MAX_TOOL_PAYLOAD'),
+        'max_tool_payload_length' => env('ATLAS_BROADCAST_MAX_TOOL_PAYLOAD', 2048),
     ],
 
     /*

--- a/docs/advanced/events.md
+++ b/docs/advanced/events.md
@@ -46,6 +46,10 @@ Fired by the executor during the agent tool loop.
 
 </div>
 
+::: tip Broadcast payload size
+The tool-call events (`AgentToolCallStarted` / `AgentToolCallCompleted` / `AgentToolCallFailed`) broadcast the call's **full** arguments, result, and error by default, so a live trace consumer sees everything. If your socket transport (Reverb / Pusher) limits message size, set `atlas.broadcast.max_tool_payload_length` (env `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`) to a per-string character cap. `null` (default) means no cap.
+:::
+
 ## Stream Events
 
 Fired during streaming responses. All stream events implement `ShouldBroadcastNow` for real-time WebSocket delivery.

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -248,6 +248,44 @@ $response = Atlas::text('openai', 'gpt-4o')
     ->asText();
 ```
 
+## Forcing Tool Use (Tool Choice)
+
+By default the model decides whether to call a tool. Use a **tool choice** to control that — Atlas translates it to each provider's own `tool_choice` shape, so you never hand-write provider-specific payloads.
+
+```php
+use Atlasphp\Atlas\Tools\ToolChoice;
+
+// Require the model to call *some* tool this turn (sugar: ->forceTools()).
+Atlas::text('openai', 'gpt-4o')
+    ->withTools([LookupOrderTool::class])
+    ->forceTools()                      // === ->toolChoice(ToolChoice::required())
+    ->message('Where is my order?')
+    ->asText();
+
+// Require a *specific* tool by name.
+->toolChoice(ToolChoice::tool('lookup_order'))
+
+// Let the model decide (the default), or forbid tools entirely.
+->toolChoice(ToolChoice::auto())
+->toolChoice(ToolChoice::none())
+```
+
+The choice maps per provider — `required` becomes the OpenAI/xAI/Chat-Completions string `"required"`, Anthropic `{"type":"any"}`, and Google `tool_config.function_calling_config.mode = "ANY"`; a named tool maps to each provider's "force this function" form.
+
+**In an agent tool loop**, a forced choice is applied only to the **opening step** and then relaxed to `auto`, so the model calls a tool to start the turn but can still produce a final text reply (a permanently-forced choice would loop until `max_steps`). Agents can declare a default in code:
+
+```php
+class SupportAgent extends Agent
+{
+    public function toolChoice(): ?ToolChoice
+    {
+        return ToolChoice::required();
+    }
+}
+```
+
+> Forcing a tool on OpenAI uses strict-mode function schemas — Atlas tools that declare `parameters()` already emit a valid strict schema. Tool choice is ignored during structured output (`->asStructured()`), which forces its own schema tool. Providers without a native tool-choice knob (e.g. provider-native server tools) fall back to their default behavior.
+
 ## Provider Compatibility
 
 Atlas adapts tool definitions to each provider's tool-calling format. For example, the Google provider normalizes tool parameter schemas

--- a/sandbox/test-force-tools-live.php
+++ b/sandbox/test-force-tools-live.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Forced tool choice — live API test across providers.
+ *
+ * Verifies the provider-normalized tool choice end-to-end through Atlas:
+ * `->forceTools()` (tool_choice = required) makes the model call a tool even on a
+ * prompt it would normally answer in plain text, and the executor then relaxes the
+ * choice so the model still produces a final reply. Also checks a specific named
+ * tool is forced to open the turn.
+ *
+ * Usage: php test-force-tools-live.php
+ * Requires OPENAI_API_KEY / ANTHROPIC_API_KEY / GEMINI_API_KEY / XAI_API_KEY in sandbox/.env
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => ['api_key' => env('OPENAI_API_KEY'), 'url' => env('OPENAI_URL', 'https://api.openai.com/v1')],
+    'anthropic' => ['api_key' => env('ANTHROPIC_API_KEY'), 'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1')],
+    'google' => ['api_key' => env('GEMINI_API_KEY', env('GOOGLE_API_KEY')), 'url' => env('GOOGLE_URL', 'https://generativelanguage.googleapis.com')],
+    'xai' => ['api_key' => env('XAI_API_KEY'), 'url' => env('XAI_URL', 'https://api.x.ai/v1')],
+]);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Schema\Fields\StringField;
+use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
+
+/** Records the order tools were called, so we can prove WHICH tool a choice forced. */
+class ToolCallLog
+{
+    /** @var array<int, string> */
+    public static array $order = [];
+
+    public static function reset(): void
+    {
+        self::$order = [];
+    }
+}
+
+/** A probe tool that records each invocation, so we can prove the model was forced to call it. */
+class LogMoodTool extends Tool
+{
+    public function name(): string
+    {
+        return 'log_mood';
+    }
+
+    public function description(): string
+    {
+        return 'Record the conversation mood. Returns a confirmation.';
+    }
+
+    /** A real parameter so the function schema is valid under OpenAI strict mode. */
+    public function parameters(): array
+    {
+        return [new StringField('mood', 'One word describing the current mood.')];
+    }
+
+    public function handle(array $args, array $context): mixed
+    {
+        ToolCallLog::$order[] = 'log_mood';
+
+        return 'mood logged';
+    }
+}
+
+/** A second, unrelated tool — the choice must NOT pick this when a specific tool is forced. */
+class GetTimeTool extends Tool
+{
+    public function name(): string
+    {
+        return 'get_time';
+    }
+
+    public function description(): string
+    {
+        return 'Get the current time for a timezone.';
+    }
+
+    public function parameters(): array
+    {
+        return [new StringField('zone', 'The IANA timezone, e.g. UTC.')];
+    }
+
+    public function handle(array $args, array $context): mixed
+    {
+        ToolCallLog::$order[] = 'get_time';
+
+        return '12:00 UTC';
+    }
+}
+
+$pass = 0;
+$fail = 0;
+function check(string $label, bool $ok, string $detail = ''): void
+{
+    global $pass, $fail;
+    $ok ? $pass++ : $fail++;
+    echo '  '.($ok ? '✓' : '✗')."  {$label}".($detail !== '' ? "  — {$detail}" : '')."\n";
+}
+
+/** forceTools(): the model must call the only tool even though the prompt invites a plain reply. */
+function runForce(Provider $provider, string $model): void
+{
+    $label = $provider->value;
+    try {
+        ToolCallLog::reset();
+
+        $r = Atlas::text($provider, $model)
+            ->instructions('Reply in plain conversational text.')
+            ->message('Just say hello back to me.')
+            ->withTools([new LogMoodTool])
+            ->forceTools()
+            ->asText();
+
+        check("{$label}: forced tool was called on a trivial prompt", ToolCallLog::$order !== [], 'order='.implode(',', ToolCallLog::$order));
+        check("{$label}: model still produced a final reply (first-step relaxation)", $r->text !== '', mb_substr($r->text, 0, 60));
+    } catch (Throwable $e) {
+        check("{$label}: forceTools live call", false, get_class($e).': '.$e->getMessage());
+    }
+}
+
+/**
+ * toolChoice(specific tool): with TWO tools available, the named one must be the
+ * tool that opens the turn — proving the choice targets a specific tool, not just
+ * "some tool". A trivial prompt that maps to neither tool removes any natural pull.
+ */
+function runForceSpecific(Provider $provider, string $model): void
+{
+    $label = $provider->value;
+    try {
+        ToolCallLog::reset();
+
+        $r = Atlas::text($provider, $model)
+            ->instructions('Reply in plain conversational text.')
+            ->message('How are you today?')
+            ->withTools([new GetTimeTool, new LogMoodTool])
+            ->toolChoice(ToolChoice::tool('log_mood'))
+            ->asText();
+
+        check("{$label}: the FORCED tool (log_mood) opened the turn, not the other", (ToolCallLog::$order[0] ?? null) === 'log_mood', 'order='.implode(',', ToolCallLog::$order));
+        check("{$label}: model still produced a final reply", $r->text !== '', mb_substr($r->text, 0, 60));
+    } catch (Throwable $e) {
+        check("{$label}: specific-tool live call", false, get_class($e).': '.$e->getMessage());
+    }
+}
+
+echo "── forceTools (tool_choice = required) across providers ──\n";
+runForce(Provider::OpenAI, 'gpt-4o-mini');
+runForce(Provider::Anthropic, 'claude-sonnet-4-5');
+runForce(Provider::Google, 'gemini-2.5-flash');
+runForce(Provider::xAI, 'grok-4.3');
+
+echo "\n── toolChoice(specific tool) — forces a NAMED tool over another, across providers ──\n";
+runForceSpecific(Provider::OpenAI, 'gpt-4o-mini');
+runForceSpecific(Provider::Anthropic, 'claude-sonnet-4-5');
+runForceSpecific(Provider::Google, 'gemini-2.5-flash');
+runForceSpecific(Provider::xAI, 'grok-4.3');
+
+echo "\n".str_repeat('─', 50)."\n";
+echo "  Passed: {$pass}   Failed: {$fail}\n";
+
+exit($fail === 0 ? 0 : 1);

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -9,6 +9,7 @@ use Atlasphp\Atlas\Messages\AssistantMessage;
 use Atlasphp\Atlas\Messages\Message;
 use Atlasphp\Atlas\Messages\UserMessage;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 
 /**
  * Abstract base class for Atlas agents.
@@ -193,5 +194,14 @@ abstract class Agent
     public function providerOptions(): array
     {
         return [];
+    }
+
+    /**
+     * Force how the model chooses tools (auto / required / none / a specific
+     * tool). Null falls back to the provider default (auto when tools exist).
+     */
+    public function toolChoice(): ?ToolChoice
+    {
+        return null;
     }
 }

--- a/src/Enums/ToolChoiceMode.php
+++ b/src/Enums/ToolChoiceMode.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Enums;
+
+/**
+ * How a model should decide whether to call tools on a turn.
+ *
+ * Provider-normalized: each provider's ToolMapper translates these to the
+ * vendor's own shape (OpenAI/xAI string, Anthropic object, Google tool_config).
+ */
+enum ToolChoiceMode: string
+{
+    /** The model decides whether to call a tool (provider default when tools exist). */
+    case Auto = 'auto';
+
+    /** The model must call a tool — any of the available tools, or a specific one. */
+    case Required = 'required';
+
+    /** The model must not call any tool. */
+    case None = 'none';
+}

--- a/src/Events/AgentToolCallCompleted.php
+++ b/src/Events/AgentToolCallCompleted.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Events;
 
 use Atlasphp\Atlas\Events\Concerns\BroadcastsOnOptionalChannel;
+use Atlasphp\Atlas\Events\Concerns\CapsBroadcastPayload;
 use Atlasphp\Atlas\Executor\ToolResult;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Illuminate\Broadcasting\Channel;
@@ -16,6 +17,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 class AgentToolCallCompleted implements ShouldBroadcastNow
 {
     use BroadcastsOnOptionalChannel;
+    use CapsBroadcastPayload;
 
     public function __construct(
         public readonly ToolCall $toolCall,
@@ -42,7 +44,7 @@ class AgentToolCallCompleted implements ShouldBroadcastNow
             'agentKey' => $this->agentKey,
             'toolCallId' => $this->toolCall->id,
             'toolName' => $this->toolCall->name,
-            'result' => mb_substr($this->result->content, 0, 500),
+            'result' => $this->capBroadcastPayload($this->result->content),
             'isError' => $this->result->isError,
             'stepNumber' => $this->stepNumber,
         ];

--- a/src/Events/AgentToolCallFailed.php
+++ b/src/Events/AgentToolCallFailed.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Events;
 
 use Atlasphp\Atlas\Events\Concerns\BroadcastsOnOptionalChannel;
+use Atlasphp\Atlas\Events\Concerns\CapsBroadcastPayload;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
@@ -15,6 +16,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 class AgentToolCallFailed implements ShouldBroadcastNow
 {
     use BroadcastsOnOptionalChannel;
+    use CapsBroadcastPayload;
 
     public function __construct(
         public readonly ToolCall $toolCall,
@@ -41,7 +43,7 @@ class AgentToolCallFailed implements ShouldBroadcastNow
             'agentKey' => $this->agentKey,
             'toolCallId' => $this->toolCall->id,
             'toolName' => $this->toolCall->name,
-            'error' => mb_substr($this->exception->getMessage(), 0, 500),
+            'error' => $this->capBroadcastPayload($this->exception->getMessage()),
             'stepNumber' => $this->stepNumber,
         ];
     }

--- a/src/Events/AgentToolCallStarted.php
+++ b/src/Events/AgentToolCallStarted.php
@@ -48,8 +48,9 @@ class AgentToolCallStarted implements ShouldBroadcastNow
     }
 
     /**
-     * Cap each string argument value to the configured broadcast limit (full by
-     * default), so large arguments can't overflow the socket transport.
+     * Cap each argument value to the configured broadcast limit, so large
+     * arguments — including a big nested structure — can't overflow the socket
+     * transport.
      *
      * @param  array<string, mixed>  $arguments
      * @return array<string, mixed>
@@ -59,7 +60,7 @@ class AgentToolCallStarted implements ShouldBroadcastNow
         $capped = [];
 
         foreach ($arguments as $key => $value) {
-            $capped[$key] = is_string($value) ? $this->capBroadcastPayload($value) : $value;
+            $capped[$key] = $this->capBroadcastValue($value);
         }
 
         return $capped;

--- a/src/Events/AgentToolCallStarted.php
+++ b/src/Events/AgentToolCallStarted.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Events;
 
 use Atlasphp\Atlas\Events\Concerns\BroadcastsOnOptionalChannel;
+use Atlasphp\Atlas\Events\Concerns\CapsBroadcastPayload;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
@@ -15,6 +16,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 class AgentToolCallStarted implements ShouldBroadcastNow
 {
     use BroadcastsOnOptionalChannel;
+    use CapsBroadcastPayload;
 
     public function __construct(
         public readonly ToolCall $toolCall,
@@ -40,25 +42,26 @@ class AgentToolCallStarted implements ShouldBroadcastNow
             'agentKey' => $this->agentKey,
             'toolCallId' => $this->toolCall->id,
             'toolName' => $this->toolCall->name,
-            'arguments' => $this->truncateArguments($this->toolCall->arguments),
+            'arguments' => $this->capArguments($this->toolCall->arguments),
             'stepNumber' => $this->stepNumber,
         ];
     }
 
     /**
-     * Truncate argument string values to prevent large WebSocket payloads.
+     * Cap each string argument value to the configured broadcast limit (full by
+     * default), so large arguments can't overflow the socket transport.
      *
      * @param  array<string, mixed>  $arguments
      * @return array<string, mixed>
      */
-    private function truncateArguments(array $arguments): array
+    private function capArguments(array $arguments): array
     {
-        $truncated = [];
+        $capped = [];
 
         foreach ($arguments as $key => $value) {
-            $truncated[$key] = is_string($value) ? mb_substr($value, 0, 200) : $value;
+            $capped[$key] = is_string($value) ? $this->capBroadcastPayload($value) : $value;
         }
 
-        return $truncated;
+        return $capped;
     }
 }

--- a/src/Events/Concerns/CapsBroadcastPayload.php
+++ b/src/Events/Concerns/CapsBroadcastPayload.php
@@ -8,14 +8,16 @@ namespace Atlasphp\Atlas\Events\Concerns;
  * Caps a string payload broadcast by the tool-call orchestration events to the
  * `atlas.broadcast.max_tool_payload_length` limit, keeping a large tool result
  * or argument from exceeding the socket transport's message-size cap. With no
- * limit configured (the default) the value is broadcast in full — nothing is
- * hidden from a live trace view.
+ * limit configured (the default), or a value of 0 or less, the value is
+ * broadcast in full — nothing is hidden from a live trace view.
+ *
+ * The cap is a character count (mb_substr), not a byte count.
  */
 trait CapsBroadcastPayload
 {
     protected function capBroadcastPayload(string $value): string
     {
-        $max = (int) config('atlas.broadcast.max_tool_payload_length', 512);
+        $max = (int) config('atlas.broadcast.max_tool_payload_length');
 
         return $max > 0 ? mb_substr($value, 0, $max) : $value;
     }

--- a/src/Events/Concerns/CapsBroadcastPayload.php
+++ b/src/Events/Concerns/CapsBroadcastPayload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Events\Concerns;
+
+/**
+ * Caps a string payload broadcast by the tool-call orchestration events to the
+ * `atlas.broadcast.max_tool_payload_length` limit, keeping a large tool result
+ * or argument from exceeding the socket transport's message-size cap. With no
+ * limit configured (the default) the value is broadcast in full — nothing is
+ * hidden from a live trace view.
+ */
+trait CapsBroadcastPayload
+{
+    protected function capBroadcastPayload(string $value): string
+    {
+        $max = (int) config('atlas.broadcast.max_tool_payload_length', 512);
+
+        return $max > 0 ? mb_substr($value, 0, $max) : $value;
+    }
+}

--- a/src/Events/Concerns/CapsBroadcastPayload.php
+++ b/src/Events/Concerns/CapsBroadcastPayload.php
@@ -5,20 +5,54 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Events\Concerns;
 
 /**
- * Caps a string payload broadcast by the tool-call orchestration events to the
- * `atlas.broadcast.max_tool_payload_length` limit, keeping a large tool result
- * or argument from exceeding the socket transport's message-size cap. With no
- * limit configured (the default), or a value of 0 or less, the value is
- * broadcast in full — nothing is hidden from a live trace view.
+ * Caps the string payloads broadcast by the tool-call orchestration events to the
+ * `atlas.broadcast.max_tool_payload_length` limit, keeping a large tool result,
+ * argument, or error from exceeding the socket transport's per-message size cap
+ * (Pusher ~10KB; Reverb configurable) — which would otherwise drop the event or
+ * close the connection.
  *
- * The cap is a character count (mb_substr), not a byte count.
+ * The cap is a **byte** length (mb_strcut, never splitting a multibyte char), so
+ * the result is safe to put on a byte-limited transport. A value of 0 or less (or
+ * an unset config) disables the cap. Default is 2048 bytes.
  */
 trait CapsBroadcastPayload
 {
     protected function capBroadcastPayload(string $value): string
     {
-        $max = (int) config('atlas.broadcast.max_tool_payload_length');
+        $max = $this->maxBroadcastPayloadBytes();
 
-        return $max > 0 ? mb_substr($value, 0, $max) : $value;
+        return $max > 0 ? mb_strcut($value, 0, $max) : $value;
+    }
+
+    /**
+     * Cap an arbitrary tool-argument value. Strings are byte-truncated; a
+     * non-string (e.g. a nested array) is left as-is unless its JSON form exceeds
+     * the cap, in which case the truncated JSON is sent so a large nested
+     * structure can't blow past the transport limit.
+     */
+    protected function capBroadcastValue(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return $this->capBroadcastPayload($value);
+        }
+
+        $max = $this->maxBroadcastPayloadBytes();
+
+        if ($max <= 0) {
+            return $value;
+        }
+
+        $encoded = json_encode($value);
+
+        if ($encoded === false || strlen($encoded) <= $max) {
+            return $value;
+        }
+
+        return mb_strcut($encoded, 0, $max);
+    }
+
+    private function maxBroadcastPayloadBytes(): int
+    {
+        return (int) config('atlas.broadcast.max_tool_payload_length', 2048);
     }
 }

--- a/src/Events/StreamToolCallReceived.php
+++ b/src/Events/StreamToolCallReceived.php
@@ -42,7 +42,7 @@ class StreamToolCallReceived implements ShouldBroadcastNow
         return [
             'toolCalls' => array_map(
                 fn (array $call): array => array_map(
-                    fn (mixed $value): mixed => is_string($value) ? $this->capBroadcastPayload($value) : $value,
+                    fn (mixed $value): mixed => $this->capBroadcastValue($value),
                     $call,
                 ),
                 $this->toolCalls,

--- a/src/Events/StreamToolCallReceived.php
+++ b/src/Events/StreamToolCallReceived.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Events;
 
 use Atlasphp\Atlas\Events\Concerns\BroadcastsOnChannel;
+use Atlasphp\Atlas\Events\Concerns\CapsBroadcastPayload;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 
@@ -14,6 +15,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 class StreamToolCallReceived implements ShouldBroadcastNow
 {
     use BroadcastsOnChannel;
+    use CapsBroadcastPayload;
 
     /**
      * @param  array<int, array<string, mixed>>  $toolCalls
@@ -26,5 +28,25 @@ class StreamToolCallReceived implements ShouldBroadcastNow
     public function broadcastAs(): string
     {
         return 'StreamToolCallReceived';
+    }
+
+    /**
+     * Cap string values in each streamed tool-call chunk (e.g. a large partial
+     * arguments string) to the configured broadcast limit, like the other
+     * tool-call events.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'toolCalls' => array_map(
+                fn (array $call): array => array_map(
+                    fn (mixed $value): mixed => is_string($value) ? $this->capBroadcastPayload($value) : $value,
+                    $call,
+                ),
+                $this->toolCalls,
+            ),
+        ];
     }
 }

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Executor;
 
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Events\AgentCompleted;
 use Atlasphp\Atlas\Events\AgentMaxStepsExceeded;
 use Atlasphp\Atlas\Events\AgentStarted;
@@ -25,6 +26,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Concurrency;
 use Illuminate\Support\Facades\DB;
@@ -203,6 +205,14 @@ class AgentExecutor
                 }
 
                 $request = $request->withAppendedMessages($messagesToAppend);
+
+                // A forced tool choice applies only to the opening step. Relaxing
+                // it to `auto` after step 1 lets the model produce a final text
+                // reply on a later step — a static `required` would compel a tool
+                // call every step and loop until maxSteps.
+                if ($stepCount === 1 && $request->toolChoice?->mode === ToolChoiceMode::Required) {
+                    $request = $request->withToolChoice(ToolChoice::auto());
+                }
             }
 
             $totalUsage = $this->mergeUsage($steps);

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -212,6 +212,8 @@ class AgentExecutor
                 // a specific named tool) would compel a tool call every step and
                 // loop until maxSteps. So a named tool is forced to OPEN the turn,
                 // then the model proceeds normally.
+                // Only reached after a tool-calls step (the stop / no-client-tool
+                // paths break above), so this fires exactly on the opening tool turn.
                 if ($stepCount === 1 && $request->toolChoice?->mode === ToolChoiceMode::Required) {
                     $request = $request->withToolChoice(ToolChoice::auto());
                 }

--- a/src/Executor/AgentExecutor.php
+++ b/src/Executor/AgentExecutor.php
@@ -208,8 +208,10 @@ class AgentExecutor
 
                 // A forced tool choice applies only to the opening step. Relaxing
                 // it to `auto` after step 1 lets the model produce a final text
-                // reply on a later step — a static `required` would compel a tool
-                // call every step and loop until maxSteps.
+                // reply on a later step — keeping any `required` choice (including
+                // a specific named tool) would compel a tool call every step and
+                // loop until maxSteps. So a named tool is forced to OPEN the turn,
+                // then the model proceeds normally.
                 if ($stepCount === 1 && $request->toolChoice?->mode === ToolChoiceMode::Required) {
                     $request = $request->withToolChoice(ToolChoice::auto());
                 }

--- a/src/Pending/AgentRequest.php
+++ b/src/Pending/AgentRequest.php
@@ -57,6 +57,7 @@ use Atlasphp\Atlas\Responses\VoiceSession;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\AgentTool;
 use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
@@ -125,6 +126,8 @@ class AgentRequest implements QueueableRequest
     protected ?int $maxStepsOverride = null;
 
     protected ?bool $concurrentOverride = null;
+
+    protected ?ToolChoice $toolChoiceOverride = null;
 
     // Conversation support — stored here, transferred to agent on resolve
     protected ?Model $conversationOwner = null;
@@ -244,6 +247,28 @@ class AgentRequest implements QueueableRequest
     public function withTemperature(float $temp): static
     {
         $this->temperatureOverride = $temp;
+
+        return $this;
+    }
+
+    /**
+     * Override the agent's tool choice (auto / required / none / a specific
+     * tool). Atlas emits the correct provider shape.
+     */
+    public function toolChoice(ToolChoice $toolChoice): static
+    {
+        $this->toolChoiceOverride = $toolChoice;
+
+        return $this;
+    }
+
+    /**
+     * Require the model to call a tool this turn — sugar for
+     * `toolChoice(ToolChoice::required())`.
+     */
+    public function forceTools(): static
+    {
+        $this->toolChoiceOverride = ToolChoice::required();
 
         return $this;
     }
@@ -995,6 +1020,7 @@ class AgentRequest implements QueueableRequest
             providerOptions: $this->providerOptions !== []
                 ? $this->providerOptions
                 : $agent->providerOptions(),
+            toolChoice: $this->toolChoiceOverride ?? $agent->toolChoice(),
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cacheOverride ?? $this->config->promptCache,
@@ -1114,6 +1140,7 @@ class AgentRequest implements QueueableRequest
             'max_steps' => $this->maxStepsOverride,
             'concurrent' => $this->concurrentOverride,
             'cache' => $this->cacheOverride,
+            'tool_choice' => $this->toolChoiceOverride,
             'provider_options' => $this->providerOptions,
             'conversation_id' => $this->conversationId,
             'owner_type' => $this->conversationOwner?->getMorphClass(),
@@ -1190,6 +1217,10 @@ class AgentRequest implements QueueableRequest
 
         if ($payload['max_steps'] !== null) {
             $request->withMaxSteps($payload['max_steps']);
+        }
+
+        if (! empty($payload['tool_choice'])) {
+            $request->toolChoice($payload['tool_choice']);
         }
 
         if ($payload['concurrent'] !== null) {

--- a/src/Pending/AgentRequest.php
+++ b/src/Pending/AgentRequest.php
@@ -127,6 +127,7 @@ class AgentRequest implements QueueableRequest
 
     protected ?bool $concurrentOverride = null;
 
+    /** Overrides the agent's own {@see Agent::toolChoice()} when set (see buildRequest). */
     protected ?ToolChoice $toolChoiceOverride = null;
 
     // Conversation support — stored here, transferred to agent on resolve
@@ -1140,7 +1141,7 @@ class AgentRequest implements QueueableRequest
             'max_steps' => $this->maxStepsOverride,
             'concurrent' => $this->concurrentOverride,
             'cache' => $this->cacheOverride,
-            'tool_choice' => $this->toolChoiceOverride,
+            'tool_choice' => $this->toolChoiceOverride?->toArray(),
             'provider_options' => $this->providerOptions,
             'conversation_id' => $this->conversationId,
             'owner_type' => $this->conversationOwner?->getMorphClass(),
@@ -1219,8 +1220,8 @@ class AgentRequest implements QueueableRequest
             $request->withMaxSteps($payload['max_steps']);
         }
 
-        if (! empty($payload['tool_choice'])) {
-            $request->toolChoice($payload['tool_choice']);
+        if (isset($payload['tool_choice'])) {
+            $request->toolChoice(ToolChoice::fromArray($payload['tool_choice']));
         }
 
         if ($payload['concurrent'] !== null) {

--- a/src/Pending/TextRequest.php
+++ b/src/Pending/TextRequest.php
@@ -38,6 +38,7 @@ use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Support\VariableInterpolator;
 use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
@@ -88,6 +89,8 @@ class TextRequest implements QueueableRequest
     protected bool $concurrent = false;
 
     protected ?bool $cache = null;
+
+    protected ?ToolChoice $toolChoice = null;
 
     public function __construct(
         protected readonly Provider|string $provider,
@@ -175,6 +178,28 @@ class TextRequest implements QueueableRequest
     public function withMaxSteps(?int $maxSteps): static
     {
         $this->maxSteps = $maxSteps;
+
+        return $this;
+    }
+
+    /**
+     * Set how the model chooses tools (auto / required / none / a specific tool).
+     * Atlas emits the correct provider shape — no provider-specific payload needed.
+     */
+    public function toolChoice(ToolChoice $toolChoice): static
+    {
+        $this->toolChoice = $toolChoice;
+
+        return $this;
+    }
+
+    /**
+     * Require the model to call a tool this turn — sugar for
+     * `toolChoice(ToolChoice::required())`.
+     */
+    public function forceTools(): static
+    {
+        $this->toolChoice = ToolChoice::required();
 
         return $this;
     }
@@ -384,6 +409,7 @@ class TextRequest implements QueueableRequest
             tools: array_map(fn (Tool $t) => $t->toDefinition(), $resolvedTools),
             providerTools: $this->providerTools,
             providerOptions: $this->providerOptions,
+            toolChoice: $this->toolChoice,
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache ?? (bool) config('atlas.prompt_cache', true),
@@ -408,6 +434,7 @@ class TextRequest implements QueueableRequest
             'temperature' => $this->temperature,
             'tools' => array_map(fn (Tool|string $tool): string => is_string($tool) ? $tool : $tool::class, $this->tools),
             'providerTools' => $this->providerTools,
+            'toolChoice' => $this->toolChoice,
             'maxSteps' => $this->maxSteps,
             'concurrent' => $this->concurrent,
             'cache' => $this->cache,
@@ -466,6 +493,10 @@ class TextRequest implements QueueableRequest
 
         if (! empty($payload['providerTools'])) {
             $request->withProviderTools($payload['providerTools']);
+        }
+
+        if (! empty($payload['toolChoice'])) {
+            $request->toolChoice($payload['toolChoice']);
         }
 
         if (array_key_exists('maxSteps', $payload)) {

--- a/src/Pending/TextRequest.php
+++ b/src/Pending/TextRequest.php
@@ -434,7 +434,7 @@ class TextRequest implements QueueableRequest
             'temperature' => $this->temperature,
             'tools' => array_map(fn (Tool|string $tool): string => is_string($tool) ? $tool : $tool::class, $this->tools),
             'providerTools' => $this->providerTools,
-            'toolChoice' => $this->toolChoice,
+            'toolChoice' => $this->toolChoice?->toArray(),
             'maxSteps' => $this->maxSteps,
             'concurrent' => $this->concurrent,
             'cache' => $this->cache,
@@ -495,8 +495,8 @@ class TextRequest implements QueueableRequest
             $request->withProviderTools($payload['providerTools']);
         }
 
-        if (! empty($payload['toolChoice'])) {
-            $request->toolChoice($payload['toolChoice']);
+        if (isset($payload['toolChoice'])) {
+            $request->toolChoice(ToolChoice::fromArray($payload['toolChoice']));
         }
 
         if (array_key_exists('maxSteps', $payload)) {

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -142,6 +142,12 @@ class Text implements TextHandler
 
         if ($tools !== []) {
             $body['tools'] = $tools;
+
+            // Skip when a schema is set — structured() forces the schema tool's
+            // own tool_choice after this method returns.
+            if ($request->toolChoice !== null && $request->schema === null) {
+                $body = array_merge($body, $this->tools->mapToolChoice($request->toolChoice));
+            }
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -11,6 +11,7 @@ use Atlasphp\Atlas\Providers\Anthropic\MediaResolver;
 use Atlasphp\Atlas\Providers\Anthropic\MessageFactory;
 use Atlasphp\Atlas\Providers\Anthropic\ResponseParser;
 use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
+use Atlasphp\Atlas\Providers\Concerns\AppliesToolChoice;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Providers\SseParser;
@@ -30,6 +31,8 @@ use Generator;
  */
 class Text implements TextHandler
 {
+    use AppliesToolChoice;
+
     public function __construct(
         protected readonly ProviderConfig $config,
         protected readonly HttpClient $http,
@@ -142,12 +145,7 @@ class Text implements TextHandler
 
         if ($tools !== []) {
             $body['tools'] = $tools;
-
-            // Skip when a schema is set — structured() forces the schema tool's
-            // own tool_choice after this method returns.
-            if ($request->toolChoice !== null && $request->schema === null) {
-                $body = array_merge($body, $this->tools->mapToolChoice($request->toolChoice));
-            }
+            $body = $this->applyToolChoice($body, $request, $this->tools);
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/Anthropic/ToolMapper.php
+++ b/src/Providers/Anthropic/ToolMapper.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers\Anthropic;
 
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\Contracts\ToolMapperContract;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Log;
 
@@ -43,6 +45,24 @@ class ToolMapper implements ToolMapperContract
             'description' => $tool->description,
             'input_schema' => $tool->hasParameters() ? $tool->parameters : ['type' => 'object', 'properties' => (object) []],
         ], $tools);
+    }
+
+    /**
+     * Map a normalized tool choice to Anthropic's `tool_choice` object:
+     * `{type:auto}`, `{type:any}` (require any tool), `{type:tool, name}`
+     * (require a specific tool), or `{type:none}`.
+     *
+     * @return array<string, mixed>
+     */
+    public function mapToolChoice(ToolChoice $choice): array
+    {
+        return ['tool_choice' => match ($choice->mode) {
+            ToolChoiceMode::Auto => ['type' => 'auto'],
+            ToolChoiceMode::None => ['type' => 'none'],
+            ToolChoiceMode::Required => $choice->tool !== null
+                ? ['type' => 'tool', 'name' => $choice->tool]
+                : ['type' => 'any'],
+        }];
     }
 
     /**

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -11,6 +11,7 @@ use Atlasphp\Atlas\Providers\ChatCompletions\MediaResolver;
 use Atlasphp\Atlas\Providers\ChatCompletions\MessageFactory;
 use Atlasphp\Atlas\Providers\ChatCompletions\ResponseParser;
 use Atlasphp\Atlas\Providers\ChatCompletions\ToolMapper;
+use Atlasphp\Atlas\Providers\Concerns\AppliesToolChoice;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Providers\SseParser;
@@ -29,6 +30,8 @@ use Generator;
  */
 class Text implements TextHandler
 {
+    use AppliesToolChoice;
+
     public function __construct(
         protected readonly ProviderConfig $config,
         protected readonly HttpClient $http,
@@ -116,11 +119,7 @@ class Text implements TextHandler
 
         if ($request->tools !== []) {
             $body['tools'] = $this->toolMapper->mapTools($request->tools);
-
-            // Skipped for structured output, which forces its own choice.
-            if ($request->toolChoice !== null && $request->schema === null) {
-                $body = array_merge($body, $this->toolMapper->mapToolChoice($request->toolChoice));
-            }
+            $body = $this->applyToolChoice($body, $request, $this->toolMapper);
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -116,6 +116,11 @@ class Text implements TextHandler
 
         if ($request->tools !== []) {
             $body['tools'] = $this->toolMapper->mapTools($request->tools);
+
+            // Skipped for structured output, which forces its own choice.
+            if ($request->toolChoice !== null && $request->schema === null) {
+                $body = array_merge($body, $this->toolMapper->mapToolChoice($request->toolChoice));
+            }
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/ChatCompletions/ToolMapper.php
+++ b/src/Providers/ChatCompletions/ToolMapper.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers\ChatCompletions;
 
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\Contracts\ToolMapperContract;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Log;
 
@@ -34,6 +36,24 @@ class ToolMapper implements ToolMapperContract
                 'parameters' => $tool->hasParameters() ? $tool->parameters : (object) [],
             ],
         ], $tools);
+    }
+
+    /**
+     * Map a normalized tool choice to the Chat Completions `tool_choice` shape:
+     * the strings `auto`/`required`/`none`, or a nested
+     * `{type:function, function:{name}}` object to force a specific tool.
+     *
+     * @return array<string, mixed>
+     */
+    public function mapToolChoice(ToolChoice $choice): array
+    {
+        return ['tool_choice' => match ($choice->mode) {
+            ToolChoiceMode::Auto => 'auto',
+            ToolChoiceMode::None => 'none',
+            ToolChoiceMode::Required => $choice->tool !== null
+                ? ['type' => 'function', 'function' => ['name' => $choice->tool]]
+                : 'required',
+        }];
     }
 
     /**

--- a/src/Providers/Concerns/AppliesToolChoice.php
+++ b/src/Providers/Concerns/AppliesToolChoice.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Concerns;
+
+use Atlasphp\Atlas\Providers\Contracts\ToolMapperContract;
+use Atlasphp\Atlas\Requests\TextRequest;
+
+/**
+ * Merges a request's normalized tool choice into a provider request body.
+ *
+ * Shared by the text handlers so the guard lives in one place: a choice is only
+ * applied when one is set AND the request is not a structured-output call (which
+ * forces its own `tool_choice` for the schema tool). Each handler passes its own
+ * mapper since the property name differs per provider.
+ */
+trait AppliesToolChoice
+{
+    /**
+     * @param  array<string, mixed>  $body
+     * @return array<string, mixed>
+     */
+    protected function applyToolChoice(array $body, TextRequest $request, ToolMapperContract $mapper): array
+    {
+        if ($request->toolChoice === null || $request->schema !== null) {
+            return $body;
+        }
+
+        return array_merge($body, $mapper->mapToolChoice($request->toolChoice));
+    }
+}

--- a/src/Providers/Contracts/ToolMapperContract.php
+++ b/src/Providers/Contracts/ToolMapperContract.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\Contracts;
 
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 
 /**
@@ -18,6 +19,16 @@ interface ToolMapperContract
      * @return array<int, array<string, mixed>>
      */
     public function mapTools(array $tools): array;
+
+    /**
+     * Translate a normalized tool choice into the provider's request-body
+     * fragment (e.g. `['tool_choice' => 'required']`, or for Google a
+     * `['tool_config' => [...]]`). Returns an empty array when the provider has
+     * no representation for the choice.
+     *
+     * @return array<string, mixed>
+     */
+    public function mapToolChoice(ToolChoice $choice): array;
 
     /**
      * @param  array<int, ProviderTool>  $providerTools

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\Google\Handlers;
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Concerns\AppliesToolChoice;
 use Atlasphp\Atlas\Providers\Google\Concerns\BuildsGoogleHeaders;
 use Atlasphp\Atlas\Providers\Google\MediaResolver;
 use Atlasphp\Atlas\Providers\Google\MessageFactory;
@@ -29,6 +30,7 @@ use Generator;
  */
 class Text implements TextHandler
 {
+    use AppliesToolChoice;
     use BuildsGoogleHeaders;
 
     public function __construct(
@@ -120,11 +122,7 @@ class Text implements TextHandler
             $body['tools'][] = [
                 'function_declarations' => $this->tools->mapTools($request->tools),
             ];
-
-            // Skipped for structured output, which forces its own choice.
-            if ($request->toolChoice !== null && $request->schema === null) {
-                $body = array_merge($body, $this->tools->mapToolChoice($request->toolChoice));
-            }
+            $body = $this->applyToolChoice($body, $request, $this->tools);
         }
 
         if ($request->providerTools !== []) {

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -120,6 +120,11 @@ class Text implements TextHandler
             $body['tools'][] = [
                 'function_declarations' => $this->tools->mapTools($request->tools),
             ];
+
+            // Skipped for structured output, which forces its own choice.
+            if ($request->toolChoice !== null && $request->schema === null) {
+                $body = array_merge($body, $this->tools->mapToolChoice($request->toolChoice));
+            }
         }
 
         if ($request->providerTools !== []) {

--- a/src/Providers/Google/ToolMapper.php
+++ b/src/Providers/Google/ToolMapper.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers\Google;
 
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\Contracts\ToolMapperContract;
 use Atlasphp\Atlas\Providers\Tools\CodeExecution;
 use Atlasphp\Atlas\Providers\Tools\GoogleSearch;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 
 /**
@@ -31,6 +33,26 @@ class ToolMapper implements ToolMapperContract
                 ? $this->sanitizeSchema($tool->parameters)
                 : ['type' => 'object', 'properties' => (object) []],
         ], $tools);
+    }
+
+    /**
+     * Map a normalized tool choice to Gemini's `tool_config`:
+     * `function_calling_config.mode` AUTO / ANY (require a call) / NONE, with
+     * `allowed_function_names` to force a specific tool.
+     *
+     * @return array<string, mixed>
+     */
+    public function mapToolChoice(ToolChoice $choice): array
+    {
+        $config = match ($choice->mode) {
+            ToolChoiceMode::Auto => ['mode' => 'AUTO'],
+            ToolChoiceMode::None => ['mode' => 'NONE'],
+            ToolChoiceMode::Required => $choice->tool !== null
+                ? ['mode' => 'ANY', 'allowed_function_names' => [$choice->tool]]
+                : ['mode' => 'ANY'],
+        };
+
+        return ['tool_config' => ['function_calling_config' => $config]];
     }
 
     /**

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Providers\OpenAi\Handlers;
 
 use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Concerns\AppliesToolChoice;
 use Atlasphp\Atlas\Providers\Concerns\BuildsHeaders;
 use Atlasphp\Atlas\Providers\Contracts\MessageFactoryContract;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
@@ -29,6 +30,7 @@ use Generator;
  */
 class Text implements TextHandler
 {
+    use AppliesToolChoice;
     use BuildsHeaders, HasOrganizationHeader {
         HasOrganizationHeader::extraHeaders insteadof BuildsHeaders;
     }
@@ -140,11 +142,7 @@ class Text implements TextHandler
 
         if ($tools !== []) {
             $body['tools'] = $tools;
-
-            // Skipped for structured output, which forces its own choice.
-            if ($request->toolChoice !== null && $request->schema === null) {
-                $body = array_merge($body, $this->toolMapper->mapToolChoice($request->toolChoice));
-            }
+            $body = $this->applyToolChoice($body, $request, $this->toolMapper);
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -140,6 +140,11 @@ class Text implements TextHandler
 
         if ($tools !== []) {
             $body['tools'] = $tools;
+
+            // Skipped for structured output, which forces its own choice.
+            if ($request->toolChoice !== null && $request->schema === null) {
+                $body = array_merge($body, $this->toolMapper->mapToolChoice($request->toolChoice));
+            }
         }
 
         return array_merge($body, $request->providerOptions);

--- a/src/Providers/OpenAi/ToolMapper.php
+++ b/src/Providers/OpenAi/ToolMapper.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers\OpenAi;
 
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Messages\ToolCall;
 use Atlasphp\Atlas\Providers\Contracts\ToolMapperContract;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 
 /**
@@ -64,6 +66,24 @@ class ToolMapper implements ToolMapperContract
         $required = $parameters['required'] ?? [];
 
         return count($properties) === count($required);
+    }
+
+    /**
+     * Map a normalized tool choice to the Responses API `tool_choice` shape:
+     * the strings `auto`/`required`/`none`, or a flat `{type:function, name}`
+     * object to force a specific tool.
+     *
+     * @return array<string, mixed>
+     */
+    public function mapToolChoice(ToolChoice $choice): array
+    {
+        return ['tool_choice' => match ($choice->mode) {
+            ToolChoiceMode::Auto => 'auto',
+            ToolChoiceMode::None => 'none',
+            ToolChoiceMode::Required => $choice->tool !== null
+                ? ['type' => 'function', 'name' => $choice->tool]
+                : 'required',
+        }];
     }
 
     /**

--- a/src/Requests/TextRequest.php
+++ b/src/Requests/TextRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Requests;
 
 use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\ToolChoice;
 
 /**
  * Request object for text generation, streaming, and structured output.
@@ -32,6 +33,7 @@ final class TextRequest
         public readonly array $tools,
         public readonly array $providerTools,
         public readonly array $providerOptions,
+        public readonly ?ToolChoice $toolChoice = null,
         public readonly array $middleware = [],
         public readonly array $meta = [],
         public readonly bool $cache = false,
@@ -56,6 +58,7 @@ final class TextRequest
             tools: $this->tools,
             providerTools: $this->providerTools,
             providerOptions: $this->providerOptions,
+            toolChoice: $this->toolChoice,
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
@@ -81,6 +84,7 @@ final class TextRequest
             tools: $tools,
             providerTools: $this->providerTools,
             providerOptions: $this->providerOptions,
+            toolChoice: $this->toolChoice,
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
@@ -107,6 +111,7 @@ final class TextRequest
             tools: $this->tools,
             providerTools: $this->providerTools,
             providerOptions: $this->providerOptions,
+            toolChoice: $this->toolChoice,
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
@@ -132,6 +137,34 @@ final class TextRequest
             tools: $this->tools,
             providerTools: $this->providerTools,
             providerOptions: $this->providerOptions,
+            toolChoice: $this->toolChoice,
+            middleware: $this->middleware,
+            meta: $this->meta,
+            cache: $this->cache,
+        );
+    }
+
+    /**
+     * Return a copy with the tool choice replaced.
+     *
+     * Used by the executor to relax a forced choice after the opening step so the
+     * model can still produce a final text reply.
+     */
+    public function withToolChoice(?ToolChoice $toolChoice): self
+    {
+        return new self(
+            model: $this->model,
+            instructions: $this->instructions,
+            message: $this->message,
+            messageMedia: $this->messageMedia,
+            messages: $this->messages,
+            maxTokens: $this->maxTokens,
+            temperature: $this->temperature,
+            schema: $this->schema,
+            tools: $this->tools,
+            providerTools: $this->providerTools,
+            providerOptions: $this->providerOptions,
+            toolChoice: $toolChoice,
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,

--- a/src/Tools/ToolChoice.php
+++ b/src/Tools/ToolChoice.php
@@ -50,4 +50,24 @@ final class ToolChoice
     {
         return $this->mode === ToolChoiceMode::Required && $this->tool !== null;
     }
+
+    /**
+     * Primitive representation for queue serialization (survives any queue driver).
+     *
+     * @return array{mode: string, tool: ?string}
+     */
+    public function toArray(): array
+    {
+        return ['mode' => $this->mode->value, 'tool' => $this->tool];
+    }
+
+    /**
+     * Rebuild from {@see toArray()} output.
+     *
+     * @param  array{mode: string, tool?: ?string}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(ToolChoiceMode::from($data['mode']), $data['tool'] ?? null);
+    }
 }

--- a/src/Tools/ToolChoice.php
+++ b/src/Tools/ToolChoice.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Tools;
+
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
+
+/**
+ * Provider-normalized tool-choice intent.
+ *
+ * Expresses, once, whether the model should call tools — let it decide (`auto`),
+ * require any tool (`required`), require a specific named tool (`tool`), or forbid
+ * tools (`none`). Each provider's ToolMapper translates this to the vendor's own
+ * shape, so a consumer never hand-writes provider-specific `tool_choice` payloads.
+ */
+final class ToolChoice
+{
+    private function __construct(
+        public readonly ToolChoiceMode $mode,
+        public readonly ?string $tool = null,
+    ) {}
+
+    /** Let the model decide whether to call a tool. */
+    public static function auto(): self
+    {
+        return new self(ToolChoiceMode::Auto);
+    }
+
+    /** Require the model to call one of the available tools. */
+    public static function required(): self
+    {
+        return new self(ToolChoiceMode::Required);
+    }
+
+    /** Forbid the model from calling any tool. */
+    public static function none(): self
+    {
+        return new self(ToolChoiceMode::None);
+    }
+
+    /** Require the model to call this specific tool by name. */
+    public static function tool(string $name): self
+    {
+        return new self(ToolChoiceMode::Required, $name);
+    }
+
+    /** Whether a specific named tool was requested. */
+    public function isSpecificTool(): bool
+    {
+        return $this->mode === ToolChoiceMode::Required && $this->tool !== null;
+    }
+}

--- a/tests/Unit/Events/AgentEventsTest.php
+++ b/tests/Unit/Events/AgentEventsTest.php
@@ -710,7 +710,7 @@ it('AgentMaxStepsExceeded broadcastWith includes summary without raw steps', fun
 
 // ─── broadcastWith payload (full by default, capped when configured) ───────
 
-it('AgentToolCallCompleted broadcastWith sends the full result by default', function () {
+it('AgentToolCallCompleted broadcastWith sends a sub-cap result in full', function () {
     $toolCall = new ToolCall('tc-1', 'search', []);
     $result = new ToolResult(toolCall: $toolCall, content: str_repeat('x', 1000));
 
@@ -722,10 +722,23 @@ it('AgentToolCallCompleted broadcastWith sends the full result by default', func
 
     $data = $event->broadcastWith();
 
+    // 1000 bytes is under the 2048-byte default — sent in full.
     expect(mb_strlen($data['result']))->toBe(1000);
 });
 
-it('AgentToolCallFailed broadcastWith sends the full error by default', function () {
+it('AgentToolCallCompleted broadcastWith caps an oversized result at the 2048-byte default', function () {
+    $toolCall = new ToolCall('tc-1', 'search', []);
+
+    $event = new AgentToolCallCompleted(
+        toolCall: $toolCall,
+        result: new ToolResult(toolCall: $toolCall, content: str_repeat('x', 5000)),
+        channel: new Channel('test'),
+    );
+
+    expect(strlen($event->broadcastWith()['result']))->toBe(2048);
+});
+
+it('AgentToolCallFailed broadcastWith sends a sub-cap error in full', function () {
     $toolCall = new ToolCall('tc-1', 'fetch', []);
     $exception = new RuntimeException(str_repeat('e', 1000));
 
@@ -738,6 +751,23 @@ it('AgentToolCallFailed broadcastWith sends the full error by default', function
     $data = $event->broadcastWith();
 
     expect(mb_strlen($data['error']))->toBe(1000);
+});
+
+it('caps broadcast payloads by bytes without splitting a multibyte character', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 10);
+    $toolCall = new ToolCall('tc-1', 'search', []);
+
+    // 'é' is 2 bytes in UTF-8; 10 of them = 20 bytes. A 10-byte cut yields 5 chars.
+    $event = new AgentToolCallCompleted(
+        toolCall: $toolCall,
+        result: new ToolResult(toolCall: $toolCall, content: str_repeat('é', 10)),
+        channel: new Channel('test'),
+    );
+
+    $result = $event->broadcastWith()['result'];
+
+    expect(strlen($result))->toBeLessThanOrEqual(10)            // byte-bounded for the transport
+        ->and(mb_check_encoding($result, 'UTF-8'))->toBeTrue(); // never split mid-character
 });
 
 it('AgentToolCallFailed broadcastWith caps the error when a max length is configured', function () {
@@ -762,6 +792,58 @@ it('AgentToolCallStarted broadcastWith does not truncate non-string arguments', 
 
     expect($data['arguments']['value'])->toBe(42)
         ->and($data['arguments']['enabled'])->toBeTrue();
+});
+
+it('AgentToolCallStarted byte-caps a large string argument', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 100);
+
+    $event = new AgentToolCallStarted(
+        toolCall: new ToolCall('tc-1', 'search', ['q' => str_repeat('x', 1000)]),
+        channel: new Channel('test'),
+    );
+
+    expect(strlen($event->broadcastWith()['arguments']['q']))->toBe(100);
+});
+
+it('AgentToolCallStarted caps a large NESTED argument by its JSON length (cannot bypass the cap)', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 100);
+
+    $event = new AgentToolCallStarted(
+        toolCall: new ToolCall('tc-1', 'search', ['data' => ['blob' => str_repeat('y', 1000)]]),
+        channel: new Channel('test'),
+    );
+
+    $arg = $event->broadcastWith()['arguments']['data'];
+
+    // Oversized nested structure is replaced with its truncated JSON form.
+    expect($arg)->toBeString()
+        ->and(strlen($arg))->toBe(100);
+});
+
+it('AgentToolCallStarted leaves a small nested argument untouched', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 2048);
+
+    $event = new AgentToolCallStarted(
+        toolCall: new ToolCall('tc-1', 'search', ['data' => ['k' => 'v']]),
+        channel: new Channel('test'),
+    );
+
+    expect($event->broadcastWith()['arguments']['data'])->toBe(['k' => 'v']);
+});
+
+it('AgentToolCallStarted caps nothing when the limit is 0', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 0);
+    $nested = ['blob' => str_repeat('y', 5000)];
+
+    $event = new AgentToolCallStarted(
+        toolCall: new ToolCall('tc-1', 'search', ['s' => str_repeat('x', 5000), 'data' => $nested]),
+        channel: new Channel('test'),
+    );
+
+    $args = $event->broadcastWith()['arguments'];
+
+    expect(strlen($args['s']))->toBe(5000)
+        ->and($args['data'])->toBe($nested);
 });
 
 // ─── channel defaults ─────────────────────────────────────────────────────

--- a/tests/Unit/Events/AgentEventsTest.php
+++ b/tests/Unit/Events/AgentEventsTest.php
@@ -486,7 +486,7 @@ it('AgentToolCallStarted broadcastWith includes tool details', function () {
         ->and($data['stepNumber'])->toBe(2);
 });
 
-it('AgentToolCallStarted truncates large string arguments', function () {
+it('AgentToolCallStarted broadcasts full string arguments by default', function () {
     $event = new AgentToolCallStarted(
         toolCall: new ToolCall('tc-1', 'process', ['content' => str_repeat('x', 500)]),
         channel: new Channel('test'),
@@ -494,7 +494,25 @@ it('AgentToolCallStarted truncates large string arguments', function () {
 
     $data = $event->broadcastWith();
 
-    expect(mb_strlen($data['arguments']['content']))->toBe(200);
+    expect(mb_strlen($data['arguments']['content']))->toBe(500);
+});
+
+it('caps broadcast tool payloads when a max length is configured', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 200);
+
+    $started = new AgentToolCallStarted(
+        toolCall: new ToolCall('tc-1', 'process', ['content' => str_repeat('x', 500)]),
+        channel: new Channel('test'),
+    );
+
+    $completed = new AgentToolCallCompleted(
+        toolCall: new ToolCall('tc-2', 'search', []),
+        result: new ToolResult(toolCall: new ToolCall('tc-2', 'search', []), content: str_repeat('y', 500)),
+        channel: new Channel('test'),
+    );
+
+    expect(mb_strlen($started->broadcastWith()['arguments']['content']))->toBe(200)
+        ->and(mb_strlen($completed->broadcastWith()['result']))->toBe(200);
 });
 
 it('AgentToolCallCompleted broadcastWith includes result summary', function () {
@@ -690,9 +708,9 @@ it('AgentMaxStepsExceeded broadcastWith includes summary without raw steps', fun
     ]);
 });
 
-// ─── broadcastWith truncation ─────────────────────────────────────────────
+// ─── broadcastWith payload (full by default, capped when configured) ───────
 
-it('AgentToolCallCompleted broadcastWith truncates large result content', function () {
+it('AgentToolCallCompleted broadcastWith sends the full result by default', function () {
     $toolCall = new ToolCall('tc-1', 'search', []);
     $result = new ToolResult(toolCall: $toolCall, content: str_repeat('x', 1000));
 
@@ -704,10 +722,10 @@ it('AgentToolCallCompleted broadcastWith truncates large result content', functi
 
     $data = $event->broadcastWith();
 
-    expect(mb_strlen($data['result']))->toBe(500);
+    expect(mb_strlen($data['result']))->toBe(1000);
 });
 
-it('AgentToolCallFailed broadcastWith truncates large error message', function () {
+it('AgentToolCallFailed broadcastWith sends the full error by default', function () {
     $toolCall = new ToolCall('tc-1', 'fetch', []);
     $exception = new RuntimeException(str_repeat('e', 1000));
 
@@ -719,7 +737,19 @@ it('AgentToolCallFailed broadcastWith truncates large error message', function (
 
     $data = $event->broadcastWith();
 
-    expect(mb_strlen($data['error']))->toBe(500);
+    expect(mb_strlen($data['error']))->toBe(1000);
+});
+
+it('AgentToolCallFailed broadcastWith caps the error when a max length is configured', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 300);
+
+    $event = new AgentToolCallFailed(
+        toolCall: new ToolCall('tc-1', 'fetch', []),
+        exception: new RuntimeException(str_repeat('e', 1000)),
+        channel: new Channel('test'),
+    );
+
+    expect(mb_strlen($event->broadcastWith()['error']))->toBe(300);
 });
 
 it('AgentToolCallStarted broadcastWith does not truncate non-string arguments', function () {

--- a/tests/Unit/Events/StreamEventsTest.php
+++ b/tests/Unit/Events/StreamEventsTest.php
@@ -107,6 +107,28 @@ it('StreamToolCallReceived broadcastAs returns StreamToolCallReceived', function
     expect($event->broadcastAs())->toBe('StreamToolCallReceived');
 });
 
+it('StreamToolCallReceived broadcastWith sends full tool-call strings by default', function () {
+    $event = new StreamToolCallReceived(
+        channel: new Channel('test'),
+        toolCalls: [['id' => 'call_1', 'name' => 'search', 'arguments' => str_repeat('x', 1000)]],
+    );
+
+    expect(mb_strlen($event->broadcastWith()['toolCalls'][0]['arguments']))->toBe(1000);
+});
+
+it('StreamToolCallReceived broadcastWith caps tool-call strings when configured', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 100);
+
+    $event = new StreamToolCallReceived(
+        channel: new Channel('test'),
+        toolCalls: [['id' => 'call_1', 'name' => 'search', 'arguments' => str_repeat('x', 1000)]],
+    );
+
+    $capped = $event->broadcastWith()['toolCalls'][0];
+    expect(mb_strlen($capped['arguments']))->toBe(100)
+        ->and($capped['id'])->toBe('call_1'); // short values untouched
+});
+
 // ─── StreamStarted ─────────────────────────────────────────────────────────
 
 it('StreamStarted implements ShouldBroadcastNow', function () {

--- a/tests/Unit/Executor/AgentExecutorTest.php
+++ b/tests/Unit/Executor/AgentExecutorTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Events\AgentCompleted;
 use Atlasphp\Atlas\Events\AgentMaxStepsExceeded;
 use Atlasphp\Atlas\Events\AgentStarted;
@@ -27,6 +28,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\DB;
 
@@ -161,6 +163,25 @@ function makeMockDriver(array $responses): Driver
         }
     };
 }
+
+it('forces the tool choice on the opening step, then relaxes it to auto', function () {
+    $driver = makeMockDriver([
+        // Step 1: the model calls a tool (forced).
+        new TextResponse('', new Usage(1, 1), FinishReason::ToolCalls, toolCalls: [new ToolCall('call_1', 'echo', ['text' => 'hi'])]),
+        // Step 2: the model produces its final text reply.
+        new TextResponse('done', new Usage(1, 1), FinishReason::Stop),
+    ]);
+
+    $registry = new ToolRegistry([makeEchoTool()]);
+    $executor = new AgentExecutor($driver, new ToolExecutor($registry), makeFakeDispatcher());
+
+    $request = makeTextRequest()->withToolChoice(ToolChoice::required());
+    $executor->execute($request, maxSteps: 10, concurrent: false, meta: []);
+
+    expect($driver->receivedRequests)->toHaveCount(2)
+        ->and($driver->receivedRequests[0]->toolChoice?->mode)->toBe(ToolChoiceMode::Required)
+        ->and($driver->receivedRequests[1]->toolChoice?->mode)->toBe(ToolChoiceMode::Auto);
+});
 
 it('handles single round trip with no tools', function () {
     $driver = makeMockDriver([

--- a/tests/Unit/Executor/AgentExecutorTest.php
+++ b/tests/Unit/Executor/AgentExecutorTest.php
@@ -183,6 +183,32 @@ it('forces the tool choice on the opening step, then relaxes it to auto', functi
         ->and($driver->receivedRequests[1]->toolChoice?->mode)->toBe(ToolChoiceMode::Auto);
 });
 
+it('forces a specific named tool on the opening step, then relaxes to auto', function () {
+    $driver = makeMockDriver([
+        new TextResponse('', new Usage(1, 1), FinishReason::ToolCalls, toolCalls: [new ToolCall('call_1', 'echo', ['text' => 'hi'])]),
+        new TextResponse('done', new Usage(1, 1), FinishReason::Stop),
+    ]);
+
+    $executor = new AgentExecutor($driver, new ToolExecutor(new ToolRegistry([makeEchoTool()])), makeFakeDispatcher());
+    $executor->execute(makeTextRequest()->withToolChoice(ToolChoice::tool('echo')), maxSteps: 10, concurrent: false, meta: []);
+
+    expect($driver->receivedRequests[0]->toolChoice?->isSpecificTool())->toBeTrue()
+        ->and($driver->receivedRequests[1]->toolChoice?->mode)->toBe(ToolChoiceMode::Auto);
+});
+
+it('does not relax a non-required tool choice', function () {
+    $driver = makeMockDriver([
+        new TextResponse('', new Usage(1, 1), FinishReason::ToolCalls, toolCalls: [new ToolCall('call_1', 'echo', ['text' => 'hi'])]),
+        new TextResponse('done', new Usage(1, 1), FinishReason::Stop),
+    ]);
+
+    $executor = new AgentExecutor($driver, new ToolExecutor(new ToolRegistry([makeEchoTool()])), makeFakeDispatcher());
+    $executor->execute(makeTextRequest()->withToolChoice(ToolChoice::none()), maxSteps: 10, concurrent: false, meta: []);
+
+    // Only `Required` is relaxed — a `none` choice passes through unchanged.
+    expect($driver->receivedRequests[1]->toolChoice?->mode)->toBe(ToolChoiceMode::None);
+});
+
 it('handles single round trip with no tools', function () {
     $driver = makeMockDriver([
         new TextResponse('Hello!', new Usage(10, 20), FinishReason::Stop),

--- a/tests/Unit/Pending/AgentRequestQueueTest.php
+++ b/tests/Unit/Pending/AgentRequestQueueTest.php
@@ -6,6 +6,7 @@ use Atlasphp\Atlas\Agent;
 use Atlasphp\Atlas\AgentRegistry;
 use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Input\Audio;
 use Atlasphp\Atlas\Input\Image;
 use Atlasphp\Atlas\Input\Input;
@@ -15,6 +16,7 @@ use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
+use Atlasphp\Atlas\Tools\ToolChoice;
 
 // ─── Test agent ─────────────────────────────────────────────────────────────
 
@@ -252,4 +254,49 @@ it('restores an explicit cache override when executing from a queue payload', fu
     ], 'asText');
 
     expect($captured->cache)->toBeFalse();
+});
+
+it('restores a tool choice when executing from a queue payload', function () {
+    registerQueueTestAgent(QueueTestMinimalAgent::class);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('capabilities')->andReturn(new ProviderCapabilities(text: true));
+    $captured = null;
+    $driver->shouldReceive('text')->once()->andReturnUsing(function ($req) use (&$captured) {
+        $captured = $req;
+
+        return new TextResponse('ok', new Usage(1, 1), FinishReason::Stop);
+    });
+    app(ProviderRegistryContract::class)->register('openai', fn () => $driver);
+
+    AgentRequest::executeFromPayload([
+        'key' => 'queue-minimal',
+        'message' => 'hi',
+        'message_media' => [],
+        'instructions' => null,
+        'variables' => [],
+        'meta' => [],
+        'provider' => 'openai',
+        'model' => 'gpt-4o',
+        'max_tokens' => null,
+        'temperature' => null,
+        'max_steps' => null,
+        'concurrent' => null,
+        'cache' => null,
+        'tool_choice' => ['mode' => 'required', 'tool' => 'log_mood'],
+        'provider_options' => [],
+        'middleware' => [],
+        'owner_type' => null,
+        'owner_id' => null,
+        'message_owner_type' => null,
+        'message_owner_id' => null,
+        'conversation_id' => null,
+        'message_limit' => null,
+        'respond_mode' => false,
+        'retry_mode' => false,
+    ], 'asText');
+
+    expect($captured->toolChoice)->toBeInstanceOf(ToolChoice::class)
+        ->and($captured->toolChoice->mode)->toBe(ToolChoiceMode::Required)
+        ->and($captured->toolChoice->tool)->toBe('log_mood');
 });

--- a/tests/Unit/Pending/AgentRequestTest.php
+++ b/tests/Unit/Pending/AgentRequestTest.php
@@ -9,6 +9,7 @@ use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Enums\Modality;
 use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Events\ModalityCompleted;
 use Atlasphp\Atlas\Events\ModalityStarted;
 use Atlasphp\Atlas\Exceptions\AgentNotFoundException;
@@ -35,6 +36,7 @@ use Atlasphp\Atlas\Testing\StructuredResponseFake;
 use Atlasphp\Atlas\Testing\TextResponseFake;
 use Atlasphp\Atlas\Testing\VoiceSessionFake;
 use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Model;
@@ -1365,6 +1367,39 @@ it('cache() override flows through buildRequest to the driver request', function
     makeAgentRequest('minimal')->cache(false)->message('Hi')->asText();
 
     expect($captured->cache)->toBeFalse();
+});
+
+it('forceTools override flows through buildRequest to the driver request', function () {
+    registerTestAgent(RequestTestMinimalAgent::class);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('capabilities')->andReturn(new ProviderCapabilities(text: true));
+
+    $captured = null;
+    $driver->shouldReceive('text')->once()->andReturnUsing(function ($req) use (&$captured) {
+        $captured = $req;
+
+        return new TextResponse('ok', new Usage(1, 1), FinishReason::Stop);
+    });
+
+    $registry = app(ProviderRegistryContract::class);
+    $registry->register('openai', fn () => $driver);
+
+    config(['atlas.defaults.text' => ['provider' => 'openai', 'model' => 'gpt-4o']]);
+    AtlasConfig::refresh();
+
+    makeAgentRequest('minimal')->forceTools()->message('Hi')->asText();
+
+    expect($captured->toolChoice)->toBeInstanceOf(ToolChoice::class)
+        ->and($captured->toolChoice->mode)->toBe(ToolChoiceMode::Required);
+});
+
+it('defaults the agent tool choice to null when none is set', function () {
+    registerTestAgent(RequestTestMinimalAgent::class);
+
+    expect(makeAgentRequest('minimal')->toolChoice(ToolChoice::none()))
+        ->toBeInstanceOf(AgentRequest::class);
+    expect((new RequestTestMinimalAgent)->toolChoice())->toBeNull();
 });
 
 it('agent request defaults the cache flag from atlas.prompt_cache config', function () {

--- a/tests/Unit/Pending/TextRequestTest.php
+++ b/tests/Unit/Pending/TextRequestTest.php
@@ -217,11 +217,16 @@ it('toolChoice threads a specific tool through to the built request', function (
         ->and($request->toolChoice?->tool)->toBe('get_weather');
 });
 
-it('serializes and restores the tool choice across the queue payload', function () {
-    $payload = createTextPending()->forceTools()->toQueuePayload();
+it('serializes the tool choice to a primitive in the queue payload (survives any driver)', function () {
+    $payload = createTextPending()->toolChoice(ToolChoice::tool('get_weather'))->toQueuePayload();
 
-    expect($payload['toolChoice'])->toBeInstanceOf(ToolChoice::class)
-        ->and($payload['toolChoice']->mode)->toBe(ToolChoiceMode::Required);
+    expect($payload['toolChoice'])->toBe(['mode' => 'required', 'tool' => 'get_weather']);
+    // Restore path reconstructs the same choice.
+    expect(ToolChoice::fromArray($payload['toolChoice'])->tool)->toBe('get_weather');
+});
+
+it('omits the tool choice from the payload when none is set', function () {
+    expect(createTextPending()->toQueuePayload()['toolChoice'])->toBeNull();
 });
 
 it('chaining toolChoice/forceTools returns $this', function () {

--- a/tests/Unit/Pending/TextRequestTest.php
+++ b/tests/Unit/Pending/TextRequestTest.php
@@ -6,6 +6,7 @@ use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Enums\Modality;
 use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Events\ModalityCompleted;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Messages\AssistantMessage;
@@ -27,6 +28,7 @@ use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Testing\StreamResponseFake;
 use Atlasphp\Atlas\Testing\TextResponseFake;
 use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Event;
 
@@ -199,6 +201,34 @@ it('withTools includes tool definitions in built request', function () {
 
     expect($request->tools)->toHaveCount(1);
     expect($request->tools[0]->name)->toBe('test_tool');
+});
+
+it('forceTools sets a required tool choice on the built request', function () {
+    $request = createTextPending()->forceTools()->buildRequest();
+
+    expect($request->toolChoice?->mode)->toBe(ToolChoiceMode::Required)
+        ->and($request->toolChoice?->tool)->toBeNull();
+});
+
+it('toolChoice threads a specific tool through to the built request', function () {
+    $request = createTextPending()->toolChoice(ToolChoice::tool('get_weather'))->buildRequest();
+
+    expect($request->toolChoice?->mode)->toBe(ToolChoiceMode::Required)
+        ->and($request->toolChoice?->tool)->toBe('get_weather');
+});
+
+it('serializes and restores the tool choice across the queue payload', function () {
+    $payload = createTextPending()->forceTools()->toQueuePayload();
+
+    expect($payload['toolChoice'])->toBeInstanceOf(ToolChoice::class)
+        ->and($payload['toolChoice']->mode)->toBe(ToolChoiceMode::Required);
+});
+
+it('chaining toolChoice/forceTools returns $this', function () {
+    $pending = createTextPending();
+
+    expect($pending->toolChoice(ToolChoice::auto()))->toBe($pending)
+        ->and($pending->forceTools())->toBe($pending);
 });
 
 it('withTools accumulates across multiple calls', function () {

--- a/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
@@ -15,6 +15,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Http;
 
@@ -46,8 +47,33 @@ function makeAnthropicTextRequest(array $overrides = []): TextRequest
         tools: $overrides['tools'] ?? [],
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
+        toolChoice: $overrides['toolChoice'] ?? null,
     );
 }
+
+it('emits the Anthropic tool_choice object when a choice is set with tools', function () {
+    Http::fake(['api.anthropic.com/*' => Http::response(fakeAnthropicTextResponse())]);
+
+    makeAnthropicTextHandler()->text(makeAnthropicTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        'toolChoice' => ToolChoice::required(),
+    ]));
+
+    Http::assertSent(fn ($request) => $request['tool_choice'] === ['type' => 'any']);
+});
+
+it('does not emit a normalized tool_choice during structured output', function () {
+    Http::fake(['api.anthropic.com/*' => Http::response(fakeAnthropicTextResponse())]);
+
+    makeAnthropicTextHandler()->structured(makeAnthropicTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        'toolChoice' => ToolChoice::required(),
+        'schema' => new Schema('out', 'Out', ['type' => 'object', 'properties' => (object) []]),
+    ]));
+
+    // structured() forces the schema tool, not the normalized "any".
+    Http::assertSent(fn ($request) => $request['tool_choice'] === ['type' => 'tool', 'name' => 'out']);
+});
 
 function fakeAnthropicTextResponse(array $overrides = []): array
 {

--- a/tests/Unit/Providers/Anthropic/ToolMapperTest.php
+++ b/tests/Unit/Providers/Anthropic/ToolMapperTest.php
@@ -9,8 +9,18 @@ use Atlasphp\Atlas\Providers\Tools\ProviderTool;
 use Atlasphp\Atlas\Providers\Tools\ProviderToolRegistry;
 use Atlasphp\Atlas\Providers\Tools\WebFetch;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Log;
+
+it('maps tool choice to the Anthropic object shape', function (ToolChoice $choice, array $expected) {
+    expect((new ToolMapper)->mapToolChoice($choice))->toBe(['tool_choice' => $expected]);
+})->with([
+    'auto' => [ToolChoice::auto(), ['type' => 'auto']],
+    'required' => [ToolChoice::required(), ['type' => 'any']],
+    'none' => [ToolChoice::none(), ['type' => 'none']],
+    'specific tool' => [ToolChoice::tool('get_weather'), ['type' => 'tool', 'name' => 'get_weather']],
+]);
 
 it('maps tools to input_schema format', function () {
     $mapper = new ToolMapper;

--- a/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
@@ -123,6 +123,34 @@ it('emits tool_choice when a choice is set with tools', function () {
     Http::assertSent(fn ($r) => ($r->data()['tool_choice'] ?? null) === 'required');
 });
 
+it('does not emit tool_choice during structured output', function () {
+    Http::fake([
+        'localhost:11434/v1/chat/completions' => Http::response([
+            'choices' => [['message' => ['content' => '{}', 'role' => 'assistant'], 'finish_reason' => 'stop']],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
+        ]),
+    ]);
+
+    $request = new TextRequest(
+        model: 'llama3.1',
+        instructions: null,
+        message: 'Give me data',
+        messageMedia: [],
+        messages: [],
+        maxTokens: null,
+        temperature: null,
+        schema: new Schema('out', 'Out', ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]]),
+        tools: [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        providerTools: [],
+        providerOptions: [],
+        toolChoice: ToolChoice::required(),
+    );
+
+    makeChatCompletionsDriver()->structured($request);
+
+    Http::assertSent(fn ($r) => ! isset($r->data()['tool_choice']));
+});
+
 it('sends structured request with json_schema response_format', function () {
     Http::fake([
         'localhost:11434/v1/chat/completions' => Http::response([

--- a/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
@@ -11,6 +11,8 @@ use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Requests\RerankRequest;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\ToolChoice;
+use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Http;
 
 function makeChatCompletionsDriver(): ChatCompletionsDriver
@@ -91,6 +93,34 @@ it('sends text request to chat/completions endpoint', function () {
     expect($response->usage->outputTokens)->toBe(5);
 
     Http::assertSent(fn ($r) => str_contains($r->url(), '/chat/completions'));
+});
+
+it('emits tool_choice when a choice is set with tools', function () {
+    Http::fake([
+        'localhost:11434/v1/chat/completions' => Http::response([
+            'choices' => [['message' => ['content' => 'ok', 'role' => 'assistant'], 'finish_reason' => 'stop']],
+            'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1],
+        ]),
+    ]);
+
+    $request = new TextRequest(
+        model: 'llama3.1',
+        instructions: null,
+        message: 'Hi',
+        messageMedia: [],
+        messages: [],
+        maxTokens: null,
+        temperature: null,
+        schema: null,
+        tools: [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        providerTools: [],
+        providerOptions: [],
+        toolChoice: ToolChoice::required(),
+    );
+
+    makeChatCompletionsDriver()->text($request);
+
+    Http::assertSent(fn ($r) => ($r->data()['tool_choice'] ?? null) === 'required');
 });
 
 it('sends structured request with json_schema response_format', function () {

--- a/tests/Unit/Providers/ChatCompletions/ToolMapperTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ToolMapperTest.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Providers\ChatCompletions\ToolMapper;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Log;
+
+it('maps tool choice to the Chat Completions shape', function (ToolChoice $choice, mixed $expected) {
+    expect((new ToolMapper)->mapToolChoice($choice))->toBe(['tool_choice' => $expected]);
+})->with([
+    'auto' => [ToolChoice::auto(), 'auto'],
+    'required' => [ToolChoice::required(), 'required'],
+    'none' => [ToolChoice::none(), 'none'],
+    'specific tool' => [ToolChoice::tool('get_weather'), ['type' => 'function', 'function' => ['name' => 'get_weather']]],
+]);
 
 it('maps tool definitions to nested function format', function () {
     $mapper = new ToolMapper;

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -13,6 +13,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Http;
 
@@ -44,8 +45,20 @@ function makeGoogleTextRequest(array $overrides = []): TextRequest
         tools: $overrides['tools'] ?? [],
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
+        toolChoice: $overrides['toolChoice'] ?? null,
     );
 }
+
+it('emits Gemini tool_config when a choice is set with tools', function () {
+    Http::fake(['generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse())]);
+
+    makeGoogleTextHandler()->text(makeGoogleTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        'toolChoice' => ToolChoice::required(),
+    ]));
+
+    Http::assertSent(fn ($request) => $request['tool_config'] === ['function_calling_config' => ['mode' => 'ANY']]);
+});
 
 function fakeGeminiTextResponse(array $overrides = []): array
 {

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -60,6 +60,18 @@ it('emits Gemini tool_config when a choice is set with tools', function () {
     Http::assertSent(fn ($request) => $request['tool_config'] === ['function_calling_config' => ['mode' => 'ANY']]);
 });
 
+it('does not emit tool_config during structured output', function () {
+    Http::fake(['generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse())]);
+
+    makeGoogleTextHandler()->text(makeGoogleTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        'toolChoice' => ToolChoice::required(),
+        'schema' => new Schema('out', 'Out', ['type' => 'object', 'properties' => (object) []]),
+    ]));
+
+    Http::assertSent(fn ($request) => ! isset($request['tool_config']));
+});
+
 function fakeGeminiTextResponse(array $overrides = []): array
 {
     return [

--- a/tests/Unit/Providers/Google/ToolMapperTest.php
+++ b/tests/Unit/Providers/Google/ToolMapperTest.php
@@ -8,7 +8,18 @@ use Atlasphp\Atlas\Providers\Google\ToolMapper;
 use Atlasphp\Atlas\Providers\Tools\CodeExecution;
 use Atlasphp\Atlas\Providers\Tools\GoogleSearch;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+
+it('maps tool choice to Gemini tool_config', function (ToolChoice $choice, array $expectedConfig) {
+    expect((new ToolMapper)->mapToolChoice($choice))
+        ->toBe(['tool_config' => ['function_calling_config' => $expectedConfig]]);
+})->with([
+    'auto' => [ToolChoice::auto(), ['mode' => 'AUTO']],
+    'required' => [ToolChoice::required(), ['mode' => 'ANY']],
+    'none' => [ToolChoice::none(), ['mode' => 'NONE']],
+    'specific tool' => [ToolChoice::tool('get_weather'), ['mode' => 'ANY', 'allowed_function_names' => ['get_weather']]],
+]);
 
 it('maps tools to function_declarations format', function () {
     $mapper = new ToolMapper;

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -14,6 +14,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
 use Illuminate\Support\Facades\Http;
 
@@ -45,8 +46,60 @@ function makeOpenAiTextRequest(array $overrides = []): TextRequest
         tools: $overrides['tools'] ?? [],
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
+        toolChoice: $overrides['toolChoice'] ?? null,
     );
 }
+
+it('emits tool_choice when a choice is set alongside tools', function () {
+    Http::fake([
+        'api.openai.com/v1/responses' => Http::response([
+            'status' => 'completed',
+            'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'ok']]]],
+            'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+        ]),
+    ]);
+
+    makeTextHandler()->text(makeOpenAiTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', [])],
+        'toolChoice' => ToolChoice::required(),
+    ]));
+
+    Http::assertSent(fn ($request) => isset($request['tools']) && $request['tool_choice'] === 'required');
+});
+
+it('omits the normalized tool_choice when there are no tools', function () {
+    Http::fake([
+        'api.openai.com/v1/responses' => Http::response([
+            'status' => 'completed',
+            'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'ok']]]],
+            'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+        ]),
+    ]);
+
+    makeTextHandler()->text(makeOpenAiTextRequest([
+        'toolChoice' => ToolChoice::required(),
+    ]));
+
+    Http::assertSent(fn ($request) => ! isset($request['tool_choice']));
+});
+
+it('does not emit a normalized tool_choice during structured output', function () {
+    Http::fake([
+        'api.openai.com/v1/responses' => Http::response([
+            'status' => 'completed',
+            'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => '{}']]]],
+            'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+        ]),
+    ]);
+
+    makeTextHandler()->structured(makeOpenAiTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', [])],
+        'toolChoice' => ToolChoice::required(),
+        'schema' => new Schema('out', 'Out', ['type' => 'object', 'properties' => (object) []]),
+    ]));
+
+    Http::assertSent(fn ($request) => ! isset($request['tool_choice']));
+});
 
 it('sends text request to /v1/responses', function () {
     Http::fake([

--- a/tests/Unit/Providers/OpenAi/ToolMapperTest.php
+++ b/tests/Unit/Providers/OpenAi/ToolMapperTest.php
@@ -7,7 +7,17 @@ use Atlasphp\Atlas\Providers\OpenAi\ToolMapper;
 use Atlasphp\Atlas\Providers\Tools\CodeInterpreter;
 use Atlasphp\Atlas\Providers\Tools\FileSearch;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
+use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+
+it('maps tool choice to the Responses API shape', function (ToolChoice $choice, mixed $expected) {
+    expect((new ToolMapper)->mapToolChoice($choice))->toBe(['tool_choice' => $expected]);
+})->with([
+    'auto' => [ToolChoice::auto(), 'auto'],
+    'required' => [ToolChoice::required(), 'required'],
+    'none' => [ToolChoice::none(), 'none'],
+    'specific tool' => [ToolChoice::tool('get_weather'), ['type' => 'function', 'name' => 'get_weather']],
+]);
 
 it('maps tool definitions to flat function format', function () {
     $mapper = new ToolMapper;

--- a/tests/Unit/Queue/QueuePayloadTest.php
+++ b/tests/Unit/Queue/QueuePayloadTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
 use Atlasphp\Atlas\Pending\AudioRequest;
 use Atlasphp\Atlas\Pending\EmbedRequest;
 use Atlasphp\Atlas\Pending\ImageRequest;
@@ -14,6 +15,7 @@ use Atlasphp\Atlas\Pending\VideoRequest;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
+use Atlasphp\Atlas\Providers\Tools\WebSearch;
 use Atlasphp\Atlas\Responses\AudioResponse;
 use Atlasphp\Atlas\Responses\EmbeddingsResponse;
 use Atlasphp\Atlas\Responses\ImageResponse;
@@ -24,6 +26,7 @@ use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Responses\VideoResponse;
+use Atlasphp\Atlas\Tools\ToolChoice;
 
 // ─── TextRequest ────────────────────────────────────────────────────────────
 
@@ -80,6 +83,42 @@ it('TextRequest preserves an explicit cache override across the queue boundary',
     TextRequest::executeFromPayload($payload, 'asText');
 
     expect($captured->cache)->toBeFalse();
+});
+
+it('TextRequest executeFromPayload restores providerTools and toolChoice', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('capabilities')->andReturn(new ProviderCapabilities(text: true));
+    $captured = null;
+    $driver->shouldReceive('text')->andReturnUsing(function ($req) use (&$captured) {
+        $captured = $req;
+
+        return new TextResponse('ok', new Usage(1, 1), FinishReason::Stop);
+    });
+    app(ProviderRegistryContract::class)->register('openai', fn () => $driver);
+
+    TextRequest::executeFromPayload([
+        'provider' => 'openai',
+        'model' => 'gpt-5',
+        'instructions' => null,
+        'message' => 'Hello',
+        'messageMedia' => [],
+        'messages' => [],
+        'maxTokens' => null,
+        'temperature' => null,
+        'tools' => [],
+        'providerTools' => [new WebSearch],
+        'toolChoice' => ['mode' => 'required', 'tool' => null],
+        'maxSteps' => null,
+        'concurrent' => true,
+        'schema' => null,
+        'providerOptions' => [],
+        'meta' => [],
+    ], 'asText');
+
+    expect($captured->providerTools)->toHaveCount(1)
+        ->and($captured->providerTools[0])->toBeInstanceOf(WebSearch::class)
+        ->and($captured->toolChoice)->toBeInstanceOf(ToolChoice::class)
+        ->and($captured->toolChoice->mode)->toBe(ToolChoiceMode::Required);
 });
 
 it('TextRequest toQueuePayload serializes tools as class strings', function () {

--- a/tests/Unit/Tools/ToolChoiceTest.php
+++ b/tests/Unit/Tools/ToolChoiceTest.php
@@ -36,3 +36,20 @@ it('builds a specific-tool choice (required mode + name)', function () {
         ->and($choice->tool)->toBe('get_weather')
         ->and($choice->isSpecificTool())->toBeTrue();
 });
+
+it('serializes to a primitive array and back', function (ToolChoice $choice) {
+    $restored = ToolChoice::fromArray($choice->toArray());
+
+    expect($restored->mode)->toBe($choice->mode)
+        ->and($restored->tool)->toBe($choice->tool);
+})->with([
+    'auto' => [ToolChoice::auto()],
+    'required' => [ToolChoice::required()],
+    'none' => [ToolChoice::none()],
+    'specific tool' => [ToolChoice::tool('get_weather')],
+]);
+
+it('toArray uses the enum value and the tool name', function () {
+    expect(ToolChoice::tool('get_weather')->toArray())->toBe(['mode' => 'required', 'tool' => 'get_weather'])
+        ->and(ToolChoice::none()->toArray())->toBe(['mode' => 'none', 'tool' => null]);
+});

--- a/tests/Unit/Tools/ToolChoiceTest.php
+++ b/tests/Unit/Tools/ToolChoiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\ToolChoiceMode;
+use Atlasphp\Atlas\Tools\ToolChoice;
+
+it('builds an auto choice', function () {
+    $choice = ToolChoice::auto();
+
+    expect($choice->mode)->toBe(ToolChoiceMode::Auto)
+        ->and($choice->tool)->toBeNull()
+        ->and($choice->isSpecificTool())->toBeFalse();
+});
+
+it('builds a required choice', function () {
+    $choice = ToolChoice::required();
+
+    expect($choice->mode)->toBe(ToolChoiceMode::Required)
+        ->and($choice->tool)->toBeNull()
+        ->and($choice->isSpecificTool())->toBeFalse();
+});
+
+it('builds a none choice', function () {
+    $choice = ToolChoice::none();
+
+    expect($choice->mode)->toBe(ToolChoiceMode::None)
+        ->and($choice->tool)->toBeNull()
+        ->and($choice->isSpecificTool())->toBeFalse();
+});
+
+it('builds a specific-tool choice (required mode + name)', function () {
+    $choice = ToolChoice::tool('get_weather');
+
+    expect($choice->mode)->toBe(ToolChoiceMode::Required)
+        ->and($choice->tool)->toBe('get_weather')
+        ->and($choice->isSpecificTool())->toBeTrue();
+});


### PR DESCRIPTION
This pull request introduces provider-normalized forced tool choice support to Atlas, allowing developers to require models to call any tool or a specific tool, with unified handling across OpenAI, Anthropic, Google, and xAI. It also enhances the broadcasting of tool-call events by sending the full arguments, results, and errors by default, with a configurable cap to prevent oversized WebSocket payloads. Comprehensive live tests and documentation updates are included.

**Tool Choice (Provider-Normalized Forcing):**

* Added support for forcing tool use via `->forceTools()` and `->toolChoice(...)`, letting you require any tool, a specific tool, auto, or none; Atlas maps these to each provider’s API shape and applies forced choice only to the opening agent step, then relaxes to allow a reply. [[1]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373R251-R288) [[2]](diffhunk://#diff-cc6284cad538131e58621854a457c063a1e8b242b03e80158075251b87eb20daR1-R23) [[3]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eR12) [[4]](diffhunk://#diff-1688ac7d951a6a683e7b6611d4651fad74e4d77c8b8f549cfd32bb1dc664cc4eR198-R206)
* Added a live test suite (`sandbox/test-force-tools-live.php`) verifying forced tool choice and specific tool selection across all providers, ensuring correct mapping and behavior.
* Updated documentation and changelogs to describe the new tool choice features, including migration notes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL11-R27) [[2]](diffhunk://#diff-77f6e0d3cf2f9acd5fbe9b4997899a40264a314f761b555c4eb95859ee200373R251-R288) AUDIT.md: [[3]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L7-R7) [[4]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688R106-R118) [[5]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L120-R135)

**Broadcasting Enhancements:**

* Tool-call events (`AgentToolCallStarted`, `AgentToolCallCompleted`, `AgentToolCallFailed`) now broadcast the full arguments, result, and error by default; a new config option (`ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`) allows capping payload length to fit socket transport limits. [[1]](diffhunk://#diff-a95b2274bdee554a7ca7298fef5ffae21a3c92a2d1243ff7bec80a3e3b0c484cR8) [[2]](diffhunk://#diff-a95b2274bdee554a7ca7298fef5ffae21a3c92a2d1243ff7bec80a3e3b0c484cR20) [[3]](diffhunk://#diff-a95b2274bdee554a7ca7298fef5ffae21a3c92a2d1243ff7bec80a3e3b0c484cL45-R47) [[4]](diffhunk://#diff-5a2fb6410200ba45cb15d2711be79cf83050cff40a279dcc74af2b9f66a94fe4R8) [[5]](diffhunk://#diff-5a2fb6410200ba45cb15d2711be79cf83050cff40a279dcc74af2b9f66a94fe4R19) [[6]](diffhunk://#diff-5a2fb6410200ba45cb15d2711be79cf83050cff40a279dcc74af2b9f66a94fe4L44-R46) [[7]](diffhunk://#diff-b915a975313320f03300fd50a1e09cee36997b98348bf8b6590d6f0f0ca99addR8) [[8]](diffhunk://#diff-b915a975313320f03300fd50a1e09cee36997b98348bf8b6590d6f0f0ca99addR19) [[9]](diffhunk://#diff-b915a975313320f03300fd50a1e09cee36997b98348bf8b6590d6f0f0ca99addL43-R65) config/atlas.php: [[10]](diffhunk://#diff-0547b8abb0d1b756bd782300755c54f2f74633554fa48ae70413cc0cef6157a9R226-R247) [[11]](diffhunk://#diff-ec805582268c139916013866671931df45a6d737ab07028e37d148c21d07fecfR49-R52)

**Testing and Quality:**

* Increased Pest test coverage to include the new tool choice suite, ensuring robust verification of provider behavior. (AUDIT.md: [AUDIT.mdL120-R135](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L120-R135))

No breaking changes are introduced, but users relying on previous broadcast truncation should set the new cap if needed.