### PR TITLE
Implement StrictSchema normalization for strict mode compliance

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Error handling & resilience (all 4 providers): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
+**Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
 
 Reproduce:
 - Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
@@ -157,6 +157,25 @@ Reproduce: `cd sandbox` and run an inline script booting `bootstrap.php` (see th
 
 **Mid-stream provider errors** (a `data: {"error":…}` / `event: error` arriving on a 200 stream) are detected and thrown as a model-carrying `ProviderException` — verified by unit tests with fixture SSE streams (can't be triggered on demand from a healthy provider).
 
+## Error & request context tracing (live, 2026-06-10)
+
+Validates the observability additions end-to-end against **real provider APIs** via
+`sandbox/test-error-context-live.php`. **56/56 live checks passed** across OpenAI / Anthropic / Google / xAI.
+
+Per provider, two phases:
+
+1. **Successful call** — `ProviderRequestStarted` + `ProviderRequestCompleted` fire carrying the **same** `correlationId` and the correct `provider` + `model`.
+2. **Bad-key call** — the provider's **real** error message surfaces on `ProviderException::providerMessage`, `responseBody()` returns the decoded error, and `ProviderRequestFailed` carries `provider` + `correlationId`.
+
+| Provider  | Bad-key status | Atlas exception | Provider message (live) |
+|-----------|:--------------:|-----------------|-------------------------|
+| OpenAI    | 401 | `AuthenticationException` | "Incorrect API key provided: sk-…. You can find your API key at …" |
+| Anthropic | 401 | `AuthenticationException` | "invalid x-api-key" |
+| Google    | 400 | `InvalidRequestException` | "API key not valid. Please pass a valid API key." |
+| xAI       | 400 | `InvalidRequestException` | "Incorrect API key provided: sk***ef. …" |
+
+> Google/xAI classify a bad key as **400** (not 401) — those already carried `providerMessage`; this release specifically restored the **401** auth message for OpenAI/Anthropic, which previously showed a generic "Authentication failed" with an empty `providerMessage`.
+
 ## Per-provider results
 
 | Provider   | Live suite                 | Notes |
@@ -173,4 +192,4 @@ Reproduce: `cd sandbox` and run an inline script booting `bootstrap.php` (see th
 
 ## Package checks (2026-06-10)
 
-`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 3033 Pest tests ✓** (incl. the full error-handling suite: connection/streaming/retry, provider error-message extraction, exception hierarchy + typed errors, and the queue fail-fast lifecycle).
+`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 3148 Pest tests ✓** (incl. the full error-handling suite plus the new observability coverage: auth/authz provider messages, `responseBody()`/`rawResponse()`, transport-event correlation id + provider/model, and the `ProviderRequestContext` value object).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Fixed
 
+- Structured output via the `Schema` builder now works on OpenAI, xAI, and OpenAI-compatible providers (Ollama, LM Studio) — previously these 400'd because strict JSON-schema requirements (`additionalProperties: false`, all keys required, optionals as nullable) weren't applied. Optional fields now round-trip as nullable.
 - Rate limits and transient server errors now retry automatically.
 - Per-call and global timeouts are honored, including on queued requests.
 - Network failures and mid-stream errors now surface as exceptions instead of returning truncated, successful-looking responses.

--- a/sandbox/test-lmstudio-provider.php
+++ b/sandbox/test-lmstudio-provider.php
@@ -197,16 +197,13 @@ test('stream yields text chunks and Done', function () use ($model) {
 
 echo "\n\n── Structured Output";
 
-test('json_schema structured response', function () use ($model) {
-    $schema = new Schema('person', 'A person', [
-        'type' => 'object',
-        'properties' => [
-            'name' => ['type' => 'string'],
-            'age' => ['type' => 'integer'],
-        ],
-        'required' => ['name', 'age'],
-        'additionalProperties' => false,
-    ]);
+// Built via the fluent Schema builder (the documented public API) — exercises the
+// builder -> strict-mode normalization path (Chat Completions uses strict json_schema).
+test('json_schema structured response (builder)', function () use ($model) {
+    $schema = Schema::object('person', 'A person')
+        ->string('name', 'Full name')
+        ->integer('age', 'Age in years')
+        ->build();
 
     $r = Atlas::text('lmstudio', $model)
         ->message('Create a person named Bob who is 42.')

--- a/sandbox/test-openai-provider.php
+++ b/sandbox/test-openai-provider.php
@@ -243,17 +243,14 @@ test('stream accumulates full text', function () {
 
 echo "\n\n── Structured Output";
 
-test('json_schema structured response', function () {
-    $schema = new Schema('person', 'A person', [
-        'type' => 'object',
-        'properties' => [
-            'name' => ['type' => 'string'],
-            'age' => ['type' => 'integer'],
-            'hobbies' => ['type' => 'array', 'items' => ['type' => 'string']],
-        ],
-        'required' => ['name', 'age', 'hobbies'],
-        'additionalProperties' => false,
-    ]);
+// Built via the fluent Schema builder (the documented public API) — exercises the
+// builder -> OpenAI strict-mode normalization path that real consumers use.
+test('json_schema structured response (builder)', function () {
+    $schema = Schema::object('person', 'A person')
+        ->string('name', 'Full name')
+        ->integer('age', 'Age in years')
+        ->stringArray('hobbies', 'List of hobbies')
+        ->build();
 
     $r = Atlas::text(Provider::OpenAI, 'gpt-4o-mini')
         ->message('Create a person named Bob who is 42 and likes chess and hiking.')
@@ -269,24 +266,14 @@ test('json_schema structured response', function () {
     assert_true($r->finishReason === FinishReason::Stop, 'Should finish with Stop');
 });
 
-test('nested structured schema', function () {
-    $schema = new Schema('company', 'A company', [
-        'type' => 'object',
-        'properties' => [
-            'name' => ['type' => 'string'],
-            'address' => [
-                'type' => 'object',
-                'properties' => [
-                    'city' => ['type' => 'string'],
-                    'country' => ['type' => 'string'],
-                ],
-                'required' => ['city', 'country'],
-                'additionalProperties' => false,
-            ],
-        ],
-        'required' => ['name', 'address'],
-        'additionalProperties' => false,
-    ]);
+test('nested structured schema (builder)', function () {
+    $schema = Schema::object('company', 'A company')
+        ->string('name', 'Company name')
+        ->object('address', 'Company address', function ($obj) {
+            $obj->string('city', 'City')
+                ->string('country', 'Country');
+        })
+        ->build();
 
     $r = Atlas::text(Provider::OpenAI, 'gpt-4o-mini')
         ->message('Apple Inc is in Cupertino, USA.')
@@ -296,6 +283,25 @@ test('nested structured schema', function () {
     assert_true($r->structured['name'] === 'Apple Inc', 'Company should be Apple Inc');
     assert_true($r->structured['address']['city'] === 'Cupertino', 'City should be Cupertino');
     assert_true($r->structured['address']['country'] === 'USA', 'Country should be USA');
+});
+
+// Optional field via ->optional(): under OpenAI strict mode this must round-trip as a
+// nullable key that is still present in `required`. Before the strict-schema fix this
+// 400'd ("'additionalProperties' is required to be supplied and to be false").
+test('structured schema with optional field (builder)', function () {
+    $schema = Schema::object('contact', 'A contact')
+        ->string('name', 'Full name')
+        ->string('phone', 'Phone number')->optional()
+        ->build();
+
+    $r = Atlas::text(Provider::OpenAI, 'gpt-4o-mini')
+        ->message('The contact is named Dana. No phone number was provided.')
+        ->withSchema($schema)
+        ->asStructured();
+
+    assert_true($r->structured['name'] === 'Dana', "Name should be Dana, got: {$r->structured['name']}");
+    assert_true(array_key_exists('phone', $r->structured), 'Optional phone key should be present');
+    assert_true($r->structured['phone'] === null, 'Phone should be null when omitted');
 });
 
 // ── Tool Calling ─────────────────────────────────────────────────────────────

--- a/sandbox/test-xai-provider.php
+++ b/sandbox/test-xai-provider.php
@@ -214,20 +214,19 @@ test('stream accumulates full text', function () {
 
 echo "\n\n── Structured Output";
 
-test('json_schema structured response', function () {
-    $schema = new Schema('person', 'A person', [
-        'type' => 'object',
-        'properties' => [
-            'name' => ['type' => 'string'],
-            'age' => ['type' => 'integer'],
-            'hobbies' => ['type' => 'array', 'items' => ['type' => 'string']],
-        ],
-        'required' => ['name', 'age', 'hobbies'],
-        'additionalProperties' => false,
-    ]);
+// Built via the fluent Schema builder (the documented public API), including an
+// optional field — exercises the builder -> strict-mode normalization path (xAI
+// inherits OpenAI's strict json_schema handling).
+test('json_schema structured response (builder)', function () {
+    $schema = Schema::object('person', 'A person')
+        ->string('name', 'Full name')
+        ->integer('age', 'Age in years')
+        ->stringArray('hobbies', 'List of hobbies')
+        ->string('nickname', 'Optional nickname')->optional()
+        ->build();
 
     $r = Atlas::text(Provider::xAI, 'grok-3-mini')
-        ->message('Create a person named Bob who is 42 and likes chess and hiking.')
+        ->message('Create a person named Bob who is 42 and likes chess and hiking. No nickname.')
         ->withSchema($schema)
         ->asStructured();
 
@@ -236,6 +235,7 @@ test('json_schema structured response', function () {
     assert_true($r->structured['age'] === 42, "Age should be 42, got: {$r->structured['age']}");
     assert_true(is_array($r->structured['hobbies']), 'Hobbies should be array');
     assert_true(count($r->structured['hobbies']) >= 2, 'Should have at least 2 hobbies');
+    assert_true(array_key_exists('nickname', $r->structured), 'Optional nickname key should be present');
 });
 
 // ── Tool Calling ─────────────────────────────────────────────────────────────

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -21,6 +21,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Schema\StrictSchema;
 use Generator;
 
 /**
@@ -84,7 +85,7 @@ class Text implements TextHandler
                 'json_schema' => [
                     'name' => $request->schema->name(),
                     'strict' => true,
-                    'schema' => $request->schema->toArray(),
+                    'schema' => StrictSchema::normalize($request->schema->toArray()),
                 ],
             ];
         }

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -21,6 +21,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Schema\StrictSchema;
 use Generator;
 
 /**
@@ -85,7 +86,7 @@ class Text implements TextHandler
                 'format' => [
                     'type' => 'json_schema',
                     'name' => $request->schema->name(),
-                    'schema' => $request->schema->toArray(),
+                    'schema' => StrictSchema::normalize($request->schema->toArray()),
                     'strict' => true,
                 ],
             ];

--- a/src/Schema/StrictSchema.php
+++ b/src/Schema/StrictSchema.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Schema;
+
+/**
+ * Normalizes a JSON Schema array into the strict form required by OpenAI's
+ * structured-output mode (and OpenAI-compatible providers such as xAI,
+ * Ollama, and LM Studio).
+ *
+ * OpenAI strict `json_schema` requires, on every object node:
+ *   - `additionalProperties: false`
+ *   - every property listed in `required`
+ *
+ * Optional fields (present in `properties` but absent from `required`) may not
+ * simply be omitted from `required` under strict mode; the documented pattern
+ * is to keep them required and make their type nullable. This transformer
+ * applies both rules recursively while preserving the builder's `optional()`
+ * semantics.
+ *
+ * Pure and idempotent: re-normalizing an already-strict schema is a no-op,
+ * so hand-written schemas that already satisfy strict mode pass through
+ * unchanged.
+ */
+final class StrictSchema
+{
+    /**
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    public static function normalize(array $schema): array
+    {
+        return self::normalizeNode($schema);
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     * @return array<string, mixed>
+     */
+    private static function normalizeNode(array $node): array
+    {
+        if (self::isObjectNode($node)) {
+            $node = self::normalizeObject($node);
+        }
+
+        if (isset($node['items']) && is_array($node['items'])) {
+            $node['items'] = self::normalizeNode($node['items']);
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     * @return array<string, mixed>
+     */
+    private static function normalizeObject(array $node): array
+    {
+        $properties = is_array($node['properties'] ?? null) ? $node['properties'] : [];
+        $originalRequired = is_array($node['required'] ?? null) ? $node['required'] : [];
+
+        foreach ($properties as $key => $propSchema) {
+            if (! is_array($propSchema)) {
+                continue;
+            }
+
+            $propSchema = self::normalizeNode($propSchema);
+
+            if (! in_array($key, $originalRequired, true)) {
+                $propSchema = self::makeNullable($propSchema);
+            }
+
+            $properties[$key] = $propSchema;
+        }
+
+        $node['properties'] = $properties;
+        $node['required'] = array_keys($properties);
+        $node['additionalProperties'] = false;
+
+        return $node;
+    }
+
+    /**
+     * Express an optional field as a nullable type union, the strict-mode
+     * equivalent of omitting it from `required`.
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array<string, mixed>
+     */
+    private static function makeNullable(array $schema): array
+    {
+        $type = $schema['type'] ?? null;
+
+        if (is_string($type) && $type !== 'null') {
+            $schema['type'] = [$type, 'null'];
+        } elseif (is_array($type) && ! in_array('null', $type, true)) {
+            $type[] = 'null';
+            $schema['type'] = $type;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private static function isObjectNode(array $node): bool
+    {
+        return ($node['type'] ?? null) === 'object' || isset($node['properties']);
+    }
+}

--- a/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
@@ -245,6 +245,46 @@ it('sends structured request with json_schema response_format', function () {
     });
 });
 
+it('normalizes a builder schema to strict mode in response_format', function () {
+    Http::fake([
+        'localhost:11434/v1/chat/completions' => Http::response([
+            'choices' => [
+                ['message' => ['content' => '{"name":"test","phone":null}', 'role' => 'assistant'], 'finish_reason' => 'stop'],
+            ],
+            'usage' => ['prompt_tokens' => 10, 'completion_tokens' => 5],
+        ]),
+    ]);
+
+    $schema = Schema::object('output', 'Output data')
+        ->string('name', 'Name')
+        ->string('phone', 'Phone')->optional()
+        ->build();
+
+    $request = new TextRequest(
+        model: 'llama3.1',
+        instructions: null,
+        message: 'Give me data',
+        messageMedia: [],
+        messages: [],
+        maxTokens: null,
+        temperature: null,
+        schema: $schema,
+        tools: [],
+        providerTools: [],
+        providerOptions: [],
+    );
+
+    makeChatCompletionsDriver()->structured($request);
+
+    Http::assertSent(function ($r) {
+        $sent = $r->data()['response_format']['json_schema']['schema'];
+
+        return $sent['additionalProperties'] === false
+            && $sent['required'] === ['name', 'phone']
+            && $sent['properties']['phone']['type'] === ['string', 'null'];
+    });
+});
+
 it('omits Authorization header when api key is empty', function () {
     $driver = new ChatCompletionsDriver(
         config: new ProviderConfig(

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -215,6 +215,32 @@ it('sends structured request with text.format', function () {
     });
 });
 
+it('normalizes a builder schema to OpenAI strict mode (additionalProperties + all required + nullable optionals)', function () {
+    Http::fake([
+        'api.openai.com/v1/responses' => Http::response([
+            'status' => 'completed',
+            'output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => '{"name":"John","phone":null}']]]],
+            'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+        ]),
+    ]);
+
+    $schema = Schema::object('person', 'A person')
+        ->string('name', 'Name')
+        ->string('phone', 'Phone')->optional()
+        ->build();
+
+    makeTextHandler()->structured(makeOpenAiTextRequest(['schema' => $schema]));
+
+    Http::assertSent(function ($request) {
+        $sent = $request['text']['format']['schema'];
+
+        return $sent['additionalProperties'] === false
+            && $sent['required'] === ['name', 'phone']
+            && $sent['properties']['name']['type'] === 'string'
+            && $sent['properties']['phone']['type'] === ['string', 'null'];
+    });
+});
+
 it('a mid-stream error while streaming throws a ProviderException carrying the model', function () {
     Http::fake([
         'api.openai.com/v1/responses' => Http::response(

--- a/tests/Unit/Schema/StrictSchemaTest.php
+++ b/tests/Unit/Schema/StrictSchemaTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Schema\StrictSchema;
+
+it('adds additionalProperties:false and requires all keys on a flat object', function () {
+    $schema = Schema::object('person', 'A person')
+        ->string('name', 'Name')
+        ->integer('age', 'Age')
+        ->build()
+        ->toArray();
+
+    $normalized = StrictSchema::normalize($schema);
+
+    expect($normalized['additionalProperties'])->toBeFalse();
+    expect($normalized['required'])->toBe(['name', 'age']);
+});
+
+it('makes optional fields nullable but still required', function () {
+    $schema = Schema::object('contact', 'Contact')
+        ->string('name', 'Name')
+        ->string('phone', 'Phone')->optional()
+        ->build()
+        ->toArray();
+
+    $normalized = StrictSchema::normalize($schema);
+
+    expect($normalized['required'])->toBe(['name', 'phone']);
+    expect($normalized['properties']['name']['type'])->toBe('string');
+    expect($normalized['properties']['phone']['type'])->toBe(['string', 'null']);
+});
+
+it('normalizes nested objects recursively', function () {
+    $schema = Schema::object('order', 'Order')
+        ->string('id', 'ID')
+        ->object('customer', 'Customer', function ($obj) {
+            $obj->string('name', 'Name')
+                ->string('email', 'Email')->optional();
+        })
+        ->build()
+        ->toArray();
+
+    $normalized = StrictSchema::normalize($schema);
+    $customer = $normalized['properties']['customer'];
+
+    expect($customer['additionalProperties'])->toBeFalse();
+    expect($customer['required'])->toBe(['name', 'email']);
+    expect($customer['properties']['email']['type'])->toBe(['string', 'null']);
+});
+
+it('normalizes object items inside arrays', function () {
+    $schema = Schema::object('cart', 'Cart')
+        ->array('items', 'Line items', function ($builder) {
+            $builder->string('sku', 'SKU')
+                ->integer('qty', 'Quantity');
+        })
+        ->build()
+        ->toArray();
+
+    $normalized = StrictSchema::normalize($schema);
+    $items = $normalized['properties']['items']['items'];
+
+    expect($items['additionalProperties'])->toBeFalse();
+    expect($items['required'])->toBe(['sku', 'qty']);
+});
+
+it('leaves scalar arrays untouched aside from requiring the parent key', function () {
+    $schema = Schema::object('post', 'Post')
+        ->stringArray('tags', 'Tags')
+        ->build()
+        ->toArray();
+
+    $normalized = StrictSchema::normalize($schema);
+
+    expect($normalized['required'])->toBe(['tags']);
+    expect($normalized['properties']['tags']['type'])->toBe('array');
+    expect($normalized['properties']['tags']['items']['type'])->toBe('string');
+});
+
+it('is idempotent on an already-strict schema', function () {
+    $raw = [
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'name' => ['type' => 'string'],
+            'phone' => ['type' => ['string', 'null']],
+        ],
+        'required' => ['name', 'phone'],
+    ];
+
+    $once = StrictSchema::normalize($raw);
+    $twice = StrictSchema::normalize($once);
+
+    expect($once)->toBe($twice);
+    expect($once['properties']['phone']['type'])->toBe(['string', 'null']);
+    expect($once['required'])->toBe(['name', 'phone']);
+});
+
+it('does not duplicate null when an optional field is already nullable', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => [
+            'phone' => ['type' => ['string', 'null']],
+        ],
+    ];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['properties']['phone']['type'])->toBe(['string', 'null']);
+});
+
+it('leaves a scalar node without type:object or properties untouched', function () {
+    $raw = ['type' => 'string', 'description' => 'just a string'];
+
+    expect(StrictSchema::normalize($raw))->toBe($raw);
+});
+
+it('treats a node with properties but no type key as an object', function () {
+    $raw = ['properties' => ['x' => ['type' => 'string']]];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['additionalProperties'])->toBeFalse();
+    expect($normalized['required'])->toBe(['x']);
+});
+
+it('handles an object node that has no properties key', function () {
+    $raw = ['type' => 'object'];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['additionalProperties'])->toBeFalse();
+    expect($normalized['required'])->toBe([]);
+    expect($normalized['properties'])->toBe([]);
+});
+
+it('ignores a non-array required value', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => ['x' => ['type' => 'string']],
+        'required' => 'not-an-array',
+    ];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    // required treated as empty -> x is optional -> nullable, and required rebuilt.
+    expect($normalized['required'])->toBe(['x']);
+    expect($normalized['properties']['x']['type'])->toBe(['string', 'null']);
+});
+
+it('skips non-array property entries while still requiring their key', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => [
+            'bad' => 'not-an-array',
+            'good' => ['type' => 'string'],
+        ],
+    ];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['properties']['bad'])->toBe('not-an-array');
+    expect($normalized['properties']['good']['type'])->toBe(['string', 'null']);
+    expect($normalized['required'])->toBe(['bad', 'good']);
+});
+
+it('leaves a non-array items value untouched', function () {
+    $raw = ['type' => 'array', 'items' => 'not-an-array'];
+
+    expect(StrictSchema::normalize($raw))->toBe($raw);
+});
+
+it('appends null to an optional field whose type is already a union', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => [
+            'x' => ['type' => ['string', 'integer']],
+        ],
+    ];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['properties']['x']['type'])->toBe(['string', 'integer', 'null']);
+});
+
+it('leaves an optional field with no type key unchanged aside from requiring it', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => [
+            'x' => ['description' => 'no type'],
+        ],
+    ];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['properties']['x'])->toBe(['description' => 'no type']);
+    expect($normalized['required'])->toBe(['x']);
+});
+
+it('does not alter an optional field already typed as the null string', function () {
+    $raw = [
+        'type' => 'object',
+        'properties' => [
+            'x' => ['type' => 'null'],
+        ],
+    ];
+
+    $normalized = StrictSchema::normalize($raw);
+
+    expect($normalized['properties']['x']['type'])->toBe('null');
+    expect($normalized['required'])->toBe(['x']);
+});


### PR DESCRIPTION
This pull request introduces strict JSON Schema normalization for structured output on OpenAI, xAI, and OpenAI-compatible providers (Ollama, LM Studio). It ensures that schemas built via the fluent `Schema` builder are transformed into the strict format required by these providers, fixing previous issues where requests would fail with 400 errors due to missing strictness (such as `additionalProperties: false` and proper handling of optional fields as nullable). The changes are validated by new and updated tests, and documentation is updated to reflect improved observability and test coverage.

**Structured Output Strictness and Schema Normalization:**

* Added a new `StrictSchema` utility (`src/Schema/StrictSchema.php`) that recursively normalizes builder-generated schemas to OpenAI's strict requirements: all properties listed as required, `additionalProperties: false`, and optional fields made nullable. This ensures compatibility with OpenAI, xAI, Ollama, and LM Studio structured output modes.
* Updated `Text` handlers for OpenAI and ChatCompletions to use `StrictSchema::normalize()` before sending schemas, guaranteeing strict compliance for all structured output requests. [[1]](diffhunk://#diff-188df3cd767324e833afa208fa5c01eb7a91b1430a2064a9a86bb74dc354e804R24) [[2]](diffhunk://#diff-188df3cd767324e833afa208fa5c01eb7a91b1430a2064a9a86bb74dc354e804L87-R88) [[3]](diffhunk://#diff-3ca5b54ee8f32fd6320a7c82efcc732bfa6f9e5720f60658cdaef7f3eda07822R24) [[4]](diffhunk://#diff-3ca5b54ee8f32fd6320a7c82efcc732bfa6f9e5720f60658cdaef7f3eda07822L88-R89)

**Testing and Validation:**

* Replaced legacy array-based schema definitions in provider integration tests with the fluent `Schema` builder, and added new test cases for optional fields and nested objects. This verifies that the normalization logic works end-to-end and that optional fields round-trip as nullable. [[1]](diffhunk://#diff-72b25d7cac8b33f05ef5156f5be6eb0b9b9ca8181664a9a6691f8fcecbc717eaL200-R206) [[2]](diffhunk://#diff-ef0c6e25c9bad02ae4c06068c3d8355f8a1f7c316b75684318bec720bca33c48L246-R253) [[3]](diffhunk://#diff-ef0c6e25c9bad02ae4c06068c3d8355f8a1f7c316b75684318bec720bca33c48L272-R276) [[4]](diffhunk://#diff-ef0c6e25c9bad02ae4c06068c3d8355f8a1f7c316b75684318bec720bca33c48R288-R306) [[5]](diffhunk://#diff-c4228887d649959bb851958c13819d93bf3a8d99a4766690f3c47650588fa21dL217-R229) [[6]](diffhunk://#diff-c4228887d649959bb851958c13819d93bf3a8d99a4766690f3c47650588fa21dR238)
* Added unit tests to ensure that schemas sent to providers are normalized to strict mode, checking for `additionalProperties: false`, all properties in `required`, and nullable optionals. [[1]](diffhunk://#diff-9ae13d5456009f04b94cf5c36a15cca9796a6ec67675f5587391fd89eb9a13d1R248-R287) [[2]](diffhunk://#diff-6840fc88938b5d177802fc856e27b0a821d0cca4672a8cdfa8a79cc957de860cR218-R243)

**Documentation and Audit Updates:**

* Updated the `CHANGELOG.md` to note the fix for structured output strictness and optional field handling.
* Expanded `AUDIT.md` to document new observability coverage, including error and request context tracing, and updated test counts to reflect the additional coverage. [[1]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L7-R7) [[2]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688R160-R178) [[3]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L176-R195)