### PR TITLE
Add voice route middleware & cap event payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Catch specific provider failures with the new `ConnectionException` (network failure), `ModelNotFoundException` (unknown model), `InvalidRequestException` (bad request), and `ServerException` (provider server error).
 - xAI now accepts the `CodeInterpreter` provider tool (live-verified against xAI's Agent Tools API).
+- Protect the voice tool/transcript/close routes with the new `persistence.voice_route_middleware` config — add HTTP middleware like `['auth:sanctum', 'throttle:60,1']`. These routes are public by default, so secure them in production.
 
 ### Changed
 
@@ -30,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Error messages now carry the provider's real reason on every provider.
 - Listing available models and voices now reports failures the same way as every other call.
 - Queued requests now fail fast on errors that can't succeed (invalid key, bad request, unknown model) instead of using up every retry; transient errors still retry.
+- A stream interrupted mid-flight now broadcasts the token usage and finish reason accumulated so far instead of zeroing them, so cost tracking survives an aborted stream.
+- A queued execution failure now caps its broadcast error message to the configured byte limit, so a long provider error can't exceed the socket transport's size limit and drop the event.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Catch specific provider failures with the new `ConnectionException` (network failure), `ModelNotFoundException` (unknown model), `InvalidRequestException` (bad request), and `ServerException` (provider server error).
 - xAI now accepts the `CodeInterpreter` provider tool (live-verified against xAI's Agent Tools API).
-- Protect the voice tool/transcript/close routes with the new `persistence.voice_route_middleware` config — add HTTP middleware like `['auth:sanctum', 'throttle:60,1']`. These routes are public by default, so secure them in production.
+- Protect the voice tool/transcript/close routes with the new `voice.route_middleware` config — add HTTP middleware like `['auth:sanctum', 'throttle:60,1']`. These routes are public by default, so secure them in production.
+- Voice route and session config now lives under a dedicated `voice` config block (`route_prefix`, `route_middleware`, `session_ttl`); the legacy `persistence.voice_route_prefix` / `persistence.voice_session_ttl` keys still work.
 
 ### Changed
 

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -402,6 +402,13 @@ return [
 
         'voice_route_prefix' => 'atlas',
 
+        // The voice tool/transcript/close routes are public by default — they act
+        // on knowledge of the session id alone. List HTTP middleware here to protect
+        // them, e.g. ['auth:sanctum', 'throttle:60,1']. Your middleware should also
+        // verify the authenticated user owns the session (the owner is stored on the
+        // voice:{sessionId}:tools cache entry and on the VoiceCall record).
+        'voice_route_middleware' => [],
+
         'voice_session_ttl' => (int) env('ATLAS_VOICE_SESSION_TTL', 60),
 
         'models' => [

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -400,17 +400,6 @@ return [
         // turn. null (ATLAS_MEDIA_REPLAY_LIMIT=null) = replay all in the window.
         'media_replay_limit' => env('ATLAS_MEDIA_REPLAY_LIMIT', 2),
 
-        'voice_route_prefix' => 'atlas',
-
-        // The voice tool/transcript/close routes are public by default — they act
-        // on knowledge of the session id alone. List HTTP middleware here to protect
-        // them, e.g. ['auth:sanctum', 'throttle:60,1']. Your middleware should also
-        // verify the authenticated user owns the session (the owner is stored on the
-        // voice:{sessionId}:tools cache entry and on the VoiceCall record).
-        'voice_route_middleware' => [],
-
-        'voice_session_ttl' => (int) env('ATLAS_VOICE_SESSION_TTL', 60),
-
         'models' => [
             // 'conversation'               => \App\Models\AiConversation::class,
             // 'conversation_message'        => \App\Models\AiMessage::class,
@@ -421,6 +410,38 @@ return [
             // 'execution_tool_call'         => \App\Models\AiExecutionToolCall::class,
             // 'chunk'                       => \App\Models\AiChunk::class,
         ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Voice
+    |--------------------------------------------------------------------------
+    |
+    | Realtime voice routes (tool/transcript/close) and session caching. These
+    | are independent of persistence — session creation, live audio, and
+    | server-side tool calls work with persistence off; only durable transcript
+    | storage (the transcript route) requires it.
+    |
+    | NOTE: these keys previously lived under `persistence.voice_*`. AtlasConfig
+    | still falls back to the legacy `persistence.voice_route_prefix` /
+    | `persistence.voice_session_ttl` keys, so an older published config keeps
+    | working — but this `voice` block is the canonical location.
+    |
+    */
+
+    'voice' => [
+        // URL prefix for the voice routes (default: 'atlas').
+        'route_prefix' => 'atlas',
+
+        // HTTP middleware applied to the voice routes. They are public by default
+        // and act on knowledge of the session id alone, so secure them in
+        // production, e.g. ['auth:sanctum', 'throttle:60,1']. Your middleware
+        // should also verify the authenticated user owns the session (the owner
+        // is stored on the voice:{sessionId}:tools cache entry and the VoiceCall).
+        'route_middleware' => [],
+
+        // Minutes the session's tool map stays cached (the voice:{id}:tools entry).
+        'session_ttl' => (int) env('ATLAS_VOICE_SESSION_TTL', 60),
     ],
 
 ];

--- a/docs/advanced/events.md
+++ b/docs/advanced/events.md
@@ -8,7 +8,7 @@ Observe the full lifecycle of providers, agents, tools, streams, and queued exec
 
 ## Overview
 
-Atlas fires events across seven groups. Events fire automatically — no configuration needed to enable them. Every event is a standard Laravel event, so you can listen with `Event::listen`, an `EventServiceProvider`, or Laravel's event discovery.
+Atlas fires events across eight groups. Events fire automatically — no configuration needed to enable them. Every event is a standard Laravel event, so you can listen with `Event::listen`, an `EventServiceProvider`, or Laravel's event discovery.
 
 All events live in the `Atlasphp\Atlas\Events` namespace.
 
@@ -47,7 +47,7 @@ Fired by the executor during the agent tool loop.
 </div>
 
 ::: tip Broadcast payload size
-The tool-call events (`AgentToolCallStarted` / `AgentToolCallCompleted` / `AgentToolCallFailed`) broadcast the call's **full** arguments, result, and error by default, so a live trace consumer sees everything. If your socket transport (Reverb / Pusher) limits message size, set `atlas.broadcast.max_tool_payload_length` (env `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`) to a per-string character cap. `null` (default) means no cap.
+The tool-call events (`AgentToolCallStarted` / `AgentToolCallCompleted` / `AgentToolCallFailed`) and `ExecutionFailed` broadcast the call's arguments, result, and error to live trace consumers. Each broadcast string is capped to `atlas.broadcast.max_tool_payload_length` (env `ATLAS_BROADCAST_MAX_TOOL_PAYLOAD`) **bytes** (`mb_strcut`, never splitting a multibyte char) so a large value can't exceed your socket transport's per-message limit (Pusher ~10KB; Reverb configurable) and silently drop the event or close the connection. The default is **2048 bytes**; set `0`, `null`, or a negative value to broadcast uncapped.
 :::
 
 ## Stream Events

--- a/docs/guides/voice-integration.md
+++ b/docs/guides/voice-integration.md
@@ -65,24 +65,26 @@ return response()->json($session->toClientPayload());
     ],
 ],
 
+'voice' => [
+    // URL prefix for the voice tool/transcript/close routes (default: 'atlas').
+    'route_prefix' => 'atlas',
+
+    // HTTP middleware applied to the voice routes — see the security note below.
+    'route_middleware' => ['auth:sanctum', 'throttle:60,1'],
+],
+
 'persistence' => [
     // Voice itself does NOT require persistence — session creation, live audio,
     // and server-side tool calls all work with it off. Enable it only for durable
     // transcripts, VoiceCall records, and the VoiceCall* lifecycle events.
     'enabled' => env('ATLAS_PERSISTENCE_ENABLED', true),
-
-    // URL prefix for the voice tool/transcript/close routes (default: 'atlas').
-    'voice_route_prefix' => 'atlas',
-
-    // HTTP middleware applied to the voice routes — see the security note below.
-    'voice_route_middleware' => ['auth:sanctum', 'throttle:60,1'],
 ],
 ```
 
 ::: danger Secure the voice routes
 The tool, transcript, and close routes are **public by default** — they act on knowledge of the session id alone. With no middleware, anyone who learns a session id can execute that session's registered tools, overwrite its transcript, or close the call.
 
-Always set `persistence.voice_route_middleware` to authenticate the caller (e.g. `'auth:sanctum'`) and rate-limit it (e.g. `'throttle:60,1'`), **and** verify the authenticated user owns the session. The session owner is stored on the `voice:{sessionId}:tools` cache entry (`user_id`) and on the `VoiceCall` record — check it inside your own middleware or a route filter. Standard Laravel middleware strings work here, as do classes implementing the `Atlasphp\Atlas\Middleware\Contracts\VoiceHttpMiddleware` marker interface (registered in `atlas.middleware`) when you need container-resolved middleware.
+Always set `voice.route_middleware` to authenticate the caller (e.g. `'auth:sanctum'`) and rate-limit it (e.g. `'throttle:60,1'`), **and** verify the authenticated user owns the session. The session owner is stored on the `voice:{sessionId}:tools` cache entry (`user_id`) and on the `VoiceCall` record — check it inside your own middleware or a route filter. Standard Laravel middleware strings work here, as do classes implementing the `Atlasphp\Atlas\Middleware\Contracts\VoiceHttpMiddleware` marker interface (registered in `atlas.middleware`) when you need container-resolved middleware.
 :::
 
 ## Step 3: Frontend — Connect to Provider

--- a/docs/guides/voice-integration.md
+++ b/docs/guides/voice-integration.md
@@ -66,13 +66,24 @@ return response()->json($session->toClientPayload());
 ],
 
 'persistence' => [
-    'voice_transcripts' => [
-        'enabled' => true,
-        'middleware' => ['auth:sanctum'],
-        'route_prefix' => 'atlas',
-    ],
+    // Voice itself does NOT require persistence — session creation, live audio,
+    // and server-side tool calls all work with it off. Enable it only for durable
+    // transcripts, VoiceCall records, and the VoiceCall* lifecycle events.
+    'enabled' => env('ATLAS_PERSISTENCE_ENABLED', true),
+
+    // URL prefix for the voice tool/transcript/close routes (default: 'atlas').
+    'voice_route_prefix' => 'atlas',
+
+    // HTTP middleware applied to the voice routes — see the security note below.
+    'voice_route_middleware' => ['auth:sanctum', 'throttle:60,1'],
 ],
 ```
+
+::: danger Secure the voice routes
+The tool, transcript, and close routes are **public by default** — they act on knowledge of the session id alone. With no middleware, anyone who learns a session id can execute that session's registered tools, overwrite its transcript, or close the call.
+
+Always set `persistence.voice_route_middleware` to authenticate the caller (e.g. `'auth:sanctum'`) and rate-limit it (e.g. `'throttle:60,1'`), **and** verify the authenticated user owns the session. The session owner is stored on the `voice:{sessionId}:tools` cache entry (`user_id`) and on the `VoiceCall` record — check it inside your own middleware or a route filter. Standard Laravel middleware strings work here, as do classes implementing the `Atlasphp\Atlas\Middleware\Contracts\VoiceHttpMiddleware` marker interface (registered in `atlas.middleware`) when you need container-resolved middleware.
+:::
 
 ## Step 3: Frontend — Connect to Provider
 

--- a/sandbox/config/atlas.php
+++ b/sandbox/config/atlas.php
@@ -102,8 +102,12 @@ return [
         'message_limit' => (int) env('ATLAS_MESSAGE_LIMIT', 50),
         'media_replay_limit' => env('ATLAS_MEDIA_REPLAY_LIMIT', 2),
         'auto_store_assets' => env('ATLAS_AUTO_STORE_ASSETS', true),
-        'voice_route_prefix' => 'atlas',
-        'voice_session_ttl' => (int) env('ATLAS_VOICE_SESSION_TTL', 60),
+    ],
+
+    'voice' => [
+        'route_prefix' => 'atlas',
+        'route_middleware' => [],
+        'session_ttl' => (int) env('ATLAS_VOICE_SESSION_TTL', 60),
     ],
 
     'agents' => [

--- a/src/AtlasConfig.php
+++ b/src/AtlasConfig.php
@@ -57,6 +57,8 @@ class AtlasConfig
         public readonly bool $autoStoreAssets = true,
         public readonly bool $promptCache = true,
         public readonly string $voiceRoutePrefix = 'atlas',
+        /** @var array<int, string> */
+        public readonly array $voiceRouteMiddleware = [],
         public readonly int $voiceSessionTtl = 60,
         /** @var array<string, class-string> */
         public readonly array $persistenceModels = [],
@@ -143,6 +145,7 @@ class AtlasConfig
             autoStoreAssets: (bool) config('atlas.persistence.auto_store_assets', true),
             promptCache: (bool) config('atlas.prompt_cache', true),
             voiceRoutePrefix: config('atlas.persistence.voice_route_prefix', 'atlas'),
+            voiceRouteMiddleware: (array) config('atlas.persistence.voice_route_middleware', []),
             voiceSessionTtl: (int) config('atlas.persistence.voice_session_ttl', 60),
             persistenceModels: config('atlas.persistence.models', []),
             agents: config('atlas.agents', ['path' => null, 'namespace' => null]),

--- a/src/AtlasConfig.php
+++ b/src/AtlasConfig.php
@@ -144,9 +144,13 @@ class AtlasConfig
                 : null,
             autoStoreAssets: (bool) config('atlas.persistence.auto_store_assets', true),
             promptCache: (bool) config('atlas.prompt_cache', true),
-            voiceRoutePrefix: config('atlas.persistence.voice_route_prefix', 'atlas'),
-            voiceRouteMiddleware: (array) config('atlas.persistence.voice_route_middleware', []),
-            voiceSessionTtl: (int) config('atlas.persistence.voice_session_ttl', 60),
+            // Voice route/session config lives under the dedicated `voice` block.
+            // Read it first, falling back to the legacy `persistence.voice_*` keys
+            // so a fork on an older published config keeps working. route_middleware
+            // is new in this block, so it has no legacy fallback.
+            voiceRoutePrefix: config('atlas.voice.route_prefix', config('atlas.persistence.voice_route_prefix', 'atlas')),
+            voiceRouteMiddleware: (array) config('atlas.voice.route_middleware', []),
+            voiceSessionTtl: (int) config('atlas.voice.session_ttl', config('atlas.persistence.voice_session_ttl', 60)),
             persistenceModels: config('atlas.persistence.models', []),
             agents: config('atlas.agents', ['path' => null, 'namespace' => null]),
         );

--- a/src/AtlasServiceProvider.php
+++ b/src/AtlasServiceProvider.php
@@ -162,7 +162,10 @@ class AtlasServiceProvider extends ServiceProvider
         $this->app->booted(function (): void {
             $config = app(AtlasConfig::class);
             $prefix = $config->voiceRoutePrefix;
-            $middleware = app(MiddlewareResolver::class)->forVoiceHttp();
+            $middleware = array_merge(
+                $config->voiceRouteMiddleware,
+                app(MiddlewareResolver::class)->forVoiceHttp(),
+            );
 
             Route::prefix($prefix)
                 ->middleware($middleware)

--- a/src/Events/ExecutionEvent.php
+++ b/src/Events/ExecutionEvent.php
@@ -36,4 +36,21 @@ abstract class ExecutionEvent implements ShouldBroadcastNow
     {
         return $this->channel !== null;
     }
+
+    /**
+     * The broadcast payload. Explicit so the wire shape is intentional and the
+     * non-public channel is never serialized.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'executionId' => $this->executionId,
+            'provider' => $this->provider,
+            'model' => $this->model,
+            'agentKey' => $this->agentKey,
+            'traceId' => $this->traceId,
+        ];
+    }
 }

--- a/src/Events/ExecutionFailed.php
+++ b/src/Events/ExecutionFailed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Events;
 
+use Atlasphp\Atlas\Events\Concerns\CapsBroadcastPayload;
 use Illuminate\Broadcasting\Channel;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Broadcasting\Channel;
  */
 class ExecutionFailed extends ExecutionEvent
 {
+    use CapsBroadcastPayload;
+
     public function __construct(
         ?int $executionId,
         public readonly string $error,
@@ -26,5 +29,16 @@ class ExecutionFailed extends ExecutionEvent
     public function broadcastAs(): string
     {
         return 'ExecutionFailed';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            ...parent::broadcastWith(),
+            'error' => $this->capBroadcastPayload($this->error),
+        ];
     }
 }

--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -164,8 +164,8 @@ class StreamResponse implements IteratorAggregate, Responsable
                 event(new StreamCompleted(
                     channel: $this->broadcastChannel,
                     text: $this->accumulatedText,
-                    usage: null,
-                    finishReason: null,
+                    usage: $this->serializeUsage(),
+                    finishReason: $this->finishReason,
                     error: $e->getMessage(),
                 ));
             }

--- a/tests/Feature/Voice/VoiceRouteMiddlewareTest.php
+++ b/tests/Feature/Voice/VoiceRouteMiddlewareTest.php
@@ -48,8 +48,8 @@ it('registers voice routes with no middleware by default', function () {
     expect($route->middleware())->toBe([]);
 });
 
-it('applies configured voice_route_middleware to the voice routes', function () {
-    config()->set('atlas.persistence.voice_route_middleware', ['auth:sanctum', 'throttle:60,1']);
+it('applies configured voice.route_middleware to the voice routes', function () {
+    config()->set('atlas.voice.route_middleware', ['auth:sanctum', 'throttle:60,1']);
 
     reregisterVoiceRoutes($this->app);
 
@@ -60,14 +60,39 @@ it('applies configured voice_route_middleware to the voice routes', function () 
     expect($route->middleware())->toContain('throttle:60,1');
 });
 
-it('reads voice_route_middleware onto AtlasConfig', function () {
-    config()->set('atlas.persistence.voice_route_middleware', ['auth:sanctum']);
+it('reads voice.route_middleware onto AtlasConfig', function () {
+    config()->set('atlas.voice.route_middleware', ['auth:sanctum']);
 
     $config = AtlasConfig::refresh();
 
     expect($config->voiceRouteMiddleware)->toBe(['auth:sanctum']);
 });
 
-it('defaults voice_route_middleware to an empty array', function () {
+it('defaults voice.route_middleware to an empty array', function () {
     expect(app(AtlasConfig::class)->voiceRouteMiddleware)->toBe([]);
+});
+
+// ─── Backward compatibility with the legacy persistence.voice_* keys ────────
+
+it('falls back to legacy persistence.voice_route_prefix and voice_session_ttl', function () {
+    config()->set('atlas.voice', null);
+    config()->set('atlas.persistence.voice_route_prefix', 'legacy-prefix');
+    config()->set('atlas.persistence.voice_session_ttl', 99);
+
+    $config = AtlasConfig::refresh();
+
+    expect($config->voiceRoutePrefix)->toBe('legacy-prefix')
+        ->and($config->voiceSessionTtl)->toBe(99);
+});
+
+it('prefers the new voice block over the legacy persistence keys', function () {
+    config()->set('atlas.voice.route_prefix', 'new-prefix');
+    config()->set('atlas.voice.session_ttl', 42);
+    config()->set('atlas.persistence.voice_route_prefix', 'legacy-prefix');
+    config()->set('atlas.persistence.voice_session_ttl', 99);
+
+    $config = AtlasConfig::refresh();
+
+    expect($config->voiceRoutePrefix)->toBe('new-prefix')
+        ->and($config->voiceSessionTtl)->toBe(42);
 });

--- a/tests/Feature/Voice/VoiceRouteMiddlewareTest.php
+++ b/tests/Feature/Voice/VoiceRouteMiddlewareTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\AtlasServiceProvider;
+use Illuminate\Routing\Route as RoutingRoute;
+use Illuminate\Support\Facades\Route;
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Return the most recently registered voice tool route, or null.
+ */
+function voiceToolRoute(): ?RoutingRoute
+{
+    $match = null;
+
+    foreach (Route::getRoutes()->getRoutes() as $route) {
+        if ($route->uri() === 'atlas/voice/{sessionId}/tool') {
+            $match = $route;
+        }
+    }
+
+    return $match;
+}
+
+/**
+ * Re-run only the voice route registration with the current config.
+ * The app is already booted, so the booted() callback fires immediately.
+ */
+function reregisterVoiceRoutes(object $app): void
+{
+    AtlasConfig::refresh();
+
+    $provider = new AtlasServiceProvider($app);
+    $method = new ReflectionMethod($provider, 'registerVoiceRoutes');
+    $method->setAccessible(true);
+    $method->invoke($provider);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+it('registers voice routes with no middleware by default', function () {
+    $route = voiceToolRoute();
+
+    expect($route)->not->toBeNull();
+    expect($route->middleware())->toBe([]);
+});
+
+it('applies configured voice_route_middleware to the voice routes', function () {
+    config()->set('atlas.persistence.voice_route_middleware', ['auth:sanctum', 'throttle:60,1']);
+
+    reregisterVoiceRoutes($this->app);
+
+    $route = voiceToolRoute();
+
+    expect($route)->not->toBeNull();
+    expect($route->middleware())->toContain('auth:sanctum');
+    expect($route->middleware())->toContain('throttle:60,1');
+});
+
+it('reads voice_route_middleware onto AtlasConfig', function () {
+    config()->set('atlas.persistence.voice_route_middleware', ['auth:sanctum']);
+
+    $config = AtlasConfig::refresh();
+
+    expect($config->voiceRouteMiddleware)->toBe(['auth:sanctum']);
+});
+
+it('defaults voice_route_middleware to an empty array', function () {
+    expect(app(AtlasConfig::class)->voiceRouteMiddleware)->toBe([]);
+});

--- a/tests/Unit/AtlasServiceProviderTest.php
+++ b/tests/Unit/AtlasServiceProviderTest.php
@@ -250,6 +250,6 @@ it('resolves elevenlabs factory to ElevenLabsDriver', function () {
 
 // ─── Voice Routes ───────────────────────────────────────────────────────
 
-it('uses voice_route_prefix for voice route registration', function () {
-    expect(config('atlas.persistence.voice_route_prefix', 'atlas'))->toBe('atlas');
+it('uses voice.route_prefix for voice route registration', function () {
+    expect(config('atlas.voice.route_prefix', 'atlas'))->toBe('atlas');
 });

--- a/tests/Unit/Events/ExecutionEventsTest.php
+++ b/tests/Unit/Events/ExecutionEventsTest.php
@@ -324,3 +324,52 @@ it('ExecutionFailed passes context through to parent', function () {
         ->and($event->agentKey)->toBe('parent-agent')
         ->and($event->traceId)->toBe('trace-005');
 });
+
+// ─── broadcastWith payload ───────────────────────────────────────────────
+
+it('ExecutionCompleted broadcastWith returns the common fields and omits the channel', function () {
+    $event = new ExecutionCompleted(
+        executionId: 9,
+        channel: new PrivateChannel('test'),
+        provider: 'openai',
+        model: 'gpt-4o',
+        agentKey: 'agent',
+        traceId: 'trace-009',
+    );
+
+    expect($event->broadcastWith())->toBe([
+        'executionId' => 9,
+        'provider' => 'openai',
+        'model' => 'gpt-4o',
+        'agentKey' => 'agent',
+        'traceId' => 'trace-009',
+    ]);
+});
+
+it('ExecutionFailed broadcastWith includes the error alongside the common fields', function () {
+    $event = new ExecutionFailed(
+        executionId: 2,
+        error: 'short error',
+        provider: 'anthropic',
+        model: 'claude-4',
+        agentKey: 'k',
+        traceId: 't',
+    );
+
+    expect($event->broadcastWith())->toBe([
+        'executionId' => 2,
+        'provider' => 'anthropic',
+        'model' => 'claude-4',
+        'agentKey' => 'k',
+        'traceId' => 't',
+        'error' => 'short error',
+    ]);
+});
+
+it('ExecutionFailed broadcastWith caps the error to the configured byte limit', function () {
+    config()->set('atlas.broadcast.max_tool_payload_length', 16);
+
+    $event = new ExecutionFailed(executionId: 1, error: str_repeat('x', 100));
+
+    expect(strlen($event->broadcastWith()['error']))->toBe(16);
+});

--- a/tests/Unit/Streaming/StreamResponseBroadcastTest.php
+++ b/tests/Unit/Streaming/StreamResponseBroadcastTest.php
@@ -185,3 +185,32 @@ it('broadcasts StreamCompleted with error on exception', function () {
             && $e->usage === null;
     });
 });
+
+it('broadcasts StreamCompleted with accumulated usage and finish reason on mid-stream error', function () {
+    Event::fake();
+
+    $chunks = (function () {
+        yield new StreamChunk(type: ChunkType::Text, text: 'partial');
+        yield new StreamChunk(type: ChunkType::Done, usage: new Usage(7, 3), finishReason: FinishReason::Stop);
+        throw new RuntimeException('stream broke after usage');
+    })();
+
+    $stream = new StreamResponse($chunks);
+    $stream->broadcastOn(new Channel('test-error-usage'));
+
+    try {
+        foreach ($stream as $chunk) {
+            // consume
+        }
+    } catch (RuntimeException) {
+        // expected
+    }
+
+    Event::assertDispatched(StreamCompleted::class, function ($e) {
+        return $e->error === 'stream broke after usage'
+            && $e->text === 'partial'
+            && $e->usage['input_tokens'] === 7
+            && $e->usage['output_tokens'] === 3
+            && $e->finishReason === FinishReason::Stop;
+    });
+});


### PR DESCRIPTION
This pull request introduces new configuration options to secure the voice tool, transcript, and close routes, improves error reporting and payload handling for streaming and execution failures, and updates related documentation and tests. The main changes are grouped into voice route security, broadcast payload handling, and stream event improvements.

**Voice Route Security**

* Added a new `voice_route_middleware` configuration option in `atlas.php` and `AtlasConfig` to allow specifying HTTP middleware (such as authentication and rate limiting) for voice tool, transcript, and close routes, which are public by default. This ensures these sensitive routes can be secured in production. [[1]](diffhunk://#diff-0547b8abb0d1b756bd782300755c54f2f74633554fa48ae70413cc0cef6157a9R405-R411) [[2]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR60-R61) [[3]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR148) [[4]](diffhunk://#diff-cf4ffc132a875ab1f4b5ed14f8226bef98408f2476a2674c48d1998194550147L165-R168)
* Updated documentation and changelog to highlight the importance of protecting voice routes and to show how to configure the new middleware option. [[1]](diffhunk://#diff-d28a8784fbe905649d0446f184017191c85933850396429d50668c08e37d8383L69-R87) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR17)
* Added feature tests to verify the correct registration and configuration of voice route middleware.

**Broadcast Payload Handling**

* Introduced a `broadcastWith` method for execution events to explicitly control the shape of broadcasted data and prevent accidental serialization of non-public fields. [[1]](diffhunk://#diff-770ff56eea0273deff6d41c4e0834b827d85b672a0d8215c94c1685d15ab2f21R39-R55) [[2]](diffhunk://#diff-5696ec2960ff80ac0868225ddb0db78ddb7ea2f85797a90854ac6d8189841777R7-R16) [[3]](diffhunk://#diff-5696ec2960ff80ac0868225ddb0db78ddb7ea2f85797a90854ac6d8189841777R33-R43)
* Updated the `ExecutionFailed` event to cap the broadcast error message to a configurable byte limit, preventing oversized payloads from breaking socket transports. [[1]](diffhunk://#diff-5696ec2960ff80ac0868225ddb0db78ddb7ea2f85797a90854ac6d8189841777R33-R43) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR34-R35) [[3]](diffhunk://#diff-ec805582268c139916013866671931df45a6d737ab07028e37d148c21d07fecfL50-R50)
* Added unit tests to verify the new broadcast payloads and error message capping.

**Stream Event Improvements**

* Modified stream error handling so that if a stream is interrupted, the accumulated token usage and finish reason are still broadcast, ensuring accurate cost tracking even on aborted streams. [[1]](diffhunk://#diff-590710071340bf55c87640f2e771f9ca43cb501fcdb5f5acc31254e54338402cL167-R168) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR34-R35) [[3]](diffhunk://#diff-db88eb24a2c08fc57eb427117d043649ce9c6647f019dee2a7cbc8c19a35ca22R188-R216)

**Documentation Updates**

* Updated the events documentation to reflect the new capped payload behavior and the addition of an eighth event group. [[1]](diffhunk://#diff-ec805582268c139916013866671931df45a6d737ab07028e37d148c21d07fecfL11-R11) [[2]](diffhunk://#diff-ec805582268c139916013866671931df45a6d737ab07028e37d148c21d07fecfL50-R50)

These changes collectively improve the security, reliability, and observability of the voice integration and event broadcasting subsystems.