### PR TITLE
Enhance error handling and request configuration in providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `ConnectionException` for network failures (timeout, DNS, refused) before any response. Extends `AtlasException`.
+- `ConnectionException` — a catchable Atlas error for network failures (timeout, DNS, or refused connection) that happen before a response arrives.
 
 ### Fixed
 
-- Retries now work. `atlas.retry` and `->withRetry()` were dropped before the HTTP layer, so 429 and 5xx retries never ran.
-- `->withTimeout()` now applies to the request — it was previously stored but ignored. Provider/reasoning/media defaults are untouched unless you override.
-- `ATLAS_TIMEOUT` (`atlas.retry.timeout`) now sets the default request timeout for every provider. It was ignored before; only the per-provider `timeout` had effect.
-- Per-call `->withRetry()` / `->withTimeout()` / `->withoutRetry()` overrides now survive `->onQueue()` instead of falling back to global config.
-- Network failures now retry and throw a typed `ConnectionException` instead of a raw HTTP-client exception.
-- Mid-stream provider errors now throw `ProviderException` instead of silently truncating the stream.
+- Automatic retries for rate limits (429) and transient server errors (5xx) now run as configured; they previously never fired.
+- `->withTimeout()` now applies to the request, and `ATLAS_TIMEOUT` now sets the default request timeout for every provider.
+- Per-call retry and timeout overrides are now kept when a request is queued.
+- Network failures before a response are now reported as a catchable Atlas error instead of the HTTP client's raw exception.
+- A provider error partway through a stream now ends the stream with an error instead of silently returning a truncated response.
+- Provider error messages now surface the provider's real error text on every provider.
+- Listing models and voices now reports authentication and other failures the same way as every other call.
 
 ### Migration
 
-No breaking changes — drop-in upgrade. To handle mid-stream errors, wrap stream iteration in a try/catch for `ProviderException`.
+No breaking changes — drop-in upgrade. Two optional adjustments: wrap streamed-response iteration in a try/catch to handle a mid-stream provider error (it previously ended silently); and if you caught the HTTP client's exception around `models()` or `voices()`, catch `AtlasException` instead.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ### Fixed
 
 - Retries now work. `atlas.retry` and `->withRetry()` were dropped before the HTTP layer, so 429 and 5xx retries never ran.
+- `->withTimeout()` now applies to the request — it was previously stored but ignored. Provider/reasoning/media defaults are untouched unless you override.
+- Per-call `->withRetry()` / `->withTimeout()` / `->withoutRetry()` overrides now survive `->onQueue()` instead of falling back to global config.
 - Network failures now retry and throw a typed `ConnectionException` instead of a raw HTTP-client exception.
 - Mid-stream provider errors now throw `ProviderException` instead of silently truncating the stream.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Retries now work. `atlas.retry` and `->withRetry()` were dropped before the HTTP layer, so 429 and 5xx retries never ran.
 - `->withTimeout()` now applies to the request — it was previously stored but ignored. Provider/reasoning/media defaults are untouched unless you override.
+- `ATLAS_TIMEOUT` (`atlas.retry.timeout`) now sets the default request timeout for every provider. It was ignored before; only the per-provider `timeout` had effect.
 - Per-call `->withRetry()` / `->withTimeout()` / `->withoutRetry()` overrides now survive `->onQueue()` instead of falling back to global config.
 - Network failures now retry and throw a typed `ConnectionException` instead of a raw HTTP-client exception.
 - Mid-stream provider errors now throw `ProviderException` instead of silently truncating the stream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- `ConnectionException` — a typed exception for network-level failures (connection timeout, DNS failure, refused connection) that happen before the provider returns any response. It extends `AtlasException`, so existing catch-all handlers still catch it.
+
+### Fixed
+
+- Network failures reaching a provider (timeouts, DNS, refused connections) now retry as transient errors and surface as a typed `ConnectionException` instead of leaking a raw HTTP-client exception that escaped `catch (AtlasException)`.
+- Provider errors that occur partway through a streamed response are now detected and thrown as a `ProviderException` while you iterate the stream, instead of silently ending the stream with a truncated, successful-looking result.
+
+### Migration
+
+No breaking changes — drop-in upgrade. No consumer action required. If you consume streamed responses, wrap iteration in a try/catch for `ProviderException` to handle mid-stream provider errors (previously these were swallowed).
+
+---
+
 ## [v3.4.0](https://github.com/atlas-php/atlas/releases/tag/v3.4.0) - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `ConnectionException` — a catchable Atlas error for network failures (timeout, DNS, or refused connection) that happen before a response arrives.
+- Catch specific provider failures with the new `ConnectionException` (network failure), `ModelNotFoundException` (unknown model), `InvalidRequestException` (bad request), and `ServerException` (provider server error).
+
+### Changed
+
+- One `catch (ProviderException)` now handles every provider failure — authentication, rate limits, bad requests, server, and network errors. Catch a subclass when you need a specific case.
+- Provider "overloaded" responses are now retried automatically, like rate limits.
 
 ### Fixed
 
-- Automatic retries for rate limits (429) and transient server errors (5xx) now run as configured; they previously never fired.
-- `->withTimeout()` now applies to the request, and `ATLAS_TIMEOUT` now sets the default request timeout for every provider.
-- Per-call retry and timeout overrides are now kept when a request is queued.
-- Network failures before a response are now reported as a catchable Atlas error instead of the HTTP client's raw exception.
-- A provider error partway through a stream now ends the stream with an error instead of silently returning a truncated response.
-- Provider error messages now surface the provider's real error text on every provider.
-- Listing models and voices now reports authentication and other failures the same way as every other call.
+- Failed requests are now retried automatically on rate limits and temporary server errors; previously they were not.
+- A timeout set per call, or globally, is now honored — including on queued requests.
+- Network failures and mid-stream provider errors now surface as errors instead of being swallowed or returning a truncated, successful-looking response.
+- Error messages now carry the provider's real reason on every provider.
+- Listing available models and voices now reports failures the same way as every other call.
 
 ### Migration
 
-No breaking changes — drop-in upgrade. Two optional adjustments: wrap streamed-response iteration in a try/catch to handle a mid-stream provider error (it previously ended silently); and if you caught the HTTP client's exception around `models()` or `voices()`, catch `AtlasException` instead.
+Mostly drop-in. `catch (ProviderException)` now also catches authentication, authorization, and rate-limit errors — if you handle those separately, list their `catch` blocks first. The unused `reasoning_timeout` provider option was removed; set a longer timeout per call instead. If you read streamed responses, wrap the loop in a try/catch to handle a mid-stream error.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Network failures and mid-stream provider errors now surface as errors instead of being swallowed or returning a truncated, successful-looking response.
 - Error messages now carry the provider's real reason on every provider.
 - Listing available models and voices now reports failures the same way as every other call.
+- Queued requests now fail fast on errors that can't succeed (invalid key, bad request, unknown model) instead of using up every retry; transient errors still retry.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `ConnectionException` — a typed exception for network-level failures (connection timeout, DNS failure, refused connection) that happen before the provider returns any response. It extends `AtlasException`, so existing catch-all handlers still catch it.
+- `ConnectionException` for network failures (timeout, DNS, refused) before any response. Extends `AtlasException`.
 
 ### Fixed
 
-- Network failures reaching a provider (timeouts, DNS, refused connections) now retry as transient errors and surface as a typed `ConnectionException` instead of leaking a raw HTTP-client exception that escaped `catch (AtlasException)`.
-- Provider errors that occur partway through a streamed response are now detected and thrown as a `ProviderException` while you iterate the stream, instead of silently ending the stream with a truncated, successful-looking result.
+- Retries now work. `atlas.retry` and `->withRetry()` were dropped before the HTTP layer, so 429 and 5xx retries never ran.
+- Network failures now retry and throw a typed `ConnectionException` instead of a raw HTTP-client exception.
+- Mid-stream provider errors now throw `ProviderException` instead of silently truncating the stream.
 
 ### Migration
 
-No breaking changes — drop-in upgrade. No consumer action required. If you consume streamed responses, wrap iteration in a try/catch for `ProviderException` to handle mid-stream provider errors (previously these were swallowed).
+No breaking changes — drop-in upgrade. To handle mid-stream errors, wrap stream iteration in a try/catch for `ProviderException`.
 
 ---
 

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -172,13 +172,18 @@ return [
     |
     | timeout    — Default seconds before a single attempt is abandoned. A
     |              provider's own `timeout` (under `providers`) overrides this.
+    |              60s suits streaming and everyday completions. Slow paths —
+    |              non-streaming on large models, and especially reasoning
+    |              models (o1/o3, extended thinking) which can run for minutes —
+    |              need more: raise ATLAS_TIMEOUT, set a per-provider `timeout`,
+    |              or override per call with ->withTimeout().
     | rate_limit — Retries on 429 (Too Many Requests). Waits for Retry-After.
     | errors     — Retries on 5xx / connection timeouts. Exponential backoff.
     |
     | Permanent failures (401, 403) are never retried.
     |
     | Override per call:
-    |   ->withTimeout(120)
+    |   ->withTimeout(300)   // e.g. a reasoning model
     |   ->withRetry(rateLimit: 5, errors: 3)
     |   ->withoutRetry()
     |

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -170,7 +170,8 @@ return [
     |
     | Controls how Atlas behaves when a provider call fails or is slow.
     |
-    | timeout    — Seconds before a single attempt is abandoned.
+    | timeout    — Default seconds before a single attempt is abandoned. A
+    |              provider's own `timeout` (under `providers`) overrides this.
     | rate_limit — Retries on 429 (Too Many Requests). Waits for Retry-After.
     | errors     — Retries on 5xx / connection timeouts. Exponential backoff.
     |

--- a/docs/advanced/error-handling.md
+++ b/docs/advanced/error-handling.md
@@ -12,6 +12,7 @@ AtlasException (base — extends RuntimeException, catch all Atlas errors)
 ├── AuthorizationException         (403 — model access denied)
 ├── RateLimitException             (429 — rate limit with retry info)
 ├── ProviderException              (all other HTTP errors)
+├── ConnectionException            (network failure before any response)
 ├── UnsupportedFeatureException    (modality not supported by provider)
 ├── ProviderNotFoundException      (provider key not registered)
 ├── AgentNotFoundException         (agent key not found)
@@ -48,6 +49,51 @@ try {
     $e->statusCode;        // HTTP status code
     $e->providerMessage;   // Error message from provider
     $e->provider;          // Provider name (e.g., 'openai')
+}
+```
+
+### Connection Failures
+
+Network-level failures that occur before the provider returns any response —
+connection timeouts, DNS failures, refused connections — surface as a
+`ConnectionException`. Unlike `ProviderException`, it carries no HTTP status
+because no response was received. These failures are retried automatically as
+transient errors (controlled by `atlas.retry.errors`) before the exception is
+thrown.
+
+```php
+use Atlasphp\Atlas\Exceptions\ConnectionException;
+
+try {
+    $response = Atlas::text(Provider::OpenAI, 'gpt-4o-mini')
+        ->message('Hello')
+        ->asText();
+} catch (ConnectionException $e) {
+    // Network failure reaching the provider (timeout, DNS, refused)
+    $e->provider; // e.g. 'openai'
+    $e->model;    // e.g. 'gpt-4o-mini'
+}
+```
+
+`ConnectionException` extends `AtlasException`, so a `catch (AtlasException)`
+block catches it too.
+
+### Streaming Errors
+
+When a provider reports an error **mid-stream** (after the stream has started),
+Atlas detects the error event and throws a `ProviderException` while you iterate
+the stream — it does not silently truncate the response. Wrap stream consumption
+in a try/catch:
+
+```php
+use Atlasphp\Atlas\Exceptions\ProviderException;
+
+try {
+    foreach (Atlas::text(Provider::OpenAI, 'gpt-4o')->message('Hi')->asStream() as $chunk) {
+        echo $chunk->text;
+    }
+} catch (ProviderException $e) {
+    // Provider errored partway through the stream
 }
 ```
 

--- a/docs/advanced/error-handling.md
+++ b/docs/advanced/error-handling.md
@@ -47,10 +47,17 @@ try {
 } catch (ProviderException $e) {
     // All other HTTP errors (400, 500, etc.)
     $e->statusCode;        // HTTP status code
-    $e->providerMessage;   // Error message from provider
+    $e->providerMessage;   // Real provider error message (every provider)
     $e->provider;          // Provider name (e.g., 'openai')
 }
 ```
+
+`$e->providerMessage` carries the provider's actual error text across all
+providers, regardless of how each one shapes its error response.
+
+Provider interrogation calls (`Atlas::provider(...)->models()` and `->voices()`)
+throw the same typed exceptions — e.g. an invalid key surfaces as
+`AuthenticationException`, not a raw HTTP-client error.
 
 ### Connection Failures
 

--- a/docs/advanced/error-handling.md
+++ b/docs/advanced/error-handling.md
@@ -8,17 +8,24 @@ Atlas maps provider HTTP errors and configuration problems to typed exceptions:
 
 ```
 AtlasException (base — extends RuntimeException, catch all Atlas errors)
-├── AuthenticationException        (401 — invalid API key)
-├── AuthorizationException         (403 — model access denied)
-├── RateLimitException             (429 — rate limit with retry info)
-├── ProviderException              (all other HTTP errors)
-├── ConnectionException            (network failure before any response)
+├── ProviderException              (base for any failed provider call; catch to handle them all)
+│   ├── AuthenticationException    (401 — invalid API key)
+│   ├── AuthorizationException     (403 — model access denied)
+│   ├── RateLimitException         (429 / 529 — rate limited or overloaded, with retry info)
+│   ├── InvalidRequestException    (400 — malformed/invalid request)
+│   ├── ModelNotFoundException     (404 — unknown model)
+│   ├── ServerException            (5xx — provider-side server error)
+│   └── ConnectionException        (network failure before any response; statusCode is null)
 ├── UnsupportedFeatureException    (modality not supported by provider)
 ├── ProviderNotFoundException      (provider key not registered)
 ├── AgentNotFoundException         (agent key not found)
 ├── ToolNotFoundException          (tool name not in registry)
 └── MaxStepsExceededException      (executor exceeded step limit)
 ```
+
+Catch `ProviderException` to handle any failed provider call, or a specific
+subclass for a category. Every `ProviderException` exposes `->provider`,
+`->model`, `->statusCode` (null for `ConnectionException`), and `->providerMessage`.
 
 All exceptions live in `Atlasphp\Atlas\Exceptions`.
 

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -9,12 +9,15 @@ use Throwable;
 /**
  * Thrown when provider authentication fails (HTTP 401).
  */
-class AuthenticationException extends AtlasException
+class AuthenticationException extends ProviderException
 {
-    public function __construct(
-        public readonly string $provider,
-        ?Throwable $previous = null,
-    ) {
-        parent::__construct("Authentication failed for provider [{$provider}].", 0, $previous);
+    public function __construct(string $provider, string $model = '', ?Throwable $previous = null)
+    {
+        parent::__construct($provider, $model, 401, '', $previous);
+    }
+
+    protected function buildMessage(): string
+    {
+        return "Authentication failed for provider [{$this->provider}].";
     }
 }

--- a/src/Exceptions/AuthorizationException.php
+++ b/src/Exceptions/AuthorizationException.php
@@ -9,13 +9,15 @@ use Throwable;
 /**
  * Thrown when provider authorization fails (HTTP 403).
  */
-class AuthorizationException extends AtlasException
+class AuthorizationException extends ProviderException
 {
-    public function __construct(
-        public readonly string $provider,
-        public readonly string $model,
-        ?Throwable $previous = null,
-    ) {
-        parent::__construct("Authorization failed for [{$provider}] model [{$model}].", 0, $previous);
+    public function __construct(string $provider, string $model, ?Throwable $previous = null)
+    {
+        parent::__construct($provider, $model, 403, '', $previous);
+    }
+
+    protected function buildMessage(): string
+    {
+        return "Authorization failed for [{$this->provider}] model [{$this->model}].";
     }
 }

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+use Throwable;
+
+/**
+ * Thrown when a provider request fails at the network level before any HTTP
+ * response is received (connection timeout, DNS failure, refused connection).
+ *
+ * Distinct from ProviderException, which represents an HTTP error response the
+ * provider actually returned. Connection failures carry no HTTP status.
+ */
+class ConnectionException extends AtlasException
+{
+    public function __construct(
+        public readonly string $provider,
+        public readonly string $model,
+        ?Throwable $previous = null,
+    ) {
+        $reason = $previous?->getMessage();
+
+        parent::__construct(
+            "Connection to provider [{$provider}] failed".($reason !== null && $reason !== '' ? ": {$reason}" : '.'),
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -10,22 +10,19 @@ use Throwable;
  * Thrown when a provider request fails at the network level before any HTTP
  * response is received (connection timeout, DNS failure, refused connection).
  *
- * Distinct from ProviderException, which represents an HTTP error response the
- * provider actually returned. Connection failures carry no HTTP status.
+ * A ProviderException with a null statusCode: it's a provider-communication
+ * failure, but no HTTP response was returned.
  */
-class ConnectionException extends AtlasException
+class ConnectionException extends ProviderException
 {
-    public function __construct(
-        public readonly string $provider,
-        public readonly string $model,
-        ?Throwable $previous = null,
-    ) {
-        $reason = $previous?->getMessage();
+    public function __construct(string $provider, string $model, ?Throwable $previous = null)
+    {
+        parent::__construct($provider, $model, null, $previous?->getMessage() ?? '', $previous);
+    }
 
-        parent::__construct(
-            "Connection to provider [{$provider}] failed".($reason !== null && $reason !== '' ? ": {$reason}" : '.'),
-            0,
-            $previous,
-        );
+    protected function buildMessage(): string
+    {
+        return "Connection to provider [{$this->provider}] failed"
+            .($this->providerMessage !== '' ? ": {$this->providerMessage}" : '.');
     }
 }

--- a/src/Exceptions/InvalidRequestException.php
+++ b/src/Exceptions/InvalidRequestException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+/**
+ * Thrown when the provider rejects the request as malformed or invalid (HTTP 400).
+ */
+class InvalidRequestException extends ProviderException {}

--- a/src/Exceptions/ModelNotFoundException.php
+++ b/src/Exceptions/ModelNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+/**
+ * Thrown when the provider does not recognize the requested model (HTTP 404).
+ */
+class ModelNotFoundException extends ProviderException {}

--- a/src/Exceptions/ProviderException.php
+++ b/src/Exceptions/ProviderException.php
@@ -35,4 +35,26 @@ class ProviderException extends AtlasException
             $e,
         );
     }
+
+    /**
+     * Create from a provider error payload received mid-stream.
+     *
+     * Stream errors arrive as SSE event payloads rather than HTTP responses, so
+     * they carry no HTTP status. The message is extracted from the common
+     * provider error shapes (object with `message`, nested `error.message`, or a
+     * plain string `error`).
+     *
+     * @param  array<string, mixed>  $error
+     */
+    public static function fromStreamError(string $provider, string $model, array $error, ?int $status = null): self
+    {
+        $message = data_get($error, 'message')
+            ?? data_get($error, 'error.message')
+            ?? (is_string(data_get($error, 'error')) ? data_get($error, 'error') : null)
+            ?? 'Provider returned an error during streaming.';
+
+        $code = $status ?? (is_int(data_get($error, 'code')) ? (int) data_get($error, 'code') : 0);
+
+        return new self($provider, $model, $code, (string) $message);
+    }
 }

--- a/src/Exceptions/ProviderException.php
+++ b/src/Exceptions/ProviderException.php
@@ -24,14 +24,19 @@ class ProviderException extends AtlasException
 
     /**
      * Create from a request exception, extracting status code and error message.
+     *
+     * Optionally accepts a message already resolved by the driver (e.g. via a
+     * provider-specific override) which takes precedence over the shared chain.
      */
-    public static function from(string $provider, string $model, RequestException $e): self
+    public static function from(string $provider, string $model, RequestException $e, ?string $message = null): self
     {
+        $body = $e->response->json();
+
         return new self(
             $provider,
             $model,
             $e->response->status(),
-            $e->response->json('error.message', $e->getMessage()),
+            $message ?? self::extractMessage(is_array($body) ? $body : []) ?? $e->getMessage(),
             $e,
         );
     }
@@ -41,23 +46,47 @@ class ProviderException extends AtlasException
      *
      * Stream errors arrive as SSE event payloads rather than HTTP responses, so
      * they carry no HTTP status. The message is extracted from the common
-     * provider error shapes (object with `message`, nested `error.message`, or a
-     * plain string `error`).
+     * provider error shapes.
      *
      * @param  array<string, mixed>  $error
      */
     public static function fromStreamError(string $provider, string $model, array $error, ?int $status = null): self
     {
-        $nested = data_get($error, 'error');
         $rawCode = data_get($error, 'code');
-
-        $message = data_get($error, 'message')
-            ?? data_get($error, 'error.message')
-            ?? (is_string($nested) ? $nested : null)
-            ?? 'Provider returned an error during streaming.';
-
         $code = $status ?? (is_int($rawCode) ? $rawCode : 0);
 
-        return new self($provider, $model, $code, (string) $message);
+        return new self(
+            $provider,
+            $model,
+            $code,
+            self::extractMessage($error) ?? 'Provider returned an error during streaming.',
+        );
+    }
+
+    /**
+     * Extract a human-readable error message from a decoded provider error body.
+     *
+     * Providers nest the message differently: OpenAI/Anthropic/Google/xAI use
+     * `error.message`; ElevenLabs/Jina use `detail` (string) or `detail.message`;
+     * Cohere uses a top-level `message`; Ollama uses a string `error`. Returns
+     * null when no recognizable message is present.
+     *
+     * Order is most-specific to least: the structured `error.message` is
+     * preferred over a bare top-level `message`, since when both exist the
+     * nested one is the canonical provider error.
+     *
+     * @param  array<string, mixed>  $body
+     */
+    private static function extractMessage(array $body): ?string
+    {
+        foreach (['error.message', 'detail.message', 'detail', 'message', 'error'] as $path) {
+            $value = data_get($body, $path);
+
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Exceptions/ProviderException.php
+++ b/src/Exceptions/ProviderException.php
@@ -8,18 +8,34 @@ use Illuminate\Http\Client\RequestException;
 use Throwable;
 
 /**
- * Thrown when a provider returns an unexpected error.
+ * Base for all provider-side errors: the request reached (or tried to reach) a
+ * provider and something went wrong. Catch this to handle any provider failure;
+ * catch a subclass (AuthenticationException, RateLimitException, etc.) for a
+ * specific category.
+ *
+ * `statusCode` is null when no HTTP response was received (see ConnectionException).
  */
 class ProviderException extends AtlasException
 {
     public function __construct(
         public readonly string $provider,
         public readonly string $model,
-        public readonly int $statusCode,
+        public readonly ?int $statusCode,
         public readonly string $providerMessage,
         ?Throwable $previous = null,
     ) {
-        parent::__construct("Provider [{$provider}] error [{$statusCode}]: {$providerMessage}", 0, $previous);
+        parent::__construct($this->buildMessage(), 0, $previous);
+    }
+
+    /**
+     * Build the human-readable exception message. Subclasses override this to
+     * keep their own phrasing while still sharing the base properties.
+     */
+    protected function buildMessage(): string
+    {
+        $status = $this->statusCode !== null ? " [{$this->statusCode}]" : '';
+
+        return "Provider [{$this->provider}] error{$status}: {$this->providerMessage}";
     }
 
     /**
@@ -30,30 +46,41 @@ class ProviderException extends AtlasException
      */
     public static function from(string $provider, string $model, RequestException $e, ?string $message = null): self
     {
+        return new self($provider, $model, $e->response->status(), self::resolveMessage($e, $message), $e);
+    }
+
+    /**
+     * Resolve the provider error message from a failed response, honoring a
+     * caller-supplied override, then the shared extraction chain, then the
+     * request exception's own message. Used by the typed subclasses too.
+     */
+    public static function resolveMessage(RequestException $e, ?string $override = null): string
+    {
         $body = $e->response->json();
 
-        return new self(
-            $provider,
-            $model,
-            $e->response->status(),
-            $message ?? self::extractMessage(is_array($body) ? $body : []) ?? $e->getMessage(),
-            $e,
-        );
+        return $override ?? self::extractMessage(is_array($body) ? $body : []) ?? $e->getMessage();
     }
 
     /**
      * Create from a provider error payload received mid-stream.
      *
+     * Returns the base ProviderException, not a typed subclass: a mid-stream
+     * error arrives after a successful, authenticated connection, so the
+     * status-based categories (auth, not-found, invalid-request) don't apply —
+     * those are already classified at connection time by handleRequestException.
+     * Mid-stream errors are overload/server conditions; catch ProviderException.
+     *
      * Stream errors arrive as SSE event payloads rather than HTTP responses, so
-     * they carry no HTTP status. The message is extracted from the common
-     * provider error shapes.
+     * they usually carry no HTTP status. The message is extracted from the
+     * common provider error shapes.
      *
      * @param  array<string, mixed>  $error
      */
     public static function fromStreamError(string $provider, string $model, array $error, ?int $status = null): self
     {
         $rawCode = data_get($error, 'code');
-        $code = $status ?? (is_int($rawCode) ? $rawCode : 0);
+        // Null (not 0) when there's no real status, so buildMessage omits the bracket.
+        $code = $status ?? (is_int($rawCode) && $rawCode > 0 ? $rawCode : null);
 
         return new self(
             $provider,

--- a/src/Exceptions/ProviderException.php
+++ b/src/Exceptions/ProviderException.php
@@ -48,12 +48,15 @@ class ProviderException extends AtlasException
      */
     public static function fromStreamError(string $provider, string $model, array $error, ?int $status = null): self
     {
+        $nested = data_get($error, 'error');
+        $rawCode = data_get($error, 'code');
+
         $message = data_get($error, 'message')
             ?? data_get($error, 'error.message')
-            ?? (is_string(data_get($error, 'error')) ? data_get($error, 'error') : null)
+            ?? (is_string($nested) ? $nested : null)
             ?? 'Provider returned an error during streaming.';
 
-        $code = $status ?? (is_int(data_get($error, 'code')) ? (int) data_get($error, 'code') : 0);
+        $code = $status ?? (is_int($rawCode) ? $rawCode : 0);
 
         return new self($provider, $model, $code, (string) $message);
     }

--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -8,26 +8,36 @@ use Illuminate\Http\Client\RequestException;
 use Throwable;
 
 /**
- * Thrown when a provider returns a rate limit error (HTTP 429).
+ * Thrown when a provider signals it is rate limited or overloaded (HTTP 429,
+ * and Anthropic's 529 Overloaded).
  */
-class RateLimitException extends AtlasException
+class RateLimitException extends ProviderException
 {
     public function __construct(
-        public readonly string $provider,
-        public readonly string $model,
+        string $provider,
+        string $model,
         public readonly ?int $retryAfter = null,
         ?Throwable $previous = null,
+        int $statusCode = 429,
     ) {
-        parent::__construct("Rate limit exceeded for [{$provider}] model [{$model}].", 0, $previous);
+        parent::__construct($provider, $model, $statusCode, 'Rate limit exceeded.', $previous);
+    }
+
+    protected function buildMessage(): string
+    {
+        return "Rate limit exceeded for [{$this->provider}] model [{$this->model}].";
     }
 
     /**
-     * Create from a request exception, extracting the Retry-After header.
+     * Create from a request exception, extracting the Retry-After header and
+     * preserving the real status (429 or 529). The $message argument exists for
+     * signature compatibility with the parent factory and is unused — a rate
+     * limit's message is fixed.
      */
-    public static function from(string $provider, string $model, RequestException $e): self
+    public static function from(string $provider, string $model, RequestException $e, ?string $message = null): self
     {
         $retryAfter = (int) $e->response->header('Retry-After') ?: null;
 
-        return new self($provider, $model, $retryAfter, $e);
+        return new self($provider, $model, $retryAfter, $e, $e->response->status());
     }
 }

--- a/src/Exceptions/ServerException.php
+++ b/src/Exceptions/ServerException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+/**
+ * Thrown on a provider-side server error (HTTP 5xx). Retryable as a transient
+ * failure when retries are enabled.
+ */
+class ServerException extends ProviderException {}

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -70,6 +70,8 @@ class HttpClient
      */
     public function post(string $url, array $headers, array $body, int $timeout, ?RequestConfig $config = null): array
     {
+        $timeout = $this->effectiveTimeout($timeout, $config);
+
         return $this->withRetry($config, $url, function () use ($url, $headers, $body, $timeout) {
             $response = $this->sendPost($url, $headers, $body, $timeout);
 
@@ -90,6 +92,8 @@ class HttpClient
      */
     public function postRaw(string $url, array $headers, array $body, int $timeout, ?RequestConfig $config = null): string
     {
+        $timeout = $this->effectiveTimeout($timeout, $config);
+
         return $this->withRetry($config, $url, function () use ($url, $headers, $body, $timeout) {
             $response = $this->sendPost($url, $headers, $body, $timeout);
 
@@ -109,6 +113,8 @@ class HttpClient
      */
     public function postMultipart(string $url, array $headers, array $data, array $attachments, int $timeout, ?RequestConfig $config = null): array
     {
+        $timeout = $this->effectiveTimeout($timeout, $config);
+
         return $this->withRetry($config, $url, function () use ($url, $headers, $data, $attachments, $timeout) {
             $this->events->dispatch(new ProviderRequestStarted($url, $data, 'MULTIPART'));
 
@@ -140,6 +146,8 @@ class HttpClient
      */
     public function stream(string $url, array $headers, array $body, int $timeout, ?RequestConfig $config = null): Response
     {
+        $timeout = $this->effectiveTimeout($timeout, $config);
+
         return $this->withRetry($config, $url, function () use ($url, $headers, $body, $timeout) {
             $this->events->dispatch(new ProviderRequestStarted($url, $body, 'STREAM'));
 
@@ -157,6 +165,18 @@ class HttpClient
     }
 
     // ─── Internal ─────────────────────────────────────────────────
+
+    /**
+     * Resolve the timeout for a call.
+     *
+     * The handler's $timeout is the default (provider/reasoning/media). A
+     * per-call ->withTimeout() override wins only when explicitly set, so it
+     * never clobbers a longer provider-specific default.
+     */
+    private function effectiveTimeout(int $timeout, ?RequestConfig $config): int
+    {
+        return $config?->timeoutExplicit ? $config->timeout : $timeout;
+    }
 
     /**
      * Send a GET request, dispatch start event, and validate the response.

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -45,7 +45,9 @@ class HttpClient
     /**
      * Send a GET request and return the raw response body.
      *
-     * Used for binary responses such as video content downloads.
+     * Used for binary responses such as video content downloads. Like get(),
+     * this takes no RequestConfig — GET fetches are not retried and don't honor
+     * a per-call ->withTimeout() override; they use the handler's media timeout.
      *
      * @param  array<string, string>  $headers
      */

--- a/src/Http/RetryDecider.php
+++ b/src/Http/RetryDecider.php
@@ -7,6 +7,7 @@ namespace Atlasphp\Atlas\Http;
 use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
 use Atlasphp\Atlas\RequestConfig;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 
 /**
@@ -46,6 +47,12 @@ class RetryDecider
             if ($this->isTransientStatus($status)) {
                 return $config->errors > 0 && $attempt <= $config->errors;
             }
+        }
+
+        // Connection-level failures (timeout, DNS, refused) thrown by the HTTP
+        // client before any response — treated as transient.
+        if ($e instanceof ConnectionException) {
+            return $config->errors > 0 && $attempt <= $config->errors;
         }
 
         return false;

--- a/src/Http/RetryDecider.php
+++ b/src/Http/RetryDecider.php
@@ -32,7 +32,7 @@ class RetryDecider
             return $config->rateLimit > 0 && $attempt <= $config->rateLimit;
         }
 
-        if ($e instanceof ProviderException && $this->isTransientStatus($e->statusCode)) {
+        if ($e instanceof ProviderException && $e->statusCode !== null && $this->isTransientStatus($e->statusCode)) {
             return $config->errors > 0 && $attempt <= $config->errors;
         }
 
@@ -40,7 +40,8 @@ class RetryDecider
         if ($e instanceof RequestException) {
             $status = $e->response->status();
 
-            if ($status === 429) {
+            // 429 Too Many Requests and Anthropic's 529 Overloaded.
+            if ($status === 429 || $status === 529) {
                 return $config->rateLimit > 0 && $attempt <= $config->rateLimit;
             }
 
@@ -72,7 +73,7 @@ class RetryDecider
             return $wait * 1_000_000;
         }
 
-        if ($e instanceof RequestException && $e->response->status() === 429) {
+        if ($e instanceof RequestException && ($e->response->status() === 429 || $e->response->status() === 529)) {
             $retryAfter = (int) ($e->response->header('Retry-After') ?: 1);
 
             return min($retryAfter, 60) * 1_000_000;

--- a/src/Pending/AgentRequest.php
+++ b/src/Pending/AgentRequest.php
@@ -1181,6 +1181,7 @@ class AgentRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::agent($payload['key']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['message'] !== null) {
             $media = self::restoreMedia($payload['message_media'] ?? []);

--- a/src/Pending/AgentRequest.php
+++ b/src/Pending/AgentRequest.php
@@ -1025,6 +1025,7 @@ class AgentRequest implements QueueableRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cacheOverride ?? $this->config->promptCache,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/AudioRequest.php
+++ b/src/Pending/AudioRequest.php
@@ -197,6 +197,7 @@ class AudioRequest implements QueueableRequest
             meta: array_merge($this->meta, [
                 '_audio_mode' => $this->meta['_audio_mode'] ?? 'tts',
             ]),
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/AudioRequest.php
+++ b/src/Pending/AudioRequest.php
@@ -241,6 +241,7 @@ class AudioRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::audio($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['instructions'] !== null) {
             $request->instructions($payload['instructions']);

--- a/src/Pending/Concerns/HasQueueDispatch.php
+++ b/src/Pending/Concerns/HasQueueDispatch.php
@@ -261,6 +261,9 @@ trait HasQueueDispatch
     /**
      * Serialize the per-call request config override for the queue payload.
      *
+     * Fulfilled by the HasRequestConfig trait, which every queueable builder
+     * also uses. Declared here so the contract is enforced at class load.
+     *
      * @return array{timeout: int, rateLimit: int, errors: int, timeoutExplicit: bool}|null
      */
     abstract public function requestConfigPayload(): ?array;

--- a/src/Pending/Concerns/HasQueueDispatch.php
+++ b/src/Pending/Concerns/HasQueueDispatch.php
@@ -163,6 +163,7 @@ trait HasQueueDispatch
         // Merge terminal args into payload
         $payload = $this->toQueuePayload();
         $payload['_terminal_args'] = $terminalArgs;
+        $payload['_request_config'] = $this->requestConfigPayload();
 
         // Build the job
         $job = new ExecuteAtlasJob(
@@ -256,4 +257,11 @@ trait HasQueueDispatch
      * Get model key as string for execution record.
      */
     abstract protected function resolveModelKey(): string;
+
+    /**
+     * Serialize the per-call request config override for the queue payload.
+     *
+     * @return array{timeout: int, rateLimit: int, errors: int, timeoutExplicit: bool}|null
+     */
+    abstract public function requestConfigPayload(): ?array;
 }

--- a/src/Pending/Concerns/HasRequestConfig.php
+++ b/src/Pending/Concerns/HasRequestConfig.php
@@ -63,4 +63,29 @@ trait HasRequestConfig
         return $this->requestConfig
             ?? RequestConfig::fromAtlasConfig(app(AtlasConfig::class));
     }
+
+    /**
+     * Serialize the per-call config override for a queue payload.
+     *
+     * Returns null when no override was set, so queued jobs without an explicit
+     * ->withRetry()/->withTimeout()/->withoutRetry() fall back to global config.
+     *
+     * @return array{timeout: int, rateLimit: int, errors: int, timeoutExplicit: bool}|null
+     */
+    public function requestConfigPayload(): ?array
+    {
+        return $this->requestConfig?->toArray();
+    }
+
+    /**
+     * Restore a per-call config override from a queue payload.
+     *
+     * @param  array{timeout: int, rateLimit: int, errors: int, timeoutExplicit?: bool}|null  $data
+     */
+    public function applyRequestConfigPayload(?array $data): void
+    {
+        if ($data !== null) {
+            $this->requestConfig = RequestConfig::fromArray($data);
+        }
+    }
 }

--- a/src/Pending/EmbedRequest.php
+++ b/src/Pending/EmbedRequest.php
@@ -94,6 +94,7 @@ class EmbedRequest implements QueueableRequest
             providerOptions: $this->providerOptions,
             middleware: $this->middleware,
             meta: $this->meta,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/EmbedRequest.php
+++ b/src/Pending/EmbedRequest.php
@@ -130,6 +130,7 @@ class EmbedRequest implements QueueableRequest
     ): mixed {
         $request = Atlas::embed($payload['provider'], $payload['model'])
             ->fromInput($payload['input']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if (! empty($payload['providerOptions'])) {
             $request->withProviderOptions($payload['providerOptions']);

--- a/src/Pending/GenerativeAudioRequest.php
+++ b/src/Pending/GenerativeAudioRequest.php
@@ -126,6 +126,7 @@ abstract class GenerativeAudioRequest implements QueueableRequest
             meta: array_merge($this->meta, [
                 '_audio_mode' => $this->audioMode(),
             ]),
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/ImageRequest.php
+++ b/src/Pending/ImageRequest.php
@@ -171,6 +171,7 @@ class ImageRequest implements QueueableRequest
             count: $this->count,
             middleware: $this->middleware,
             meta: $this->meta,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/ImageRequest.php
+++ b/src/Pending/ImageRequest.php
@@ -213,6 +213,7 @@ class ImageRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::image($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['instructions'] !== null) {
             $request->instructions($payload['instructions']);

--- a/src/Pending/ModerateRequest.php
+++ b/src/Pending/ModerateRequest.php
@@ -94,6 +94,7 @@ class ModerateRequest implements QueueableRequest
             providerOptions: $this->providerOptions,
             middleware: $this->middleware,
             meta: $this->meta,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/ModerateRequest.php
+++ b/src/Pending/ModerateRequest.php
@@ -130,6 +130,7 @@ class ModerateRequest implements QueueableRequest
     ): mixed {
         $request = Atlas::moderate($payload['provider'], $payload['model'])
             ->fromInput($payload['input']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if (! empty($payload['providerOptions'])) {
             $request->withProviderOptions($payload['providerOptions']);

--- a/src/Pending/MusicRequest.php
+++ b/src/Pending/MusicRequest.php
@@ -47,6 +47,7 @@ class MusicRequest extends GenerativeAudioRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::music($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         static::applyPayload($request, $payload, $executionId);
 

--- a/src/Pending/RerankRequest.php
+++ b/src/Pending/RerankRequest.php
@@ -180,6 +180,7 @@ class RerankRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::rerank($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['query'] !== null) {
             $request->query($payload['query']);

--- a/src/Pending/RerankRequest.php
+++ b/src/Pending/RerankRequest.php
@@ -141,6 +141,7 @@ class RerankRequest implements QueueableRequest
             providerOptions: $this->providerOptions,
             middleware: $this->middleware,
             meta: $this->meta,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/SfxRequest.php
+++ b/src/Pending/SfxRequest.php
@@ -47,6 +47,7 @@ class SfxRequest extends GenerativeAudioRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::sfx($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         static::applyPayload($request, $payload, $executionId);
 

--- a/src/Pending/SpeechRequest.php
+++ b/src/Pending/SpeechRequest.php
@@ -232,6 +232,7 @@ class SpeechRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::speech($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['instructions'] !== null) {
             $request->instructions($payload['instructions']);

--- a/src/Pending/SpeechRequest.php
+++ b/src/Pending/SpeechRequest.php
@@ -189,6 +189,7 @@ class SpeechRequest implements QueueableRequest
             meta: array_merge($this->meta, [
                 '_audio_mode' => 'speech',
             ]),
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/TextRequest.php
+++ b/src/Pending/TextRequest.php
@@ -413,6 +413,7 @@ class TextRequest implements QueueableRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache ?? (bool) config('atlas.prompt_cache', true),
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/TextRequest.php
+++ b/src/Pending/TextRequest.php
@@ -467,6 +467,7 @@ class TextRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::text($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['instructions'] !== null) {
             $request->instructions($payload['instructions']);

--- a/src/Pending/VideoRequest.php
+++ b/src/Pending/VideoRequest.php
@@ -202,6 +202,7 @@ class VideoRequest implements QueueableRequest
         ?Channel $broadcastChannel = null,
     ): mixed {
         $request = Atlas::video($payload['provider'], $payload['model']);
+        $request->applyRequestConfigPayload($payload['_request_config'] ?? null);
 
         if ($payload['instructions'] !== null) {
             $request->instructions($payload['instructions']);

--- a/src/Pending/VideoRequest.php
+++ b/src/Pending/VideoRequest.php
@@ -161,6 +161,7 @@ class VideoRequest implements QueueableRequest
             providerOptions: $this->providerOptions,
             middleware: $this->middleware,
             meta: $this->meta,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 

--- a/src/Pending/VoiceRequest.php
+++ b/src/Pending/VoiceRequest.php
@@ -206,6 +206,7 @@ class VoiceRequest
             providerOptions: $this->providerOptions,
             middleware: $this->middleware,
             meta: $this->meta,
+            requestConfig: $this->resolveRequestConfig(),
         );
     }
 }

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -68,7 +68,7 @@ class Text implements TextHandler
             config: $request->requestConfig,
         );
 
-        return new StreamResponse($this->parseSSE($raw));
+        return new StreamResponse($this->parseSSE($raw, $request->model));
     }
 
     public function structured(TextRequest $request): StructuredResponse
@@ -162,7 +162,7 @@ class Text implements TextHandler
      *
      * @return Generator<int, StreamChunk>
      */
-    protected function parseSSE(mixed $rawResponse): Generator
+    protected function parseSSE(mixed $rawResponse, string $model = ''): Generator
     {
         /** @var array<int, array{id: string, name: string, json: string}> $toolBlocks */
         $toolBlocks = [];
@@ -263,7 +263,7 @@ class Text implements TextHandler
             yield $this->parser->parseStreamChunk([
                 'event' => $event,
                 'data' => $data,
-            ]);
+            ], $model);
         }
     }
 

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -49,6 +49,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $this->buildBody($request),
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return $this->parser->parseText($data);
@@ -64,6 +65,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return new StreamResponse($this->parseSSE($raw));
@@ -92,6 +94,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $textResponse = $this->parser->parseText($data);

--- a/src/Providers/Anthropic/ResponseParser.php
+++ b/src/Providers/Anthropic/ResponseParser.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\Anthropic;
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Providers\Contracts\ResponseParserContract;
 use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\TextResponse;
@@ -115,6 +116,12 @@ class ResponseParser implements ResponseParserContract
     {
         $event = $data['event'] ?? '';
         $payload = $data['data'] ?? [];
+
+        if ($event === 'error') {
+            $error = $payload['error'] ?? $payload;
+
+            throw ProviderException::fromStreamError('anthropic', '', is_array($error) ? $error : ['message' => (string) $error]);
+        }
 
         if ($event === 'content_block_delta') {
             $delta = $payload['delta'] ?? [];

--- a/src/Providers/Anthropic/ResponseParser.php
+++ b/src/Providers/Anthropic/ResponseParser.php
@@ -112,7 +112,7 @@ class ResponseParser implements ResponseParserContract
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data): StreamChunk
+    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
     {
         $event = $data['event'] ?? '';
         $payload = $data['data'] ?? [];
@@ -120,7 +120,7 @@ class ResponseParser implements ResponseParserContract
         if ($event === 'error') {
             $error = $payload['error'] ?? $payload;
 
-            throw ProviderException::fromStreamError('anthropic', '', is_array($error) ? $error : ['message' => (string) $error]);
+            throw ProviderException::fromStreamError('anthropic', $model, is_array($error) ? $error : ['message' => (string) $error]);
         }
 
         if ($event === 'content_block_delta') {

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -48,6 +48,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $this->buildBody($request),
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return $this->parser->parseText($data);
@@ -64,6 +65,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return new StreamResponse($this->parseSSE($raw));
@@ -89,6 +91,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $textResponse = $this->parser->parseText($data);

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -68,7 +68,7 @@ class Text implements TextHandler
             config: $request->requestConfig,
         );
 
-        return new StreamResponse($this->parseSSE($raw));
+        return new StreamResponse($this->parseSSE($raw, $request->model));
     }
 
     public function structured(TextRequest $request): StructuredResponse
@@ -136,7 +136,7 @@ class Text implements TextHandler
      *
      * @return Generator<int, StreamChunk>
      */
-    protected function parseSSE(mixed $rawResponse): Generator
+    protected function parseSSE(mixed $rawResponse, string $model = ''): Generator
     {
         /** @var array<int, array{id: string, name: string, arguments: string}> $toolBlocks */
         $toolBlocks = [];
@@ -185,7 +185,7 @@ class Text implements TextHandler
                 $toolBlocks = [];
             }
 
-            yield $this->parser->parseStreamChunk($data);
+            yield $this->parser->parseStreamChunk($data, $model);
         }
     }
 

--- a/src/Providers/ChatCompletions/ResponseParser.php
+++ b/src/Providers/ChatCompletions/ResponseParser.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\ChatCompletions;
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Providers\Contracts\ResponseParserContract;
 use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\TextResponse;
@@ -92,6 +93,12 @@ class ResponseParser implements ResponseParserContract
      */
     public function parseStreamChunk(array $data): StreamChunk
     {
+        if (isset($data['error'])) {
+            $error = is_array($data['error']) ? $data['error'] : ['message' => (string) $data['error']];
+
+            throw ProviderException::fromStreamError('chat_completions', '', $error);
+        }
+
         /** @var array<string, mixed> $delta */
         $delta = $data['choices'][0]['delta'] ?? [];
         $finishReason = $data['choices'][0]['finish_reason'] ?? null;

--- a/src/Providers/ChatCompletions/ResponseParser.php
+++ b/src/Providers/ChatCompletions/ResponseParser.php
@@ -91,12 +91,12 @@ class ResponseParser implements ResponseParserContract
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data): StreamChunk
+    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
     {
         if (isset($data['error'])) {
             $error = is_array($data['error']) ? $data['error'] : ['message' => (string) $data['error']];
 
-            throw ProviderException::fromStreamError('chat_completions', '', $error);
+            throw ProviderException::fromStreamError('chat_completions', $model, $error);
         }
 
         /** @var array<string, mixed> $delta */

--- a/src/Providers/Contracts/ResponseParserContract.php
+++ b/src/Providers/Contracts/ResponseParserContract.php
@@ -32,5 +32,5 @@ interface ResponseParserContract
     /**
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data): StreamChunk;
+    public function parseStreamChunk(array $data, string $model = ''): StreamChunk;
 }

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -7,6 +7,7 @@ namespace Atlasphp\Atlas\Providers;
 use Atlasphp\Atlas\AtlasCache;
 use Atlasphp\Atlas\Exceptions\AuthenticationException;
 use Atlasphp\Atlas\Exceptions\AuthorizationException;
+use Atlasphp\Atlas\Exceptions\ConnectionException;
 use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
@@ -42,6 +43,7 @@ use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\VideoResponse;
 use Atlasphp\Atlas\Responses\VoiceSession;
 use Closure;
+use Illuminate\Http\Client\ConnectionException as HttpConnectionException;
 use Illuminate\Http\Client\RequestException;
 
 /**
@@ -208,6 +210,9 @@ abstract class Driver
         } catch (RequestException $e) {
             // handleRequestException() is declared never — always re-throws as a typed Atlas exception
             $this->handleRequestException($request->model, $e);
+        } catch (HttpConnectionException $e) {
+            // Network-level failure before any response (timeout, DNS, refused).
+            throw new ConnectionException($this->name(), $request->model, $e);
         }
     }
 

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -182,7 +182,7 @@ abstract class Driver
      */
     protected function dispatch(string $method, mixed $request, Closure $handler): mixed
     {
-        try {
+        return $this->translating($request->model, function () use ($method, $request, $handler) {
             if ($this->middlewareStack === null) {
                 return $handler($request);
             }
@@ -207,12 +207,26 @@ abstract class Driver
                 $middleware,
                 fn (ProviderContext $ctx) => $handler($ctx->request),
             );
+        });
+    }
+
+    /**
+     * Run a provider call, translating transport failures to typed Atlas
+     * exceptions. Shared by dispatch() and the interrogation endpoints so every
+     * provider call surfaces the same exception types.
+     *
+     * @param  Closure(): mixed  $fn
+     */
+    protected function translating(?string $model, Closure $fn): mixed
+    {
+        try {
+            return $fn();
         } catch (RequestException $e) {
             // handleRequestException() is declared never — always re-throws as a typed Atlas exception
-            $this->handleRequestException($request->model, $e);
+            $this->handleRequestException($model ?? '', $e);
         } catch (HttpConnectionException $e) {
             // Network-level failure before any response (timeout, DNS, refused).
-            throw new ConnectionException($this->name(), $request->model, $e);
+            throw new ConnectionException($this->name(), $model ?? '', $e);
         }
     }
 
@@ -262,12 +276,12 @@ abstract class Driver
 
     public function models(): ModelList
     {
-        return $this->resolveHandler('provider', fn () => $this->providerHandler('models'))->models();
+        return $this->translating('', fn () => $this->resolveHandler('provider', fn () => $this->providerHandler('models'))->models());
     }
 
     public function voices(): VoiceList
     {
-        return $this->resolveHandler('provider', fn () => $this->providerHandler('voices'))->voices();
+        return $this->translating('', fn () => $this->resolveHandler('provider', fn () => $this->providerHandler('voices'))->voices());
     }
 
     public function validate(): bool
@@ -302,7 +316,19 @@ abstract class Driver
             401 => throw new AuthenticationException($this->name(), $e),
             403 => throw new AuthorizationException($this->name(), $model, $e),
             429 => throw RateLimitException::from($this->name(), $model, $e),
-            default => throw ProviderException::from($this->name(), $model, $e),
+            default => throw ProviderException::from($this->name(), $model, $e, $this->extractErrorMessage($e)),
         };
+    }
+
+    /**
+     * Provider-specific hook to extract the error message from a failed response.
+     *
+     * Returns null by default, letting ProviderException::from() run its shared
+     * extraction chain (which covers every current provider). Override only for
+     * a provider whose error shape the chain doesn't handle.
+     */
+    protected function extractErrorMessage(RequestException $e): ?string
+    {
+        return null;
     }
 }

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -8,8 +8,11 @@ use Atlasphp\Atlas\AtlasCache;
 use Atlasphp\Atlas\Exceptions\AuthenticationException;
 use Atlasphp\Atlas\Exceptions\AuthorizationException;
 use Atlasphp\Atlas\Exceptions\ConnectionException;
+use Atlasphp\Atlas\Exceptions\InvalidRequestException;
+use Atlasphp\Atlas\Exceptions\ModelNotFoundException;
 use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
+use Atlasphp\Atlas\Exceptions\ServerException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Middleware\MiddlewareResolver;
@@ -312,12 +315,27 @@ abstract class Driver
      */
     public function handleRequestException(string $model, RequestException $e): never
     {
-        match ($e->response->status()) {
-            401 => throw new AuthenticationException($this->name(), $e),
+        $status = $e->response->status();
+
+        // Auth errors carry a fixed message; only resolve the provider's text
+        // for the message-bearing categories (match evaluates one arm).
+        match ($status) {
+            400 => throw new InvalidRequestException($this->name(), $model, $status, $this->errorMessage($e), $e),
+            401 => throw new AuthenticationException($this->name(), $model, $e),
             403 => throw new AuthorizationException($this->name(), $model, $e),
-            429 => throw RateLimitException::from($this->name(), $model, $e),
-            default => throw ProviderException::from($this->name(), $model, $e, $this->extractErrorMessage($e)),
+            404 => throw new ModelNotFoundException($this->name(), $model, $status, $this->errorMessage($e), $e),
+            429, 529 => throw RateLimitException::from($this->name(), $model, $e),
+            500, 502, 503, 504 => throw new ServerException($this->name(), $model, $status, $this->errorMessage($e), $e),
+            default => throw new ProviderException($this->name(), $model, $status, $this->errorMessage($e), $e),
         };
+    }
+
+    /**
+     * Resolve the provider error message, honoring a provider-specific override.
+     */
+    private function errorMessage(RequestException $e): string
+    {
+        return ProviderException::resolveMessage($e, $this->extractErrorMessage($e));
     }
 
     /**

--- a/src/Providers/ElevenLabs/Handlers/Audio.php
+++ b/src/Providers/ElevenLabs/Handlers/Audio.php
@@ -82,6 +82,7 @@ class Audio implements AudioHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         return new AudioResponse(
@@ -119,6 +120,7 @@ class Audio implements AudioHandler
                 ['name' => 'file', 'contents' => $fileContents, 'filename' => 'audio.mp3'],
             ],
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         return new TextResponse(

--- a/src/Providers/ElevenLabs/Handlers/Music.php
+++ b/src/Providers/ElevenLabs/Handlers/Music.php
@@ -72,6 +72,7 @@ class Music
             headers: $this->headers(),
             body: $body,
             timeout: max($this->config->mediaTimeout, 300),
+            config: $request->requestConfig,
         );
 
         return new AudioResponse(

--- a/src/Providers/ElevenLabs/Handlers/Sfx.php
+++ b/src/Providers/ElevenLabs/Handlers/Sfx.php
@@ -56,6 +56,7 @@ class Sfx
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         return new AudioResponse(

--- a/src/Providers/ElevenLabs/Handlers/Voice.php
+++ b/src/Providers/ElevenLabs/Handlers/Voice.php
@@ -51,7 +51,7 @@ class Voice implements VoiceHandler
             $dynamicAgent = true;
         }
 
-        $signedUrl = $this->getSignedUrl($agentId);
+        $signedUrl = $this->getSignedUrl($agentId, $request->model);
 
         return new VoiceSession(
             sessionId: 'rt_el_'.bin2hex(random_bytes(16)),
@@ -116,7 +116,7 @@ class Voice implements VoiceHandler
      *
      * GET /v1/convai/conversation/get-signed-url?agent_id={agent_id}
      */
-    protected function getSignedUrl(string $agentId): string
+    protected function getSignedUrl(string $agentId, string $model): string
     {
         $data = $this->http->get(
             url: "{$this->config->baseUrl}/convai/conversation/get-signed-url?".http_build_query(['agent_id' => $agentId]),
@@ -129,7 +129,7 @@ class Voice implements VoiceHandler
         if ($signedUrl === null) {
             throw new ProviderException(
                 provider: 'elevenlabs',
-                model: 'convai',
+                model: $model,
                 statusCode: 500,
                 providerMessage: 'ElevenLabs signed URL response missing signed_url.',
             );

--- a/src/Providers/ElevenLabs/Handlers/Voice.php
+++ b/src/Providers/ElevenLabs/Handlers/Voice.php
@@ -94,6 +94,7 @@ class Voice implements VoiceHandler
             headers: $this->headers(),
             body: $this->buildAgentConfig($request),
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $agentId = $data['agent_id'] ?? null;

--- a/src/Providers/Google/Handlers/Embed.php
+++ b/src/Providers/Google/Handlers/Embed.php
@@ -46,6 +46,7 @@ class Embed implements EmbedHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         // Gemini returns totalTokenCount with no input/output split — embeddings have no output tokens
@@ -81,6 +82,7 @@ class Embed implements EmbedHandler
             headers: $this->headers(),
             body: ['requests' => $requests],
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $embeddings = array_map(

--- a/src/Providers/Google/Handlers/Image.php
+++ b/src/Providers/Google/Handlers/Image.php
@@ -54,6 +54,7 @@ class Image implements ImageHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         $parts = $data['candidates'][0]['content']['parts'] ?? [];

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -65,7 +65,7 @@ class Text implements TextHandler
             config: $request->requestConfig,
         );
 
-        return new StreamResponse($this->parseSSE($raw));
+        return new StreamResponse($this->parseSSE($raw, $request->model));
     }
 
     public function structured(TextRequest $request): StructuredResponse
@@ -147,10 +147,10 @@ class Text implements TextHandler
      *
      * @return Generator<int, StreamChunk>
      */
-    protected function parseSSE(mixed $rawResponse): Generator
+    protected function parseSSE(mixed $rawResponse, string $model = ''): Generator
     {
         foreach (SseParser::parseDataOnly($rawResponse) as $data) {
-            $chunk = $this->parser->parseStreamChunk($data);
+            $chunk = $this->parser->parseStreamChunk($data, $model);
 
             // Split Done chunks that carry text into Text + Done
             if ($chunk->type === ChunkType::Done && $chunk->text !== null) {

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -49,6 +49,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $this->buildBody($request),
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return $this->parser->parseText($data);
@@ -61,6 +62,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $this->buildBody($request),
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return new StreamResponse($this->parseSSE($raw));
@@ -80,6 +82,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $text = $this->parser->parseText($data);

--- a/src/Providers/Google/ResponseParser.php
+++ b/src/Providers/Google/ResponseParser.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\Google;
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Providers\Contracts\ResponseParserContract;
 use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\TextResponse;
@@ -120,6 +121,12 @@ class ResponseParser implements ResponseParserContract
      */
     public function parseStreamChunk(array $data): StreamChunk
     {
+        if (isset($data['error'])) {
+            $error = is_array($data['error']) ? $data['error'] : ['message' => (string) $data['error']];
+
+            throw ProviderException::fromStreamError('google', '', $error);
+        }
+
         $candidate = $data['candidates'][0] ?? [];
         $parts = $candidate['content']['parts'] ?? [];
         $finishReason = $candidate['finishReason'] ?? null;

--- a/src/Providers/Google/ResponseParser.php
+++ b/src/Providers/Google/ResponseParser.php
@@ -119,12 +119,12 @@ class ResponseParser implements ResponseParserContract
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data): StreamChunk
+    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
     {
         if (isset($data['error'])) {
             $error = is_array($data['error']) ? $data['error'] : ['message' => (string) $data['error']];
 
-            throw ProviderException::fromStreamError('google', '', $error);
+            throw ProviderException::fromStreamError('google', $model, $error);
         }
 
         $candidate = $data['candidates'][0] ?? [];

--- a/src/Providers/Handlers/AbstractProviderHandler.php
+++ b/src/Providers/Handlers/AbstractProviderHandler.php
@@ -53,7 +53,7 @@ abstract class AbstractProviderHandler implements ProviderHandler
             $this->models();
 
             return true;
-        } catch (\Exception) {
+        } catch (\Throwable) {
             return false;
         }
     }

--- a/src/Providers/Handlers/AbstractRerankHandler.php
+++ b/src/Providers/Handlers/AbstractRerankHandler.php
@@ -47,6 +47,7 @@ abstract class AbstractRerankHandler implements RerankHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return $this->parseResponse($data, $request->documents);

--- a/src/Providers/OpenAi/Handlers/Audio.php
+++ b/src/Providers/OpenAi/Handlers/Audio.php
@@ -51,6 +51,7 @@ class Audio implements AudioHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         return new AudioResponse(
@@ -87,6 +88,7 @@ class Audio implements AudioHandler
                 ['name' => 'file', 'contents' => $fileContents, 'filename' => $filename],
             ],
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         return new TextResponse(

--- a/src/Providers/OpenAi/Handlers/Embed.php
+++ b/src/Providers/OpenAi/Handlers/Embed.php
@@ -41,6 +41,7 @@ class Embed implements EmbedHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         /** @var array<int, array<string, mixed>> $items */

--- a/src/Providers/OpenAi/Handlers/Image.php
+++ b/src/Providers/OpenAi/Handlers/Image.php
@@ -65,6 +65,7 @@ class Image implements ImageHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
     }
 
@@ -113,6 +114,7 @@ class Image implements ImageHandler
             data: $fields,
             attachments: $attachments,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
     }
 

--- a/src/Providers/OpenAi/Handlers/Moderate.php
+++ b/src/Providers/OpenAi/Handlers/Moderate.php
@@ -40,6 +40,7 @@ class Moderate implements ModerateHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         /** @var array<string, mixed> $result */

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -70,7 +70,7 @@ class Text implements TextHandler
             config: $request->requestConfig,
         );
 
-        return new StreamResponse($this->parseSSE($raw));
+        return new StreamResponse($this->parseSSE($raw, $request->model));
     }
 
     public function structured(TextRequest $request): StructuredResponse
@@ -156,10 +156,10 @@ class Text implements TextHandler
      *
      * @return Generator<int, StreamChunk>
      */
-    protected function parseSSE(mixed $rawResponse): Generator
+    protected function parseSSE(mixed $rawResponse, string $model = ''): Generator
     {
         foreach (SseParser::parse($rawResponse) as $event) {
-            yield $this->parser->parseStreamChunk($event);
+            yield $this->parser->parseStreamChunk($event, $model);
         }
     }
 }

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -51,6 +51,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $this->buildPayload($request),
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return $this->parser->parseText($data);
@@ -66,6 +67,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         return new StreamResponse($this->parseSSE($raw));
@@ -91,6 +93,7 @@ class Text implements TextHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $textResponse = $this->parser->parseText($data);

--- a/src/Providers/OpenAi/Handlers/Video.php
+++ b/src/Providers/OpenAi/Handlers/Video.php
@@ -68,6 +68,7 @@ class Video implements VideoHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         $videoId = (string) ($data['id'] ?? '');

--- a/src/Providers/OpenAi/Handlers/Video.php
+++ b/src/Providers/OpenAi/Handlers/Video.php
@@ -58,7 +58,7 @@ class Video implements VideoHandler
         $sourceImage = $request->media[0] ?? null;
 
         if ($sourceImage !== null) {
-            $body['input_reference'] = $this->resolveInputReference($sourceImage);
+            $body['input_reference'] = $this->resolveInputReference($sourceImage, $request->model);
         }
 
         $body = array_merge($body, $request->providerOptions);
@@ -189,7 +189,7 @@ class Video implements VideoHandler
      *
      * @return array<string, mixed>
      */
-    private function resolveInputReference(Input $input): array
+    private function resolveInputReference(Input $input, string $model): array
     {
         if ($input->isUrl()) {
             return ['image_url' => $input->url()];
@@ -205,7 +205,7 @@ class Video implements VideoHandler
             if ($raw === false) {
                 throw new ProviderException(
                     provider: 'openai',
-                    model: 'video',
+                    model: $model,
                     statusCode: 400,
                     providerMessage: "Cannot read image file: {$input->path()}",
                 );
@@ -220,7 +220,7 @@ class Video implements VideoHandler
             } catch (\RuntimeException $e) {
                 throw new ProviderException(
                     provider: 'openai',
-                    model: 'video',
+                    model: $model,
                     statusCode: 400,
                     providerMessage: 'Cannot read image from storage: '.$e->getMessage(),
                 );
@@ -229,7 +229,7 @@ class Video implements VideoHandler
 
         throw new ProviderException(
             provider: 'openai',
-            model: 'video',
+            model: $model,
             statusCode: 400,
             providerMessage: 'Cannot resolve image input — no supported source set.',
         );

--- a/src/Providers/OpenAi/Handlers/Voice.php
+++ b/src/Providers/OpenAi/Handlers/Voice.php
@@ -63,6 +63,7 @@ class Voice implements VoiceHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $sessionId = (string) ($data['id'] ?? 'rt_'.bin2hex(random_bytes(16)));

--- a/src/Providers/OpenAi/ResponseParser.php
+++ b/src/Providers/OpenAi/ResponseParser.php
@@ -145,7 +145,7 @@ class ResponseParser implements ResponseParserContract
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data): StreamChunk
+    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
     {
         $event = (string) ($data['event'] ?? '');
         /** @var array<string, mixed> $payload */
@@ -190,7 +190,7 @@ class ResponseParser implements ResponseParserContract
             $error = $payload['response']['error'] ?? $payload['error'] ?? $payload;
             $error = is_array($error) ? $error : ['message' => (string) $error];
 
-            throw ProviderException::fromStreamError('openai', '', $error);
+            throw ProviderException::fromStreamError('openai', $model, $error);
         }
 
         return new StreamChunk(type: ChunkType::Text, text: null);

--- a/src/Providers/OpenAi/ResponseParser.php
+++ b/src/Providers/OpenAi/ResponseParser.php
@@ -186,10 +186,11 @@ class ResponseParser implements ResponseParserContract
             );
         }
 
-        if ($event === 'response.failed') {
-            $error = (string) ($payload['response']['error']['message'] ?? 'Response generation failed');
+        if ($event === 'response.failed' || $event === 'error' || isset($payload['error'])) {
+            $error = $payload['response']['error'] ?? $payload['error'] ?? $payload;
+            $error = is_array($error) ? $error : ['message' => (string) $error];
 
-            throw new ProviderException('openai', '', 0, $error);
+            throw ProviderException::fromStreamError('openai', '', $error);
         }
 
         return new StreamChunk(type: ChunkType::Text, text: null);

--- a/src/Providers/ProviderConfig.php
+++ b/src/Providers/ProviderConfig.php
@@ -18,7 +18,6 @@ class ProviderConfig
         public readonly string $baseUrl,
         public readonly ?string $organization = null,
         public readonly int $timeout = 60,
-        public readonly int $reasoningTimeout = 300,
         public readonly int $mediaTimeout = 120,
         public readonly array $capabilityOverrides = [],
         public readonly array $extra = [],
@@ -31,7 +30,7 @@ class ProviderConfig
      */
     public static function fromArray(array $config): self
     {
-        $known = ['api_key', 'url', 'base_url', 'organization', 'timeout', 'reasoning_timeout', 'media_timeout', 'driver', 'capabilities'];
+        $known = ['api_key', 'url', 'base_url', 'organization', 'timeout', 'media_timeout', 'driver', 'capabilities'];
 
         return new self(
             apiKey: (string) ($config['api_key'] ?? ''),
@@ -40,7 +39,6 @@ class ProviderConfig
             // Falls back to the global default request timeout (atlas.retry.timeout)
             // when a provider doesn't set its own, so ATLAS_TIMEOUT applies everywhere.
             timeout: (int) ($config['timeout'] ?? config('atlas.retry.timeout', 60)),
-            reasoningTimeout: (int) ($config['reasoning_timeout'] ?? 300),
             mediaTimeout: (int) ($config['media_timeout'] ?? 120),
             capabilityOverrides: (array) ($config['capabilities'] ?? []),
             extra: array_diff_key($config, array_flip($known)),

--- a/src/Providers/ProviderConfig.php
+++ b/src/Providers/ProviderConfig.php
@@ -37,7 +37,9 @@ class ProviderConfig
             apiKey: (string) ($config['api_key'] ?? ''),
             baseUrl: (string) ($config['base_url'] ?? $config['url'] ?? ''),
             organization: isset($config['organization']) ? (string) $config['organization'] : null,
-            timeout: (int) ($config['timeout'] ?? 60),
+            // Falls back to the global default request timeout (atlas.retry.timeout)
+            // when a provider doesn't set its own, so ATLAS_TIMEOUT applies everywhere.
+            timeout: (int) ($config['timeout'] ?? config('atlas.retry.timeout', 60)),
             reasoningTimeout: (int) ($config['reasoning_timeout'] ?? 300),
             mediaTimeout: (int) ($config['media_timeout'] ?? 120),
             capabilityOverrides: (array) ($config['capabilities'] ?? []),

--- a/src/Providers/Xai/Handlers/Audio.php
+++ b/src/Providers/Xai/Handlers/Audio.php
@@ -45,6 +45,7 @@ class Audio implements AudioHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         return new AudioResponse(

--- a/src/Providers/Xai/Handlers/Image.php
+++ b/src/Providers/Xai/Handlers/Image.php
@@ -62,6 +62,7 @@ class Image implements ImageHandler
                 headers: $this->headers(),
                 body: array_merge($body, $request->providerOptions),
                 timeout: $this->config->mediaTimeout,
+                config: $request->requestConfig,
             ),
             $request,
         );
@@ -89,6 +90,7 @@ class Image implements ImageHandler
                 headers: $this->headers(),
                 body: array_merge($body, $request->providerOptions),
                 timeout: $this->config->mediaTimeout,
+                config: $request->requestConfig,
             ),
             $request,
         );

--- a/src/Providers/Xai/Handlers/Video.php
+++ b/src/Providers/Xai/Handlers/Video.php
@@ -59,6 +59,7 @@ class Video implements VideoHandler
             headers: $this->headers(),
             body: $body,
             timeout: $this->config->mediaTimeout,
+            config: $request->requestConfig,
         );
 
         $requestId = (string) ($data['request_id'] ?? $data['id'] ?? '');

--- a/src/Providers/Xai/Handlers/Video.php
+++ b/src/Providers/Xai/Handlers/Video.php
@@ -49,7 +49,7 @@ class Video implements VideoHandler
         $sourceImage = $request->media[0] ?? null;
 
         if ($sourceImage !== null) {
-            $body['image'] = $this->resolveImageSource($sourceImage);
+            $body['image'] = $this->resolveImageSource($sourceImage, $request->model);
         }
 
         $body = array_merge($body, $request->providerOptions);
@@ -137,7 +137,7 @@ class Video implements VideoHandler
      *
      * @return array{url: string}
      */
-    private function resolveImageSource(Input $input): array
+    private function resolveImageSource(Input $input, string $model): array
     {
         if ($input->isUrl()) {
             return ['url' => $input->url()];
@@ -153,7 +153,7 @@ class Video implements VideoHandler
             if ($raw === false) {
                 throw new ProviderException(
                     provider: 'xai',
-                    model: 'video',
+                    model: $model,
                     statusCode: 400,
                     providerMessage: "Cannot read image file: {$input->path()}",
                 );
@@ -168,7 +168,7 @@ class Video implements VideoHandler
             } catch (\RuntimeException $e) {
                 throw new ProviderException(
                     provider: 'xai',
-                    model: 'video',
+                    model: $model,
                     statusCode: 400,
                     providerMessage: 'Cannot read image from storage: '.$e->getMessage(),
                 );
@@ -177,7 +177,7 @@ class Video implements VideoHandler
 
         throw new ProviderException(
             provider: 'xai',
-            model: 'video',
+            model: $model,
             statusCode: 400,
             providerMessage: 'Cannot resolve image input — no supported source set.',
         );

--- a/src/Providers/Xai/Handlers/Voice.php
+++ b/src/Providers/Xai/Handlers/Voice.php
@@ -43,6 +43,7 @@ class Voice implements VoiceHandler
             headers: $this->headers(),
             body: $sessionConfig,
             timeout: $this->config->timeout,
+            config: $request->requestConfig,
         );
 
         $ephemeralToken = $data['value'] ?? $data['client_secret'] ?? null;

--- a/src/Queue/Jobs/ExecuteAtlasJob.php
+++ b/src/Queue/Jobs/ExecuteAtlasJob.php
@@ -6,7 +6,17 @@ namespace Atlasphp\Atlas\Queue\Jobs;
 
 use Atlasphp\Atlas\Events\ExecutionCompleted;
 use Atlasphp\Atlas\Events\ExecutionFailed;
+use Atlasphp\Atlas\Exceptions\AgentNotFoundException;
+use Atlasphp\Atlas\Exceptions\AuthenticationException;
+use Atlasphp\Atlas\Exceptions\AuthorizationException;
+use Atlasphp\Atlas\Exceptions\DelegationCycleException;
+use Atlasphp\Atlas\Exceptions\InvalidRequestException;
+use Atlasphp\Atlas\Exceptions\MaxDelegationDepthException;
 use Atlasphp\Atlas\Exceptions\MaxStepsExceededException;
+use Atlasphp\Atlas\Exceptions\ModelNotFoundException;
+use Atlasphp\Atlas\Exceptions\ProviderNotFoundException;
+use Atlasphp\Atlas\Exceptions\ToolNotFoundException;
+use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Queue\Contracts\QueueableRequest;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Illuminate\Broadcasting\Channel;
@@ -71,10 +81,32 @@ class ExecuteAtlasJob implements ShouldQueue
                 executionId: $this->executionId,
                 broadcastChannel: $this->broadcastChannel,
             );
-        } catch (MaxStepsExceededException $e) {
-            // Deterministic failure — retrying will produce the same loop.
-            // Fail immediately instead of burning retries and API credits.
+        } catch (
+            // Permanent failures — retrying produces the same result and wastes
+            // attempts (and API credits). Fail immediately. Transient errors
+            // (RateLimitException, ServerException, ConnectionException, and the
+            // base ProviderException) are deliberately NOT listed, so they keep
+            // their retries.
+            MaxStepsExceededException|
+            AuthenticationException|
+            AuthorizationException|
+            InvalidRequestException|
+            ModelNotFoundException|
+            UnsupportedFeatureException|
+            ProviderNotFoundException|
+            AgentNotFoundException|
+            ToolNotFoundException|
+            MaxDelegationDepthException|
+            DelegationCycleException $e
+        ) {
             $this->fail($e);
+
+            // InteractsWithQueue::fail() is a no-op when no queue job is bound
+            // (e.g. invoked outside a worker). Finalize directly so the execution
+            // is still recorded failed and the event fires.
+            if ($this->job === null) {
+                $this->failed($e);
+            }
 
             return;
         }

--- a/src/RequestConfig.php
+++ b/src/RequestConfig.php
@@ -17,6 +17,7 @@ class RequestConfig
         public readonly int $timeout,
         public readonly int $rateLimit,
         public readonly int $errors,
+        public readonly bool $timeoutExplicit = false,
     ) {}
 
     /**
@@ -32,11 +33,43 @@ class RequestConfig
     }
 
     /**
-     * Override the timeout for this call.
+     * Rehydrate from a queue payload.
+     *
+     * @param  array{timeout: int, rateLimit: int, errors: int, timeoutExplicit?: bool}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            timeout: (int) $data['timeout'],
+            rateLimit: (int) $data['rateLimit'],
+            errors: (int) $data['errors'],
+            timeoutExplicit: (bool) ($data['timeoutExplicit'] ?? false),
+        );
+    }
+
+    /**
+     * Serialize for a queue payload.
+     *
+     * @return array{timeout: int, rateLimit: int, errors: int, timeoutExplicit: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'timeout' => $this->timeout,
+            'rateLimit' => $this->rateLimit,
+            'errors' => $this->errors,
+            'timeoutExplicit' => $this->timeoutExplicit,
+        ];
+    }
+
+    /**
+     * Override the timeout for this call. Marks the timeout as explicit so the
+     * HTTP layer applies it in place of the handler's default (which may be a
+     * longer provider/reasoning/media timeout).
      */
     public function withTimeout(int $seconds): self
     {
-        return new self($seconds, $this->rateLimit, $this->errors);
+        return new self($seconds, $this->rateLimit, $this->errors, timeoutExplicit: true);
     }
 
     /**
@@ -48,6 +81,7 @@ class RequestConfig
             $this->timeout,
             $rateLimit ?? $this->rateLimit,
             $errors ?? $this->errors,
+            $this->timeoutExplicit,
         );
     }
 
@@ -56,7 +90,7 @@ class RequestConfig
      */
     public function withoutRetry(): self
     {
-        return new self($this->timeout, 0, 0);
+        return new self($this->timeout, 0, 0, $this->timeoutExplicit);
     }
 
     /**

--- a/src/Requests/AudioRequest.php
+++ b/src/Requests/AudioRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
+
 /**
  * Request object for audio generation and transcription.
  */
@@ -29,5 +31,6 @@ final class AudioRequest
         public readonly array $providerOptions = [],
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/src/Requests/EmbedRequest.php
+++ b/src/Requests/EmbedRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
+
 /**
  * Request object for generating embeddings.
  */
@@ -21,5 +23,6 @@ final class EmbedRequest
         public readonly array $providerOptions = [],
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/src/Requests/ImageRequest.php
+++ b/src/Requests/ImageRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
+
 /**
  * Request object for image generation.
  */
@@ -26,5 +28,6 @@ final class ImageRequest
         public readonly int $count = 1,
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/src/Requests/ModerateRequest.php
+++ b/src/Requests/ModerateRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
+
 /**
  * Request object for content moderation.
  */
@@ -21,5 +23,6 @@ final class ModerateRequest
         public readonly array $providerOptions = [],
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/src/Requests/RerankRequest.php
+++ b/src/Requests/RerankRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
+
 /**
  * Request object for reranking documents against a query.
  */
@@ -24,5 +26,6 @@ final class RerankRequest
         public readonly array $providerOptions = [],
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/src/Requests/TextRequest.php
+++ b/src/Requests/TextRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolChoice;
 
@@ -37,6 +38,7 @@ final class TextRequest
         public readonly array $middleware = [],
         public readonly array $meta = [],
         public readonly bool $cache = false,
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 
     /**
@@ -62,6 +64,7 @@ final class TextRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
+            requestConfig: $this->requestConfig,
         );
     }
 
@@ -88,6 +91,7 @@ final class TextRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
+            requestConfig: $this->requestConfig,
         );
     }
 
@@ -115,6 +119,7 @@ final class TextRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
+            requestConfig: $this->requestConfig,
         );
     }
 
@@ -141,6 +146,7 @@ final class TextRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
+            requestConfig: $this->requestConfig,
         );
     }
 
@@ -168,6 +174,7 @@ final class TextRequest
             middleware: $this->middleware,
             meta: $this->meta,
             cache: $this->cache,
+            requestConfig: $this->requestConfig,
         );
     }
 }

--- a/src/Requests/VideoRequest.php
+++ b/src/Requests/VideoRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Requests;
 
+use Atlasphp\Atlas\RequestConfig;
+
 /**
  * Request object for video generation.
  */
@@ -25,5 +27,6 @@ final class VideoRequest
         public readonly array $providerOptions = [],
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/src/Requests/VoiceRequest.php
+++ b/src/Requests/VoiceRequest.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Requests;
 
 use Atlasphp\Atlas\Enums\TurnDetectionMode;
 use Atlasphp\Atlas\Enums\VoiceTransport;
+use Atlasphp\Atlas\RequestConfig;
 
 /**
  * Immutable request object for voice-to-voice sessions.
@@ -35,5 +36,6 @@ final class VoiceRequest
         public readonly array $providerOptions = [],
         public readonly array $middleware = [],
         public readonly array $meta = [],
+        public readonly ?RequestConfig $requestConfig = null,
     ) {}
 }

--- a/tests/Unit/Exceptions/ExceptionTest.php
+++ b/tests/Unit/Exceptions/ExceptionTest.php
@@ -11,6 +11,7 @@ use Atlasphp\Atlas\Exceptions\RateLimitException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
 
 it('AtlasException extends RuntimeException', function () {
     $e = new AtlasException('test');
@@ -83,7 +84,7 @@ it('ProviderException stores all properties', function () {
 it('ProviderException::from extracts status and error message', function () {
     $response = Mockery::mock(Response::class);
     $response->shouldReceive('status')->andReturn(500);
-    $response->shouldReceive('json')->with('error.message', Mockery::any())->andReturn('Model overloaded');
+    $response->shouldReceive('json')->andReturn(['error' => ['message' => 'Model overloaded']]);
 
     $requestException = Mockery::mock(RequestException::class);
     $requestException->response = $response;
@@ -94,6 +95,36 @@ it('ProviderException::from extracts status and error message', function () {
     expect($e->statusCode)->toBe(500);
     expect($e->providerMessage)->toBe('Model overloaded');
     expect($e->getPrevious())->toBe($requestException);
+});
+
+it('ProviderException::from extracts the real message across provider error shapes', function (array $body, string $expected) {
+    $response = Mockery::mock(Response::class);
+    $response->shouldReceive('status')->andReturn(400);
+    $response->shouldReceive('json')->andReturn($body);
+
+    $requestException = Mockery::mock(RequestException::class);
+    $requestException->response = $response;
+
+    expect(ProviderException::from('p', 'm', $requestException)->providerMessage)->toBe($expected);
+})->with([
+    'openai/anthropic/google error.message' => [['error' => ['message' => 'bad request']], 'bad request'],
+    'elevenlabs detail.message' => [['detail' => ['message' => 'quota exceeded']], 'quota exceeded'],
+    'elevenlabs/jina string detail' => [['detail' => 'invalid voice'], 'invalid voice'],
+    'cohere top-level message' => [['message' => 'invalid api key'], 'invalid api key'],
+    'ollama string error' => [['error' => 'model not found'], 'model not found'],
+]);
+
+it('ProviderException::from falls back to the request-exception message when the body has no recognizable error', function () {
+    Http::fake(['*' => Http::response(['weird' => 'shape'], 500)]);
+
+    try {
+        Http::get('https://x.test/fail')->throw();
+    } catch (RequestException $e) {
+        $ex = ProviderException::from('p', 'm', $e);
+
+        expect($ex->statusCode)->toBe(500);
+        expect($ex->providerMessage)->toBe($e->getMessage());
+    }
 });
 
 it('ProviderException::fromStreamError extracts the message from common shapes', function () {

--- a/tests/Unit/Exceptions/ExceptionTest.php
+++ b/tests/Unit/Exceptions/ExceptionTest.php
@@ -96,6 +96,31 @@ it('ProviderException::from extracts status and error message', function () {
     expect($e->getPrevious())->toBe($requestException);
 });
 
+it('ProviderException::fromStreamError extracts the message from common shapes', function () {
+    expect(ProviderException::fromStreamError('anthropic', '', ['message' => 'Overloaded'])->providerMessage)
+        ->toBe('Overloaded');
+
+    expect(ProviderException::fromStreamError('openai', '', ['error' => ['message' => 'bad request']])->providerMessage)
+        ->toBe('bad request');
+
+    expect(ProviderException::fromStreamError('ollama', '', ['error' => 'boom'])->providerMessage)
+        ->toBe('boom');
+});
+
+it('ProviderException::fromStreamError pulls a numeric code into statusCode', function () {
+    $e = ProviderException::fromStreamError('google', 'gemini', ['code' => 429, 'message' => 'Resource exhausted']);
+
+    expect($e->statusCode)->toBe(429);
+    expect($e->model)->toBe('gemini');
+});
+
+it('ProviderException::fromStreamError falls back to a default message when none is present', function () {
+    $e = ProviderException::fromStreamError('openai', '', ['unexpected' => true]);
+
+    expect($e->providerMessage)->toBe('Provider returned an error during streaming.');
+    expect($e->statusCode)->toBe(0);
+});
+
 it('UnsupportedFeatureException::make includes feature and provider', function () {
     $e = UnsupportedFeatureException::make('streaming', 'google');
 

--- a/tests/Unit/Exceptions/ExceptionTest.php
+++ b/tests/Unit/Exceptions/ExceptionTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Exceptions\AtlasException;
 use Atlasphp\Atlas\Exceptions\AuthenticationException;
 use Atlasphp\Atlas\Exceptions\AuthorizationException;
+use Atlasphp\Atlas\Exceptions\ConnectionException;
+use Atlasphp\Atlas\Exceptions\InvalidRequestException;
+use Atlasphp\Atlas\Exceptions\ModelNotFoundException;
 use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\ProviderNotFoundException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
+use Atlasphp\Atlas\Exceptions\ServerException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
@@ -47,6 +51,7 @@ it('RateLimitException stores provider, model, and retryAfter', function () {
 it('RateLimitException::from extracts Retry-After header', function () {
     $response = Mockery::mock(Response::class);
     $response->shouldReceive('header')->with('Retry-After')->andReturn('60');
+    $response->shouldReceive('status')->andReturn(429);
 
     $requestException = Mockery::mock(RequestException::class);
     $requestException->response = $response;
@@ -57,12 +62,25 @@ it('RateLimitException::from extracts Retry-After header', function () {
     expect($e->provider)->toBe('openai');
     expect($e->model)->toBe('gpt-4o');
     expect($e->retryAfter)->toBe(60);
+    expect($e->statusCode)->toBe(429);
     expect($e->getPrevious())->toBe($requestException);
+});
+
+it('RateLimitException::from preserves a 529 overloaded status', function () {
+    $response = Mockery::mock(Response::class);
+    $response->shouldReceive('header')->with('Retry-After')->andReturn(null);
+    $response->shouldReceive('status')->andReturn(529);
+
+    $requestException = Mockery::mock(RequestException::class);
+    $requestException->response = $response;
+
+    expect(RateLimitException::from('anthropic', 'claude', $requestException)->statusCode)->toBe(529);
 });
 
 it('RateLimitException::from returns null retryAfter when header is missing', function () {
     $response = Mockery::mock(Response::class);
     $response->shouldReceive('header')->with('Retry-After')->andReturn(null);
+    $response->shouldReceive('status')->andReturn(429);
 
     $requestException = Mockery::mock(RequestException::class);
     $requestException->response = $response;
@@ -149,7 +167,8 @@ it('ProviderException::fromStreamError falls back to a default message when none
     $e = ProviderException::fromStreamError('openai', '', ['unexpected' => true]);
 
     expect($e->providerMessage)->toBe('Provider returned an error during streaming.');
-    expect($e->statusCode)->toBe(0);
+    expect($e->statusCode)->toBeNull();
+    expect($e->getMessage())->not->toContain('[0]');
 });
 
 it('UnsupportedFeatureException::make includes feature and provider', function () {
@@ -165,4 +184,55 @@ it('ProviderNotFoundException includes key in message', function () {
 
     expect($e->getMessage())->toContain('unknown');
     expect($e)->toBeInstanceOf(AtlasException::class);
+});
+
+// ─── Hierarchy: the provider-error family extends ProviderException ──────────
+
+it('the provider-error family extends ProviderException with the right status', function (ProviderException $e, ?int $status) {
+    expect($e)->toBeInstanceOf(ProviderException::class);
+    expect($e)->toBeInstanceOf(AtlasException::class);
+    expect($e->statusCode)->toBe($status);
+})->with([
+    'authentication' => [new AuthenticationException('openai'), 401],
+    'authorization' => [new AuthorizationException('openai', 'gpt-4o'), 403],
+    'rate limit' => [new RateLimitException('openai', 'gpt-4o'), 429],
+    'invalid request' => [new InvalidRequestException('openai', 'gpt-4o', 400, 'bad'), 400],
+    'model not found' => [new ModelNotFoundException('openai', 'gpt-4o', 404, 'nope'), 404],
+    'server' => [new ServerException('openai', 'gpt-4o', 503, 'down'), 503],
+    'connection' => [new ConnectionException('openai', 'gpt-4o'), null],
+]);
+
+it('AuthenticationException threads the model when provided', function () {
+    $e = new AuthenticationException('openai', 'gpt-4o');
+
+    expect($e->model)->toBe('gpt-4o');
+    expect($e->statusCode)->toBe(401);
+});
+
+it('AuthenticationException preserves its own message and is catchable as ProviderException', function () {
+    $caught = null;
+
+    try {
+        throw new AuthenticationException('openai');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf(AuthenticationException::class);
+    expect($caught->getMessage())->toBe('Authentication failed for provider [openai].');
+    expect($caught->provider)->toBe('openai');
+});
+
+it('ConnectionException is a ProviderException with a null status and no status bracket', function () {
+    $e = new ConnectionException('openai', 'gpt-4o', new RuntimeException('cURL error 28: timed out'));
+
+    expect($e)->toBeInstanceOf(ProviderException::class);
+    expect($e->statusCode)->toBeNull();
+    expect($e->getMessage())->toBe('Connection to provider [openai] failed: cURL error 28: timed out');
+});
+
+it('ProviderException omits the status bracket when statusCode is null', function () {
+    $e = new ProviderException('openai', 'gpt-4o', null, 'something went wrong');
+
+    expect($e->getMessage())->toBe('Provider [openai] error: something went wrong');
 });

--- a/tests/Unit/Http/HttpClientTest.php
+++ b/tests/Unit/Http/HttpClientTest.php
@@ -100,6 +100,61 @@ it('retries a connection failure then rethrows when attempts are exhausted', fun
     expect($retries)->toBe(1);
 });
 
+it('retries postRaw on a transient 5xx and returns the body', function () {
+    Http::fakeSequence()
+        ->push('err', 503)
+        ->push('binary-bytes', 200);
+
+    $retries = 0;
+    Event::listen(ProviderRequestRetrying::class, function () use (&$retries): void {
+        $retries++;
+    });
+
+    $body = httpClient()->postRaw('https://api.test/x', [], [], 30, new RequestConfig(30, 0, 2));
+
+    expect($retries)->toBe(1);
+    expect($body)->toBe('binary-bytes');
+});
+
+it('retries postMultipart on a transient 5xx', function () {
+    Http::fakeSequence()
+        ->push('err', 503)
+        ->push(['ok' => true], 200);
+
+    $retries = 0;
+    Event::listen(ProviderRequestRetrying::class, function () use (&$retries): void {
+        $retries++;
+    });
+
+    $data = httpClient()->postMultipart(
+        'https://api.test/x',
+        [],
+        ['field' => 'v'],
+        [['name' => 'file', 'contents' => 'data', 'filename' => 'f.bin']],
+        30,
+        new RequestConfig(30, 0, 2),
+    );
+
+    expect($retries)->toBe(1);
+    expect($data)->toBe(['ok' => true]);
+});
+
+it('retries the initial stream connection on a transient 5xx', function () {
+    Http::fakeSequence()
+        ->push('err', 503)
+        ->push('data: [DONE]', 200);
+
+    $retries = 0;
+    Event::listen(ProviderRequestRetrying::class, function () use (&$retries): void {
+        $retries++;
+    });
+
+    $response = httpClient()->stream('https://api.test/x', [], [], 30, new RequestConfig(30, 0, 2));
+
+    expect($retries)->toBe(1);
+    expect($response->status())->toBe(200);
+});
+
 it('applies an explicit timeout override but keeps the handler default otherwise', function () {
     $client = httpClient();
     $method = new ReflectionMethod($client, 'effectiveTimeout');

--- a/tests/Unit/Http/HttpClientTest.php
+++ b/tests/Unit/Http/HttpClientTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Events\ProviderRequestCompleted;
+use Atlasphp\Atlas\Events\ProviderRequestRetrying;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Http\RetryDecider;
+use Atlasphp\Atlas\RequestConfig;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+
+function httpClient(): HttpClient
+{
+    return new HttpClient(app('events'), new RetryDecider);
+}
+
+it('returns decoded json and fires a completed event on success', function () {
+    Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+    $completed = 0;
+    Event::listen(ProviderRequestCompleted::class, function () use (&$completed): void {
+        $completed++;
+    });
+
+    $data = httpClient()->post('https://api.test/x', [], ['a' => 1], 30);
+
+    expect($data)->toBe(['ok' => true]);
+    expect($completed)->toBe(1);
+});
+
+it('throws a RequestException on a failed response', function () {
+    Http::fake(['*' => Http::response('nope', 500)]);
+
+    httpClient()->post('https://api.test/x', [], [], 30);
+})->throws(RequestException::class);
+
+it('retries a transient 5xx when the request config enables error retry', function () {
+    Http::fakeSequence()
+        ->push('err', 503)
+        ->push(['ok' => true], 200);
+
+    $retries = 0;
+    Event::listen(ProviderRequestRetrying::class, function () use (&$retries): void {
+        $retries++;
+    });
+
+    $data = httpClient()->post('https://api.test/x', [], [], 30, new RequestConfig(30, 0, 2));
+
+    expect($retries)->toBe(1);
+    expect($data)->toBe(['ok' => true]);
+});
+
+it('does not retry when no request config is passed', function () {
+    Http::fakeSequence()
+        ->push('err', 503)
+        ->push(['ok' => true], 200);
+
+    httpClient()->post('https://api.test/x', [], [], 30);
+})->throws(RequestException::class);
+
+it('does not retry a permanent 4xx even with retry enabled', function () {
+    $attempts = 0;
+    Http::fake(function () use (&$attempts) {
+        $attempts++;
+
+        return Http::response('bad', 400);
+    });
+
+    try {
+        httpClient()->post('https://api.test/x', [], [], 30, new RequestConfig(30, 3, 3));
+    } catch (RequestException) {
+        // expected
+    }
+
+    expect($attempts)->toBe(1);
+});
+
+it('retries a connection failure then rethrows when attempts are exhausted', function () {
+    Http::fake(function (): void {
+        throw new ConnectionException('cURL error 28: timed out');
+    });
+
+    $retries = 0;
+    Event::listen(ProviderRequestRetrying::class, function () use (&$retries): void {
+        $retries++;
+    });
+
+    $caught = null;
+
+    try {
+        httpClient()->post('https://api.test/x', [], [], 30, new RequestConfig(30, 0, 1));
+    } catch (ConnectionException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf(ConnectionException::class);
+    expect($retries)->toBe(1);
+});
+
+it('applies an explicit timeout override but keeps the handler default otherwise', function () {
+    $client = httpClient();
+    $method = new ReflectionMethod($client, 'effectiveTimeout');
+    $method->setAccessible(true);
+
+    // No config → handler default stands.
+    expect($method->invoke($client, 120, null))->toBe(120);
+
+    // Config present but timeout not explicitly set → handler default stands
+    // (so a 60s default never clobbers a 120s reasoning/media timeout).
+    expect($method->invoke($client, 120, new RequestConfig(30, 3, 2)))->toBe(120);
+
+    // Explicit ->withTimeout() → override wins.
+    expect($method->invoke($client, 120, (new RequestConfig(30, 3, 2))->withTimeout(15)))->toBe(15);
+});

--- a/tests/Unit/Http/RetryDeciderTest.php
+++ b/tests/Unit/Http/RetryDeciderTest.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
 use Atlasphp\Atlas\Http\RetryDecider;
 use Atlasphp\Atlas\RequestConfig;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 
@@ -60,6 +61,24 @@ it('retries connection failures (status 0)', function () {
     $e = new ProviderException('openai', 'gpt-4o', 0, 'Connection timed out');
 
     expect(decider()->shouldRetry($e, configWithRetry(errors: 2), attempt: 1))->toBeTrue();
+});
+
+it('retries Laravel ConnectionException within the error limit', function () {
+    $e = new ConnectionException('cURL error 28: Connection timed out');
+
+    expect(decider()->shouldRetry($e, configWithRetry(errors: 2), attempt: 1))->toBeTrue();
+});
+
+it('stops retrying Laravel ConnectionException when attempts exhausted', function () {
+    $e = new ConnectionException('cURL error 28: Connection timed out');
+
+    expect(decider()->shouldRetry($e, configWithRetry(errors: 2), attempt: 3))->toBeFalse();
+});
+
+it('does not retry Laravel ConnectionException when errors is zero', function () {
+    $e = new ConnectionException('cURL error 28: Connection timed out');
+
+    expect(decider()->shouldRetry($e, configWithRetry(errors: 0), attempt: 1))->toBeFalse();
 });
 
 it('stops retrying transient errors when attempts exhausted', function () {

--- a/tests/Unit/Http/RetryDeciderTest.php
+++ b/tests/Unit/Http/RetryDeciderTest.php
@@ -63,6 +63,12 @@ it('retries connection failures (status 0)', function () {
     expect(decider()->shouldRetry($e, configWithRetry(errors: 2), attempt: 1))->toBeTrue();
 });
 
+it('does not crash or retry a ProviderException with a null status', function () {
+    $e = new ProviderException('openai', 'gpt-4o', null, 'no status');
+
+    expect(decider()->shouldRetry($e, configWithRetry(errors: 2), attempt: 1))->toBeFalse();
+});
+
 it('retries Laravel ConnectionException within the error limit', function () {
     $e = new ConnectionException('cURL error 28: Connection timed out');
 
@@ -166,6 +172,12 @@ function fakeRequestException(int $status, array $headers = []): RequestExceptio
 
     return new RequestException($response);
 }
+
+it('retries RequestException with 529 overloaded status', function () {
+    $e = fakeRequestException(529);
+
+    expect(decider()->shouldRetry($e, configWithRetry(rateLimit: 3), attempt: 1))->toBeTrue();
+});
 
 it('retries RequestException with 429 status', function () {
     $e = fakeRequestException(429);

--- a/tests/Unit/Pending/Concerns/HasRequestConfigTest.php
+++ b/tests/Unit/Pending/Concerns/HasRequestConfigTest.php
@@ -68,6 +68,34 @@ it('withoutRetry disables all retry', function () {
     expect($config->retryEnabled())->toBeFalse();
 });
 
+it('requestConfigPayload is null when no override was set', function () {
+    expect(createRequestConfigHelper()->requestConfigPayload())->toBeNull();
+});
+
+it('serializes and restores an override across a queue payload round-trip', function () {
+    $source = createRequestConfigHelper();
+    $source->withRetry(rateLimit: 8, errors: 5)->withTimeout(99);
+
+    $payload = $source->requestConfigPayload();
+    expect($payload)->not->toBeNull();
+
+    $restored = createRequestConfigHelper();
+    $restored->applyRequestConfigPayload($payload);
+
+    $config = $restored->getRequestConfig();
+    expect($config->rateLimit)->toBe(8);
+    expect($config->errors)->toBe(5);
+    expect($config->timeout)->toBe(99);
+    expect($config->timeoutExplicit)->toBeTrue();
+});
+
+it('applyRequestConfigPayload with null leaves config untouched (falls back to defaults)', function () {
+    $helper = createRequestConfigHelper();
+    $helper->applyRequestConfigPayload(null);
+
+    expect($helper->getRequestConfig())->toBeNull();
+});
+
 it('resolveRequestConfig defaults from AtlasConfig', function () {
     config([
         'atlas.retry.timeout' => 45,

--- a/tests/Unit/Pending/TextRequestTest.php
+++ b/tests/Unit/Pending/TextRequestTest.php
@@ -55,6 +55,24 @@ it('returns $this from all fluent methods', function () {
     expect($pending->withProviderOptions([]))->toBe($pending);
 });
 
+it('threads withRetry config through to the built request', function () {
+    $request = createTextPending()->withRetry(rateLimit: 7, errors: 4)->buildRequest();
+
+    expect($request->requestConfig)->not->toBeNull();
+    expect($request->requestConfig->rateLimit)->toBe(7);
+    expect($request->requestConfig->errors)->toBe(4);
+});
+
+it('preserves requestConfig across with* copy methods', function () {
+    $request = createTextPending()->withRetry(errors: 9)->buildRequest();
+
+    expect($request->withClearedMessage()->requestConfig?->errors)->toBe(9);
+    expect($request->withReplacedMessages([])->requestConfig?->errors)->toBe(9);
+    expect($request->withToolChoice(null)->requestConfig?->errors)->toBe(9);
+    expect($request->withAppendedMessages([])->requestConfig?->errors)->toBe(9);
+    expect($request->withReplacedTools([])->requestConfig?->errors)->toBe(9);
+});
+
 it('builds request with correct defaults', function () {
     $request = createTextPending()->buildRequest();
 

--- a/tests/Unit/Persistence/Middleware/TrackExecutionTest.php
+++ b/tests/Unit/Persistence/Middleware/TrackExecutionTest.php
@@ -64,6 +64,29 @@ it('creates execution and completes on success', function () {
     expect($execution->completed_at)->not->toBeNull();
 });
 
+it('a retry after a failed attempt ends Completed, not stuck Failed', function () {
+    $middleware = app(TrackExecution::class);
+
+    // Attempt 1: fails → execution is marked Failed.
+    $first = new AgentContext(request: makeExecutionTextRequest(), meta: []);
+
+    try {
+        $middleware->handle($first, fn () => throw new RuntimeException('transient blip'));
+    } catch (RuntimeException) {
+        // expected
+    }
+
+    $executionId = $first->meta['execution_id'];
+    expect(Execution::find($executionId)->status)->toBe(ExecutionStatus::Failed);
+
+    // Attempt 2 (retry): the queue re-runs with the same execution_id; it succeeds.
+    $second = new AgentContext(request: makeExecutionTextRequest(), meta: ['execution_id' => $executionId]);
+    $middleware->handle($second, fn () => makeExecutionFakeResult());
+
+    // The row must end Completed — a successful retry heals the earlier Failed.
+    expect(Execution::find($executionId)->status)->toBe(ExecutionStatus::Completed);
+});
+
 it('sets execution_id in context meta', function () {
     $middleware = app(TrackExecution::class);
 

--- a/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ChunkType;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Anthropic\Handlers\Text;
 use Atlasphp\Atlas\Providers\Anthropic\MediaResolver;
@@ -53,6 +54,29 @@ function makeAnthropicTextRequest(array $overrides = []): TextRequest
         requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
+
+it('a mid-stream error while streaming throws a ProviderException carrying the model', function () {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(
+            "event: error\ndata: {\"type\":\"error\",\"error\":{\"message\":\"Overloaded\"}}\n\n",
+            200,
+        ),
+    ]);
+
+    $caught = null;
+
+    try {
+        foreach (makeAnthropicTextHandler()->stream(makeAnthropicTextRequest(['model' => 'claude-sonnet-4-5'])) as $chunk) {
+            // consume the stream
+        }
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('claude-sonnet-4-5');
+    expect($caught->providerMessage)->toBe('Overloaded');
+});
 
 it('forwards the request config to the HTTP layer (post and stream)', function () {
     $config = (new RequestConfig(30, 5, 2))->withoutRetry();

--- a/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
@@ -11,21 +11,23 @@ use Atlasphp\Atlas\Providers\Anthropic\ResponseParser;
 use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
-function makeAnthropicTextHandler(): Text
+function makeAnthropicTextHandler(?HttpClient $http = null): Text
 {
     $toolMapper = new ToolMapper;
 
     return new Text(
         config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.anthropic.com/v1']),
-        http: app(HttpClient::class),
+        http: $http ?? app(HttpClient::class),
         messages: new MessageFactory,
         media: new MediaResolver,
         tools: $toolMapper,
@@ -48,8 +50,25 @@ function makeAnthropicTextRequest(array $overrides = []): TextRequest
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
         toolChoice: $overrides['toolChoice'] ?? null,
+        requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
+
+it('forwards the request config to the HTTP layer (post and stream)', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(['content' => [['type' => 'text', 'text' => 'ok']], 'usage' => ['input_tokens' => 1, 'output_tokens' => 1], 'stop_reason' => 'end_turn']);
+    $http->shouldReceive('stream')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(Mockery::mock(Response::class));
+
+    $handler = makeAnthropicTextHandler($http);
+    $handler->text(makeAnthropicTextRequest(['requestConfig' => $config]));
+    $handler->stream(makeAnthropicTextRequest(['requestConfig' => $config]));
+});
 
 it('emits the Anthropic tool_choice object when a choice is set with tools', function () {
     Http::fake(['api.anthropic.com/*' => Http::response(fakeAnthropicTextResponse())]);

--- a/tests/Unit/Providers/Anthropic/ResponseParserTest.php
+++ b/tests/Unit/Providers/Anthropic/ResponseParserTest.php
@@ -26,6 +26,21 @@ it('throws ProviderException on a mid-stream error event', function () {
     ]);
 })->throws(ProviderException::class, 'Overloaded');
 
+it('a mid-stream error carries the model passed to the parser', function () {
+    $caught = null;
+
+    try {
+        makeAnthropicResponseParser()->parseStreamChunk([
+            'event' => 'error',
+            'data' => ['error' => ['message' => 'Overloaded']],
+        ], 'claude-sonnet-4-5');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught?->model)->toBe('claude-sonnet-4-5');
+});
+
 it('parses text from content blocks', function () {
     $parser = makeAnthropicResponseParser();
 

--- a/tests/Unit/Providers/Anthropic/ResponseParserTest.php
+++ b/tests/Unit/Providers/Anthropic/ResponseParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Providers\Anthropic\ResponseParser;
 use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
 use Atlasphp\Atlas\Responses\StreamChunk;
@@ -14,6 +15,16 @@ function makeAnthropicResponseParser(): ResponseParser
 {
     return new ResponseParser(new ToolMapper);
 }
+
+it('throws ProviderException on a mid-stream error event', function () {
+    makeAnthropicResponseParser()->parseStreamChunk([
+        'event' => 'error',
+        'data' => [
+            'type' => 'error',
+            'error' => ['type' => 'overloaded_error', 'message' => 'Overloaded'],
+        ],
+    ]);
+})->throws(ProviderException::class, 'Overloaded');
 
 it('parses text from content blocks', function () {
     $parser = makeAnthropicResponseParser();

--- a/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
@@ -8,24 +8,48 @@ use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\ChatCompletions\ChatCompletionsDriver;
 use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\RerankRequest;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
-function makeChatCompletionsDriver(): ChatCompletionsDriver
+function makeChatCompletionsDriver(?HttpClient $http = null): ChatCompletionsDriver
 {
     return new ChatCompletionsDriver(
         config: new ProviderConfig(
             apiKey: 'test-key',
             baseUrl: 'http://localhost:11434/v1',
         ),
-        http: app(HttpClient::class),
+        http: $http ?? app(HttpClient::class),
         cache: app(AtlasCache::class),
     );
 }
+
+it('forwards the request config to the HTTP layer (post and stream)', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(['choices' => [['message' => ['content' => 'ok'], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1]]);
+    $http->shouldReceive('stream')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(Mockery::mock(Response::class));
+
+    $driver = makeChatCompletionsDriver($http);
+    $request = new TextRequest(
+        model: 'llama3.1', instructions: null, message: 'Hi', messageMedia: [], messages: [],
+        maxTokens: null, temperature: null, schema: null, tools: [], providerTools: [],
+        providerOptions: [], requestConfig: $config,
+    );
+
+    $driver->text($request);
+    $driver->stream($request);
+});
 
 // ─── Provider Handler ───────────────────────────────────────────────────────
 

--- a/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\AtlasCache;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\ChatCompletions\ChatCompletionsDriver;
@@ -28,6 +29,34 @@ function makeChatCompletionsDriver(?HttpClient $http = null): ChatCompletionsDri
         cache: app(AtlasCache::class),
     );
 }
+
+it('a mid-stream error while streaming throws a ProviderException carrying the model', function () {
+    Http::fake([
+        'localhost:11434/v1/chat/completions' => Http::response(
+            "data: {\"error\":{\"message\":\"model not found\"}}\n\n",
+            200,
+        ),
+    ]);
+
+    $request = new TextRequest(
+        model: 'llama3.2', instructions: null, message: 'Hi', messageMedia: [], messages: [],
+        maxTokens: null, temperature: null, schema: null, tools: [], providerTools: [], providerOptions: [],
+    );
+
+    $caught = null;
+
+    try {
+        foreach (makeChatCompletionsDriver()->stream($request) as $chunk) {
+            // consume the stream
+        }
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('llama3.2');
+    expect($caught->providerMessage)->toBe('model not found');
+});
 
 it('forwards the request config to the HTTP layer (post and stream)', function () {
     $config = (new RequestConfig(30, 5, 2))->withoutRetry();

--- a/tests/Unit/Providers/ChatCompletions/ResponseParserTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ResponseParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Providers\ChatCompletions\ResponseParser;
 use Atlasphp\Atlas\Providers\ChatCompletions\ToolMapper;
 
@@ -11,6 +12,18 @@ function makeCcParser(): ResponseParser
 {
     return new ResponseParser(new ToolMapper);
 }
+
+it('throws ProviderException on a mid-stream object error payload', function () {
+    makeCcParser()->parseStreamChunk([
+        'error' => ['message' => 'model not found'],
+    ]);
+})->throws(ProviderException::class, 'model not found');
+
+it('throws ProviderException on a mid-stream string error payload', function () {
+    makeCcParser()->parseStreamChunk([
+        'error' => 'unexpected server error',
+    ]);
+})->throws(ProviderException::class, 'unexpected server error');
 
 it('parses text from choices message', function () {
     $parser = makeCcParser();

--- a/tests/Unit/Providers/ChatCompletions/ResponseParserTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ResponseParserTest.php
@@ -25,6 +25,20 @@ it('throws ProviderException on a mid-stream string error payload', function () 
     ]);
 })->throws(ProviderException::class, 'unexpected server error');
 
+it('a mid-stream error carries the model passed to the parser', function () {
+    $caught = null;
+
+    try {
+        makeCcParser()->parseStreamChunk([
+            'error' => ['message' => 'model not found'],
+        ], 'llama3.2');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught?->model)->toBe('llama3.2');
+});
+
 it('parses text from choices message', function () {
     $parser = makeCcParser();
 

--- a/tests/Unit/Providers/Cohere/CohereRerankHandlerTest.php
+++ b/tests/Unit/Providers/Cohere/CohereRerankHandlerTest.php
@@ -5,9 +5,31 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Cohere\CohereRerankHandler;
 use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\RerankRequest;
 use Atlasphp\Atlas\Responses\RerankResponse;
 use Illuminate\Support\Facades\Http;
+
+it('forwards the request config to the HTTP layer for rerank', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(['results' => [['index' => 0, 'relevance_score' => 0.9]], 'meta' => ['billed_units' => ['search_units' => 1]]]);
+
+    $handler = new CohereRerankHandler(
+        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.cohere.com']),
+        http: $http,
+    );
+
+    $handler->rerank(new RerankRequest(
+        model: 'rerank-v3.5',
+        query: 'q',
+        documents: ['a', 'b'],
+        requestConfig: $config,
+    ));
+});
 
 it('sends rerank request to /v2/rerank', function () {
     Http::fake([

--- a/tests/Unit/Providers/DriverTest.php
+++ b/tests/Unit/Providers/DriverTest.php
@@ -379,6 +379,19 @@ it('maps 503 to ServerException', function () {
     createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(503));
 })->throws(ServerException::class);
 
+it('maps an unmapped status to the base ProviderException', function () {
+    $caught = null;
+
+    try {
+        createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(418));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught::class)->toBe(ProviderException::class); // the base, not a subclass
+    expect($caught->statusCode)->toBe(418);
+});
+
 it('maps 529 (overloaded) to RateLimitException', function () {
     createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(529));
 })->throws(RateLimitException::class);

--- a/tests/Unit/Providers/DriverTest.php
+++ b/tests/Unit/Providers/DriverTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Enums\VoiceTransport;
+use Atlasphp\Atlas\Exceptions\AtlasException;
 use Atlasphp\Atlas\Exceptions\AuthenticationException;
 use Atlasphp\Atlas\Exceptions\AuthorizationException;
+use Atlasphp\Atlas\Exceptions\ConnectionException;
 use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
@@ -274,6 +276,38 @@ it('dispatch maps 429 RequestException from handler to RateLimitException', func
 
     $driver->text(new TextRequest('model', null, null, [], [], null, null, null, [], [], []));
 })->throws(RateLimitException::class);
+
+it('dispatch maps a connection failure from handler to Atlas ConnectionException', function () {
+    $handler = Mockery::mock(TextHandler::class);
+    $handler->shouldReceive('text')->andThrow(
+        new Illuminate\Http\Client\ConnectionException('cURL error 28: Connection timed out')
+    );
+
+    $driver = createTestDriver()->withHandler('text', $handler);
+
+    $driver->text(new TextRequest('model', null, null, [], [], null, null, null, [], [], []));
+})->throws(ConnectionException::class);
+
+it('Atlas ConnectionException is catchable as an AtlasException', function () {
+    $handler = Mockery::mock(TextHandler::class);
+    $handler->shouldReceive('text')->andThrow(
+        new Illuminate\Http\Client\ConnectionException('Connection refused')
+    );
+
+    $driver = createTestDriver()->withHandler('text', $handler);
+
+    $caught = null;
+
+    try {
+        $driver->text(new TextRequest('model', null, null, [], [], null, null, null, [], [], []));
+    } catch (AtlasException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf(ConnectionException::class);
+    expect($caught->provider)->toBe('test');
+    expect($caught->model)->toBe('model');
+});
 
 // ─── handleRequestException ─────────────────────────────────────────────────
 

--- a/tests/Unit/Providers/DriverTest.php
+++ b/tests/Unit/Providers/DriverTest.php
@@ -14,6 +14,7 @@ use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Providers\Handlers\EmbedHandler;
+use Atlasphp\Atlas\Providers\Handlers\ProviderHandler;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
 use Atlasphp\Atlas\Providers\ProviderConfig;
@@ -308,6 +309,29 @@ it('Atlas ConnectionException is catchable as an AtlasException', function () {
     expect($caught->provider)->toBe('test');
     expect($caught->model)->toBe('model');
 });
+
+// ─── interrogation endpoints translate transport errors ─────────────────────
+
+it('models() translates a 401 RequestException to AuthenticationException', function () {
+    $provider = Mockery::mock(ProviderHandler::class);
+    $provider->shouldReceive('models')->andThrow(makeRequestExceptionForStatus(401));
+
+    createTestDriver()->withHandler('provider', $provider)->models();
+})->throws(AuthenticationException::class);
+
+it('voices() translates a 500 RequestException to ProviderException', function () {
+    $provider = Mockery::mock(ProviderHandler::class);
+    $provider->shouldReceive('voices')->andThrow(makeRequestExceptionForStatus(500));
+
+    createTestDriver()->withHandler('provider', $provider)->voices();
+})->throws(ProviderException::class);
+
+it('models() translates a connection failure to Atlas ConnectionException', function () {
+    $provider = Mockery::mock(ProviderHandler::class);
+    $provider->shouldReceive('models')->andThrow(new Illuminate\Http\Client\ConnectionException('timed out'));
+
+    createTestDriver()->withHandler('provider', $provider)->models();
+})->throws(ConnectionException::class);
 
 // ─── handleRequestException ─────────────────────────────────────────────────
 

--- a/tests/Unit/Providers/DriverTest.php
+++ b/tests/Unit/Providers/DriverTest.php
@@ -8,8 +8,11 @@ use Atlasphp\Atlas\Exceptions\AtlasException;
 use Atlasphp\Atlas\Exceptions\AuthenticationException;
 use Atlasphp\Atlas\Exceptions\AuthorizationException;
 use Atlasphp\Atlas\Exceptions\ConnectionException;
+use Atlasphp\Atlas\Exceptions\InvalidRequestException;
+use Atlasphp\Atlas\Exceptions\ModelNotFoundException;
 use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Exceptions\RateLimitException;
+use Atlasphp\Atlas\Exceptions\ServerException;
 use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Driver;
@@ -363,3 +366,40 @@ it('maps 429 to RateLimitException', function () {
 it('maps 500 to ProviderException', function () {
     createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(500));
 })->throws(ProviderException::class);
+
+it('maps 400 to InvalidRequestException', function () {
+    createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(400));
+})->throws(InvalidRequestException::class);
+
+it('maps 404 to ModelNotFoundException', function () {
+    createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(404));
+})->throws(ModelNotFoundException::class);
+
+it('maps 503 to ServerException', function () {
+    createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(503));
+})->throws(ServerException::class);
+
+it('maps 529 (overloaded) to RateLimitException', function () {
+    createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus(529));
+})->throws(RateLimitException::class);
+
+it('the whole provider-error family is catchable as ProviderException', function (string $exceptionClass, int $status) {
+    $caught = null;
+
+    try {
+        createTestDriver()->handleRequestException('gpt-4o', makeRequestExceptionForStatus($status));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf($exceptionClass);
+    expect($caught)->toBeInstanceOf(ProviderException::class);
+    expect($caught->statusCode)->toBe($status);
+})->with([
+    'auth' => [AuthenticationException::class, 401],
+    'authz' => [AuthorizationException::class, 403],
+    'rate limit' => [RateLimitException::class, 429],
+    'invalid request' => [InvalidRequestException::class, 400],
+    'model not found' => [ModelNotFoundException::class, 404],
+    'server' => [ServerException::class, 503],
+]);

--- a/tests/Unit/Providers/ElevenLabs/Handlers/MusicHandlerTest.php
+++ b/tests/Unit/Providers/ElevenLabs/Handlers/MusicHandlerTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\ElevenLabs\Handlers\Music;
 use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\AudioRequest;
 use Illuminate\Support\Facades\Http;
 
-function makeMusicHandler(): Music
+function makeMusicHandler(?HttpClient $http = null): Music
 {
     return new Music(
         config: ProviderConfig::fromArray([
@@ -16,7 +17,7 @@ function makeMusicHandler(): Music
             'url' => 'https://api.elevenlabs.io/v1',
             'media_timeout' => 120,
         ]),
-        http: app(HttpClient::class),
+        http: $http ?? app(HttpClient::class),
     );
 }
 
@@ -33,8 +34,20 @@ function makeMusicRequest(array $overrides = []): AudioRequest
         format: $overrides['format'] ?? null,
         voiceClone: null,
         providerOptions: $overrides['providerOptions'] ?? [],
+        requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
+
+it('forwards the request config to postRaw', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('postRaw')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn('music-bytes');
+
+    makeMusicHandler($http)->audio(makeMusicRequest(['requestConfig' => $config]));
+});
 
 it('posts to /music with prompt', function () {
     Http::fake([

--- a/tests/Unit/Providers/ElevenLabs/Handlers/VoiceHandlerTest.php
+++ b/tests/Unit/Providers/ElevenLabs/Handlers/VoiceHandlerTest.php
@@ -55,6 +55,30 @@ function makeElevenLabsVoiceHandlerForDynamicAgent(
     return [$handler, $http];
 }
 
+it('throws ProviderException carrying the model when the signed URL is missing', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')
+        ->withArgs(fn (string $url) => str_contains($url, 'get-signed-url'))
+        ->andReturn(['no_signed_url' => true]);
+
+    $caught = null;
+
+    try {
+        makeElevenLabsVoiceHandler($http)->createSession(new VoiceRequest(
+            model: 'eleven-convai-v1',
+            instructions: null,
+            voice: null,
+            providerOptions: ['agent_id' => 'agent_abc123'],
+        ));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('eleven-convai-v1');
+    expect($caught->getMessage())->toContain('signed_url');
+});
+
 // ─── createSession with pre-configured agent ────────────────────
 
 it('creates session with pre-configured agent_id', function () {

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Google\Handlers\Text;
 use Atlasphp\Atlas\Providers\Google\MediaResolver;
@@ -51,6 +52,29 @@ function makeGoogleTextRequest(array $overrides = []): TextRequest
         requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
+
+it('a mid-stream error while streaming throws a ProviderException carrying the model', function () {
+    Http::fake([
+        '*streamGenerateContent*' => Http::response(
+            "data: {\"error\":{\"code\":429,\"message\":\"Resource exhausted\"}}\n\n",
+            200,
+        ),
+    ]);
+
+    $caught = null;
+
+    try {
+        foreach (makeGoogleTextHandler()->stream(makeGoogleTextRequest(['model' => 'gemini-2.5-flash'])) as $chunk) {
+            // consume the stream
+        }
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('gemini-2.5-flash');
+    expect($caught->providerMessage)->toBe('Resource exhausted');
+});
 
 it('forwards the request config to the HTTP layer (post and stream)', function () {
     $config = (new RequestConfig(30, 5, 2))->withoutRetry();

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -9,21 +9,23 @@ use Atlasphp\Atlas\Providers\Google\MessageFactory;
 use Atlasphp\Atlas\Providers\Google\ResponseParser;
 use Atlasphp\Atlas\Providers\Google\ToolMapper;
 use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
-function makeGoogleTextHandler(): Text
+function makeGoogleTextHandler(?HttpClient $http = null): Text
 {
     $toolMapper = new ToolMapper;
 
     return new Text(
         config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://generativelanguage.googleapis.com']),
-        http: app(HttpClient::class),
+        http: $http ?? app(HttpClient::class),
         messages: new MessageFactory,
         media: new MediaResolver,
         tools: $toolMapper,
@@ -46,8 +48,25 @@ function makeGoogleTextRequest(array $overrides = []): TextRequest
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
         toolChoice: $overrides['toolChoice'] ?? null,
+        requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
+
+it('forwards the request config to the HTTP layer (post and stream)', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(['candidates' => [['content' => ['parts' => [['text' => 'ok']]], 'finishReason' => 'STOP']], 'usageMetadata' => ['promptTokenCount' => 1, 'candidatesTokenCount' => 1]]);
+    $http->shouldReceive('stream')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(Mockery::mock(Response::class));
+
+    $handler = makeGoogleTextHandler($http);
+    $handler->text(makeGoogleTextRequest(['requestConfig' => $config]));
+    $handler->stream(makeGoogleTextRequest(['requestConfig' => $config]));
+});
 
 it('emits Gemini tool_config when a choice is set with tools', function () {
     Http::fake(['generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse())]);

--- a/tests/Unit/Providers/Google/ResponseParserTest.php
+++ b/tests/Unit/Providers/Google/ResponseParserTest.php
@@ -23,6 +23,20 @@ it('throws ProviderException on a mid-stream error payload', function () {
     ]);
 })->throws(ProviderException::class, 'Resource exhausted');
 
+it('a mid-stream error carries the model passed to the parser', function () {
+    $caught = null;
+
+    try {
+        makeGoogleResponseParser()->parseStreamChunk([
+            'error' => ['code' => 429, 'message' => 'Resource exhausted'],
+        ], 'gemini-2.5-flash');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught?->model)->toBe('gemini-2.5-flash');
+});
+
 it('parses text from candidates parts', function () {
     $parser = makeGoogleResponseParser();
 

--- a/tests/Unit/Providers/Google/ResponseParserTest.php
+++ b/tests/Unit/Providers/Google/ResponseParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Providers\Google\GoogleToolCall;
 use Atlasphp\Atlas\Providers\Google\ResponseParser;
 use Atlasphp\Atlas\Providers\Google\ToolMapper;
@@ -15,6 +16,12 @@ function makeGoogleResponseParser(): ResponseParser
 {
     return new ResponseParser(new ToolMapper);
 }
+
+it('throws ProviderException on a mid-stream error payload', function () {
+    makeGoogleResponseParser()->parseStreamChunk([
+        'error' => ['code' => 429, 'message' => 'Resource exhausted', 'status' => 'RESOURCE_EXHAUSTED'],
+    ]);
+})->throws(ProviderException::class, 'Resource exhausted');
 
 it('parses text from candidates parts', function () {
     $parser = makeGoogleResponseParser();

--- a/tests/Unit/Providers/OpenAi/Handlers/AudioHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/AudioHandlerTest.php
@@ -6,18 +6,44 @@ use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Input\Audio as AudioInput;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Audio;
 use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\AudioRequest;
 use Atlasphp\Atlas\Responses\AudioResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Illuminate\Support\Facades\Http;
 
-function makeAudioHandler(): Audio
+function makeAudioHandler(?HttpClient $http = null): Audio
 {
     return new Audio(
         config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.openai.com/v1']),
-        http: app(HttpClient::class),
+        http: $http ?? app(HttpClient::class),
     );
 }
+
+it('forwards the request config to postRaw (TTS) and postMultipart (transcription)', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('postRaw')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn('audio-bytes');
+    $http->shouldReceive('postMultipart')->once()
+        ->withArgs(fn (string $url, array $headers, array $data, array $attachments, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(['text' => 'transcribed']);
+
+    $handler = makeAudioHandler($http);
+
+    $handler->audio(new AudioRequest(
+        model: 'tts-1', instructions: 'Hi', media: [], voice: 'nova', speed: null,
+        language: null, duration: null, format: 'mp3', voiceClone: null, requestConfig: $config,
+    ));
+
+    $handler->audioToText(new AudioRequest(
+        model: 'whisper-1', instructions: null, media: [AudioInput::fromBase64('YXVkaW8=', 'audio/mpeg')],
+        voice: null, speed: null, language: null, duration: null, format: 'mp3', voiceClone: null,
+        requestConfig: $config,
+    ));
+});
 
 it('sends TTS request to /v1/audio/speech', function () {
     Http::fake([

--- a/tests/Unit/Providers/OpenAi/Handlers/ProviderHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/ProviderHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Atlasphp\Atlas\AtlasCache;
 use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\ModelList;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Provider;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Illuminate\Support\Facades\Http;
@@ -94,6 +95,18 @@ it('validate returns false when models endpoint throws', function () {
     ]);
 
     $handler = makeProviderHandler();
+
+    expect($handler->validate())->toBeFalse();
+});
+
+it('validate returns false even when models throws a non-Exception Error', function () {
+    $handler = new class(ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.openai.com/v1']), app(HttpClient::class), app(AtlasCache::class)) extends Provider
+    {
+        public function models(): ModelList
+        {
+            throw new TypeError('malformed provider response');
+        }
+    };
 
     expect($handler->validate())->toBeFalse();
 });

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Text;
 use Atlasphp\Atlas\Providers\OpenAi\MediaResolver;
@@ -212,6 +213,29 @@ it('sends structured request with text.format', function () {
             && $request['text']['format']['type'] === 'json_schema'
             && $request['text']['format']['strict'] === true;
     });
+});
+
+it('a mid-stream error while streaming throws a ProviderException carrying the model', function () {
+    Http::fake([
+        'api.openai.com/v1/responses' => Http::response(
+            "event: response.failed\ndata: {\"response\":{\"error\":{\"message\":\"boom\"}}}\n\n",
+            200,
+        ),
+    ]);
+
+    $caught = null;
+
+    try {
+        foreach (makeTextHandler()->stream(makeOpenAiTextRequest(['model' => 'gpt-4o'])) as $chunk) {
+            // consume the stream
+        }
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('gpt-4o');
+    expect($caught->providerMessage)->toBe('boom');
 });
 
 it('forwards the request config to the HTTP layer when streaming', function () {

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -10,12 +10,14 @@ use Atlasphp\Atlas\Providers\OpenAi\ResponseParser;
 use Atlasphp\Atlas\Providers\OpenAi\ToolMapper;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
 function makeTextHandler(?HttpClient $http = null): Text
@@ -47,6 +49,7 @@ function makeOpenAiTextRequest(array $overrides = []): TextRequest
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
         toolChoice: $overrides['toolChoice'] ?? null,
+        requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
 
@@ -209,6 +212,32 @@ it('sends structured request with text.format', function () {
             && $request['text']['format']['type'] === 'json_schema'
             && $request['text']['format']['strict'] === true;
     });
+});
+
+it('forwards the request config to the HTTP layer when streaming', function () {
+    $config = (new RequestConfig(30, 5, 2))->withTimeout(15);
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('stream')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(Mockery::mock(Response::class));
+
+    makeTextHandler($http)->stream(makeOpenAiTextRequest(['requestConfig' => $config]));
+});
+
+it('forwards the request config to the HTTP layer for a text call', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn([
+            'status' => 'completed',
+            'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'ok']]]],
+            'usage' => ['input_tokens' => 1, 'output_tokens' => 1],
+        ]);
+
+    makeTextHandler($http)->text(makeOpenAiTextRequest(['requestConfig' => $config]));
 });
 
 it('passes provider options through', function () {

--- a/tests/Unit/Providers/OpenAi/Handlers/VideoHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/VideoHandlerTest.php
@@ -11,6 +11,7 @@ use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Requests\VideoRequest;
 use Atlasphp\Atlas\Responses\VideoResponse;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 
 function makeOpenAiVideoHandler(): Video
 {
@@ -185,6 +186,46 @@ it('an unresolvable reference image throws a ProviderException carrying the mode
 
     expect($caught)->not->toBeNull();
     expect($caught->model)->toBe('sora-2');
+});
+
+it('an unreadable file reference image throws a ProviderException carrying the model', function () {
+    $caught = null;
+
+    set_error_handler(fn () => true); // swallow the file_get_contents warning
+
+    try {
+        makeOpenAiVideoHandler()->video(makeOpenAiVideoRequest([
+            'model' => 'sora-2',
+            'media' => [Image::fromPath('/nonexistent/atlas-ref.png')],
+        ]));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('sora-2');
+    expect($caught->getMessage())->toContain('Cannot read image file');
+});
+
+it('an unreadable storage reference image throws a ProviderException carrying the model', function () {
+    Storage::fake('local');
+
+    $caught = null;
+
+    try {
+        makeOpenAiVideoHandler()->video(makeOpenAiVideoRequest([
+            'model' => 'sora-2',
+            'media' => [Image::fromStorage('missing.png', 'local')],
+        ]));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('sora-2');
+    expect($caught->getMessage())->toContain('Cannot read image from storage');
 });
 
 it('throws ProviderException when video generation fails', function () {

--- a/tests/Unit/Providers/OpenAi/Handlers/VideoHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/VideoHandlerTest.php
@@ -171,6 +171,22 @@ it('throws ProviderException when id is missing', function () {
     $handler->video(makeOpenAiVideoRequest());
 })->throws(ProviderException::class, 'missing id');
 
+it('an unresolvable reference image throws a ProviderException carrying the model', function () {
+    $caught = null;
+
+    try {
+        makeOpenAiVideoHandler()->video(makeOpenAiVideoRequest([
+            'model' => 'sora-2',
+            'media' => [Image::fromFileId('file-abc123')],
+        ]));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('sora-2');
+});
+
 it('throws ProviderException when video generation fails', function () {
     Http::fake([
         'api.openai.com/v1/videos' => Http::response(['id' => 'video_fail', 'status' => 'queued']),

--- a/tests/Unit/Providers/OpenAi/ResponseParserTest.php
+++ b/tests/Unit/Providers/OpenAi/ResponseParserTest.php
@@ -211,6 +211,22 @@ it('throws ProviderException on a top-level error payload', function () {
     ]);
 })->throws(ProviderException::class, 'invalid request');
 
+it('a mid-stream error carries the model passed to the parser', function () {
+    $caught = null;
+
+    try {
+        makeParser()->parseStreamChunk([
+            'event' => 'error',
+            'data' => ['error' => ['message' => 'boom']],
+        ], 'gpt-4o');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('gpt-4o');
+});
+
 it('returns empty text chunk for unknown events', function () {
     $parser = makeParser();
 

--- a/tests/Unit/Providers/OpenAi/ResponseParserTest.php
+++ b/tests/Unit/Providers/OpenAi/ResponseParserTest.php
@@ -202,6 +202,15 @@ it('throws ProviderException on response.failed event', function () {
     ]);
 })->throws(ProviderException::class, 'Server error during generation');
 
+it('throws ProviderException on a top-level error payload', function () {
+    makeParser()->parseStreamChunk([
+        'event' => 'error',
+        'data' => [
+            'error' => ['message' => 'invalid request'],
+        ],
+    ]);
+})->throws(ProviderException::class, 'invalid request');
+
 it('returns empty text chunk for unknown events', function () {
     $parser = makeParser();
 

--- a/tests/Unit/Providers/ProviderConfigTest.php
+++ b/tests/Unit/Providers/ProviderConfigTest.php
@@ -33,6 +33,29 @@ it('uses default timeout values when not provided', function () {
     expect($config->mediaTimeout)->toBe(120);
 });
 
+it('falls back to the global atlas.retry.timeout when no provider timeout is set', function () {
+    config(['atlas.retry.timeout' => 90]);
+
+    $config = ProviderConfig::fromArray([
+        'api_key' => 'sk-test',
+        'url' => 'https://api.test.com',
+    ]);
+
+    expect($config->timeout)->toBe(90);
+});
+
+it('a provider-level timeout overrides the global default', function () {
+    config(['atlas.retry.timeout' => 90]);
+
+    $config = ProviderConfig::fromArray([
+        'api_key' => 'sk-test',
+        'url' => 'https://api.test.com',
+        'timeout' => 15,
+    ]);
+
+    expect($config->timeout)->toBe(15);
+});
+
 it('captures extra keys', function () {
     $config = ProviderConfig::fromArray([
         'api_key' => 'sk-test',

--- a/tests/Unit/Providers/ProviderConfigTest.php
+++ b/tests/Unit/Providers/ProviderConfigTest.php
@@ -10,7 +10,6 @@ it('creates from a full config array', function () {
         'url' => 'https://api.openai.com/v1',
         'organization' => 'org-123',
         'timeout' => 30,
-        'reasoning_timeout' => 120,
         'media_timeout' => 60,
     ]);
 
@@ -18,7 +17,6 @@ it('creates from a full config array', function () {
     expect($config->baseUrl)->toBe('https://api.openai.com/v1');
     expect($config->organization)->toBe('org-123');
     expect($config->timeout)->toBe(30);
-    expect($config->reasoningTimeout)->toBe(120);
     expect($config->mediaTimeout)->toBe(60);
 });
 
@@ -29,7 +27,6 @@ it('uses default timeout values when not provided', function () {
     ]);
 
     expect($config->timeout)->toBe(60);
-    expect($config->reasoningTimeout)->toBe(300);
     expect($config->mediaTimeout)->toBe(120);
 });
 

--- a/tests/Unit/Providers/Xai/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Xai/Handlers/TextHandlerTest.php
@@ -10,11 +10,13 @@ use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Providers\Tools\WebSearch;
 use Atlasphp\Atlas\Providers\Xai\Handlers\Text;
 use Atlasphp\Atlas\Providers\Xai\MessageFactory;
+use Atlasphp\Atlas\RequestConfig;
 use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
 function makeXaiTextHandler(?HttpClient $http = null): Text
@@ -45,8 +47,25 @@ function makeXaiHandlerTextRequest(array $overrides = []): TextRequest
         tools: $overrides['tools'] ?? [],
         providerTools: $overrides['providerTools'] ?? [],
         providerOptions: $overrides['providerOptions'] ?? [],
+        requestConfig: $overrides['requestConfig'] ?? null,
     );
 }
+
+it('forwards the request config to the HTTP layer (post and stream)', function () {
+    $config = (new RequestConfig(30, 5, 2))->withoutRetry();
+
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(['status' => 'completed', 'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'ok']]]], 'usage' => ['input_tokens' => 1, 'output_tokens' => 1]]);
+    $http->shouldReceive('stream')->once()
+        ->withArgs(fn (string $url, array $headers, array $body, int $timeout, ?RequestConfig $cfg) => $cfg === $config)
+        ->andReturn(Mockery::mock(Response::class));
+
+    $handler = makeXaiTextHandler($http);
+    $handler->text(makeXaiHandlerTextRequest(['requestConfig' => $config]));
+    $handler->stream(makeXaiHandlerTextRequest(['requestConfig' => $config]));
+});
 
 it('does not include instructions in body', function () {
     Http::fake([

--- a/tests/Unit/Providers/Xai/Handlers/VideoHandlerTest.php
+++ b/tests/Unit/Providers/Xai/Handlers/VideoHandlerTest.php
@@ -11,6 +11,7 @@ use Atlasphp\Atlas\Providers\Xai\Handlers\Video;
 use Atlasphp\Atlas\Requests\VideoRequest;
 use Atlasphp\Atlas\Responses\VideoResponse;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 
 function makeXaiVideoHandler(): Video
 {
@@ -48,6 +49,46 @@ it('an unresolvable reference image throws a ProviderException carrying the mode
 
     expect($caught)->not->toBeNull();
     expect($caught->model)->toBe('grok-video');
+});
+
+it('an unreadable file reference image throws a ProviderException carrying the model', function () {
+    $caught = null;
+
+    set_error_handler(fn () => true); // swallow the file_get_contents warning
+
+    try {
+        makeXaiVideoHandler()->video(makeXaiVideoRequest([
+            'model' => 'grok-video',
+            'media' => [Image::fromPath('/nonexistent/atlas-ref.png')],
+        ]));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('grok-video');
+    expect($caught->getMessage())->toContain('Cannot read image file');
+});
+
+it('an unreadable storage reference image throws a ProviderException carrying the model', function () {
+    Storage::fake('local');
+
+    $caught = null;
+
+    try {
+        makeXaiVideoHandler()->video(makeXaiVideoRequest([
+            'model' => 'grok-video',
+            'media' => [Image::fromStorage('missing.png', 'local')],
+        ]));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('grok-video');
+    expect($caught->getMessage())->toContain('Cannot read image from storage');
 });
 
 it('posts to /v1/videos/generations and polls until done', function () {

--- a/tests/Unit/Providers/Xai/Handlers/VideoHandlerTest.php
+++ b/tests/Unit/Providers/Xai/Handlers/VideoHandlerTest.php
@@ -34,6 +34,22 @@ function makeXaiVideoRequest(array $overrides = []): VideoRequest
     );
 }
 
+it('an unresolvable reference image throws a ProviderException carrying the model', function () {
+    $caught = null;
+
+    try {
+        makeXaiVideoHandler()->video(makeXaiVideoRequest([
+            'model' => 'grok-video',
+            'media' => [Image::fromFileId('file-abc123')],
+        ]));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->model)->toBe('grok-video');
+});
+
 it('posts to /v1/videos/generations and polls until done', function () {
     Http::fake([
         'api.x.ai/v1/videos/generations' => Http::response(['request_id' => 'vid_123']),

--- a/tests/Unit/Queue/ExecuteAtlasJobTest.php
+++ b/tests/Unit/Queue/ExecuteAtlasJobTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\Events\ExecutionCompleted;
 use Atlasphp\Atlas\Events\ExecutionFailed;
+use Atlasphp\Atlas\Exceptions\AuthenticationException;
 use Atlasphp\Atlas\Exceptions\MaxStepsExceededException;
+use Atlasphp\Atlas\Exceptions\ServerException;
 use Atlasphp\Atlas\Queue\Contracts\QueueableRequest;
 use Atlasphp\Atlas\Queue\Jobs\ExecuteAtlasJob;
 use Illuminate\Broadcasting\Channel;
@@ -225,6 +227,110 @@ it('fails immediately on MaxStepsExceededException without retrying', function (
 
     // ExecutionCompleted should NOT be dispatched because we failed early
     Event::assertNotDispatched(ExecutionCompleted::class);
+});
+
+it('fails immediately on a permanent provider error without retrying', function () {
+    Event::fake();
+
+    $requestClass = new class implements QueueableRequest
+    {
+        public function toQueuePayload(): array
+        {
+            return [];
+        }
+
+        public static function executeFromPayload(
+            array $payload,
+            string $terminal,
+            ?int $executionId = null,
+            ?Channel $broadcastChannel = null,
+        ): mixed {
+            throw new AuthenticationException('openai');
+        }
+    };
+
+    $job = new ExecuteAtlasJob(
+        requestClass: get_class($requestClass),
+        terminal: 'asText',
+        payload: [],
+        executionId: 101,
+    );
+
+    $job->job = Mockery::mock(Job::class);
+    $job->job->shouldReceive('fail')->once();
+    $job->job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+
+    $job->handle();
+
+    Event::assertNotDispatched(ExecutionCompleted::class);
+});
+
+it('finalizes failure even when no queue job is bound', function () {
+    Event::fake();
+
+    $requestClass = new class implements QueueableRequest
+    {
+        public function toQueuePayload(): array
+        {
+            return [];
+        }
+
+        public static function executeFromPayload(
+            array $payload,
+            string $terminal,
+            ?int $executionId = null,
+            ?Channel $broadcastChannel = null,
+        ): mixed {
+            throw new AuthenticationException('openai');
+        }
+    };
+
+    $job = new ExecuteAtlasJob(
+        requestClass: get_class($requestClass),
+        terminal: 'asText',
+        payload: [],
+        executionId: 103,
+    );
+
+    // No $job->job bound — fail() is a no-op, so the catch must finalize directly.
+    $job->handle();
+
+    Event::assertDispatched(ExecutionFailed::class);
+    Event::assertNotDispatched(ExecutionCompleted::class);
+});
+
+it('lets a transient provider error propagate so the queue can retry it', function () {
+    Event::fake();
+
+    $requestClass = new class implements QueueableRequest
+    {
+        public function toQueuePayload(): array
+        {
+            return [];
+        }
+
+        public static function executeFromPayload(
+            array $payload,
+            string $terminal,
+            ?int $executionId = null,
+            ?Channel $broadcastChannel = null,
+        ): mixed {
+            throw new ServerException('openai', 'gpt-4o', 503, 'overloaded');
+        }
+    };
+
+    $job = new ExecuteAtlasJob(
+        requestClass: get_class($requestClass),
+        terminal: 'asText',
+        payload: [],
+        executionId: 102,
+    );
+
+    $job->job = Mockery::mock(Job::class);
+    // fail() must NOT be called for a transient error — it should bubble up for retry.
+    $job->job->shouldNotReceive('fail');
+
+    expect(fn () => $job->handle())->toThrow(ServerException::class);
 });
 
 it('consumes StreamResponse iterator during handle', function () {

--- a/tests/Unit/RequestConfigTest.php
+++ b/tests/Unit/RequestConfigTest.php
@@ -30,6 +30,29 @@ it('withTimeout returns new instance with updated timeout', function () {
     expect($updated->errors)->toBe(2);
 });
 
+it('marks the timeout explicit only when withTimeout is called', function () {
+    expect((new RequestConfig(60, 3, 2))->timeoutExplicit)->toBeFalse();
+    expect(RequestConfig::fromAtlasConfig(AtlasConfig::fromConfig())->timeoutExplicit)->toBeFalse();
+    expect((new RequestConfig(60, 3, 2))->withTimeout(10)->timeoutExplicit)->toBeTrue();
+});
+
+it('preserves the explicit-timeout flag across withRetry and withoutRetry', function () {
+    $config = (new RequestConfig(60, 3, 2))->withTimeout(10);
+
+    expect($config->withRetry(rateLimit: 9)->timeoutExplicit)->toBeTrue();
+    expect($config->withoutRetry()->timeoutExplicit)->toBeTrue();
+});
+
+it('round-trips through toArray and fromArray', function () {
+    $config = (new RequestConfig(45, 5, 3))->withTimeout(99);
+    $restored = RequestConfig::fromArray($config->toArray());
+
+    expect($restored->timeout)->toBe(99);
+    expect($restored->rateLimit)->toBe(5);
+    expect($restored->errors)->toBe(3);
+    expect($restored->timeoutExplicit)->toBeTrue();
+});
+
 it('withRetry overrides specified values only', function () {
     $config = new RequestConfig(60, 3, 2);
 


### PR DESCRIPTION
This pull request introduces improved error handling for network and streaming failures, as well as fixes to ensure retry logic works as intended. The changes add a new `ConnectionException` for network-level errors, ensure retries for both HTTP and network failures, and make mid-stream provider errors explicit by throwing a `ProviderException`. Documentation and changelogs have been updated accordingly.

**Error handling improvements:**

* Added a new `ConnectionException` (extending `AtlasException`) to represent network failures (such as timeouts, DNS errors, or refused connections) that occur before any HTTP response is received. This exception is now thrown instead of raw HTTP client exceptions and is documented in both the changelog and error-handling docs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R28) [[2]](diffhunk://#diff-41c3bdcdf291a15e3ea66b625d44afe79a72a6cb8f3b8f7ea5c1b66519806e95R15) [[3]](diffhunk://#diff-41c3bdcdf291a15e3ea66b625d44afe79a72a6cb8f3b8f7ea5c1b66519806e95R55-R99) [[4]](diffhunk://#diff-422ddcc8ceb86bc244215a121cdeda7ecbaa8737bd29ba226b2fcd9171049250R1-R31)
* Mid-stream provider errors (errors received during streaming) now throw a `ProviderException` instead of silently truncating the stream. This is handled in the response parsers for both Anthropic and ChatCompletions providers, and is documented in the error-handling guide. [[1]](diffhunk://#diff-bd581b4e88f542ab28158ed7f19357d206d651376cf57d335e11952fcc9380e6R38-R62) [[2]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bR9) [[3]](diffhunk://#diff-5b5088f99145e86a4d353ccd1176be519d6118fe1af18a9d71b5b051576cb34bR120-R125) [[4]](diffhunk://#diff-1c56f3eeea72700fda4e0c3e1f99d895c5beb748861d27640af3d54ab507822cR9) [[5]](diffhunk://#diff-1c56f3eeea72700fda4e0c3e1f99d895c5beb748861d27640af3d54ab507822cR96-R101) [[6]](diffhunk://#diff-41c3bdcdf291a15e3ea66b625d44afe79a72a6cb8f3b8f7ea5c1b66519806e95R55-R99)

**Retry logic fixes:**

* Retry logic is corrected: retries now properly occur for 429 and 5xx HTTP errors, as well as for network failures (using the new `ConnectionException`). The retry decider now checks for network-level exceptions and respects the configured retry count. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R28) [[2]](diffhunk://#diff-f3d54ad18083e9f9808db8b0f3d06ab0631f0006bb0fc846bb3784573f7f55cdR10) [[3]](diffhunk://#diff-f3d54ad18083e9f9808db8b0f3d06ab0631f0006bb0fc846bb3784573f7f55cdR52-R57)

**Request configuration propagation:**

* The `requestConfig` (containing retry and error-handling options) is now consistently passed through all request builders and provider handlers, ensuring that retries and error handling are applied uniformly across all request types. [[1]](diffhunk://#diff-1668325ecfaf9dfb0e9831a0bd5145ee595d13b66f9cb715f382ebfbd0c995abR1028) [[2]](diffhunk://#diff-aef8ca92d58d3434f6effa1dc4100e4776c2ed82ae68eaa34362e3e6594ee21eR200) [[3]](diffhunk://#diff-57fb3c4a0b89b5362a045a604080c3b9314f974b04bb131a71cfc07fef44fc60R97) [[4]](diffhunk://#diff-24120fcb37bc51bf882eb022a04136a6dcfa0e935e460c156e3337bf0ff4e616R129) [[5]](diffhunk://#diff-007751eaf8d593babb874e4a0b73a4cdc8ca9da7b4f399dda20f5795ee6d58b5R174) [[6]](diffhunk://#diff-ac6bfbf60d8708cde0e2010ec2d527ab6b996b438c7eb93276f128f5c2240b49R97) [[7]](diffhunk://#diff-fd526dfd1ac7238f4967022dcd8734f676be541c0e6ee5fb7b49eb8ceaf01b27R144) [[8]](diffhunk://#diff-dccc26a9cdd25b5ae003b7415ecf1f693eebc1ddba0af5531ba75fd0e4f65ab9R192) [[9]](diffhunk://#diff-6d87fabba941694aa1fb85525624c76f6d67d188bdf071d9d255eeeedb537ab4R416) [[10]](diffhunk://#diff-4ef8d863bc3c5eaab062de51764ec4614b6ad3e58a45d691c43abe1eb7f75767R164) [[11]](diffhunk://#diff-f8f1e012855e4b3c98938ffb321bef28bd4f7f0ffd2860d972a16c4a658e6801R209) [[12]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R52) [[13]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R68) [[14]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R97) [[15]](diffhunk://#diff-188df3cd767324e833afa208fa5c01eb7a91b1430a2064a9a86bb74dc354e804R51) [[16]](diffhunk://#diff-188df3cd767324e833afa208fa5c01eb7a91b1430a2064a9a86bb74dc354e804R68) [[17]](diffhunk://#diff-188df3cd767324e833afa208fa5c01eb7a91b1430a2064a9a86bb74dc354e804R94)

**Documentation and changelog:**

* Updated `CHANGELOG.md` and the advanced error-handling documentation to reflect the new exceptions and error-handling behaviors, including migration notes for users. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R28) [[2]](diffhunk://#diff-41c3bdcdf291a15e3ea66b625d44afe79a72a6cb8f3b8f7ea5c1b66519806e95R15) [[3]](diffhunk://#diff-41c3bdcdf291a15e3ea66b625d44afe79a72a6cb8f3b8f7ea5c1b66519806e95R55-R99)

No breaking changes are introduced; this is a drop-in upgrade. For handling mid-stream errors, users should wrap stream iteration in a `try/catch` for `ProviderException`.