### PR TITLE
Validate embedding dimensions and improve batch alignment

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
+**Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Structured output strict-mode (builder, live OpenAI/Google/Anthropic): 2026-06-10** · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
 
 Reproduce:
 - Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
@@ -125,6 +125,46 @@ Provider-normalized `tool_choice` verified end-to-end through Atlas (`sandbox/te
 
 **Specific named tool** (`->toolChoice(ToolChoice::tool('log_mood'))`) verified live on **all four providers**: with two tools available (`get_time` + `log_mood`), the forced tool is the one that opens the turn (not the other) — proving the choice targets the named tool, not just "some tool". Result: **16/16 live checks passed** (4 forceTools + 4 specific-tool, ×2 assertions). (Note: forcing a tool on OpenAI requires a valid strict-mode function schema — Atlas tools with `parameters()` already emit `additionalProperties:false`.)
 
+## Structured output — strict-mode schema (live, 2026-06-10)
+
+Audited `Atlas::...->withSchema($schema)->asStructured()` across every structured-capable
+provider using the **fluent `Schema` builder** (the documented public API), not hand-written
+arrays. Verified end-to-end through Atlas with builder schemas covering flat fields, arrays,
+nested objects, and an `->optional()` field.
+
+**Bug found & fixed (this run):** builder schemas **400'd on OpenAI / xAI / OpenAI-compatible
+providers**. Those use OpenAI's strict `json_schema` (`strict: true`), which requires
+`additionalProperties: false` on every object and **all** keys in `required` — the builder
+emits neither, and `->optional()` produced keys absent from `required`. The prior sandbox
+tests passed only because they hand-wrote raw arrays with `additionalProperties:false` baked
+in, never exercising the builder. Fix: `Schema\StrictSchema::normalize()` applied in the
+OpenAI + ChatCompletions structured handlers (xAI inherits OpenAI) — recursively adds
+`additionalProperties:false`, lists all keys in `required`, and expresses optionals as a
+nullable type union. Google/Anthropic are intentionally **not** normalized (different
+mechanisms; Gemini's `responseSchema` 400s on `additionalProperties`).
+
+| Provider  | Model                     | Mechanism                         | Normalizer | Builder result (live)                              |
+|-----------|---------------------------|-----------------------------------|:----------:|----------------------------------------------------|
+| OpenAI    | gpt-4o-mini               | strict `json_schema`              | ✅ applied | ✅ flat, nested, optional (`phone: null`)           |
+| xAI       | (inherits OpenAI handler) | strict `json_schema`              | ✅ inherited | ⚠️ not re-run live this session; same code path + unit |
+| ChatCompletions (Ollama/LM Studio) | — | strict `json_schema`        | ✅ applied | ⚠️ unit only (no local server in run)              |
+| Google    | gemini-2.5-flash          | `responseSchema` (OpenAPI subset) | ❌ must not | ✅ flat, optional (key omitted: `{"name":"Dana"}`)  |
+| Anthropic | claude-sonnet-4-5         | forced tool `input_schema`        | ❌ not needed | ✅ flat, optional (key omitted: `{"name":"Dana"}`)  |
+
+Before the fix (live, same builder schema): `OpenAI 400 — Invalid schema for response_format
+'…': 'additionalProperties' is required to be supplied and to be false.` After: parsed object
+returned.
+
+**Provider semantics note (not a bug):** under OpenAI strict mode an optional field returns as
+explicit `null`; Google/Anthropic **omit** the key. Consumers should read optionals as
+`$data['key'] ?? null` regardless of provider.
+
+Unit coverage: `tests/Unit/Schema/StrictSchemaTest.php` (16 cases — happy + every negative
+branch) plus builder-based assertions in the OpenAI and ChatCompletions handler tests.
+Regression guard: sandbox structured cases (`test-openai-provider.php`,
+`test-xai-provider.php`, `test-lmstudio-provider.php`) now drive the builder incl.
+`->optional()`, so the next live sweep exercises the real path.
+
 ## Error handling & resilience (live, 2026-06-10)
 
 End-to-end verification of the error-handling/HTTP/retry/queue work against **real provider APIs**. Classification is driven purely by HTTP status code + exception type + structural JSON shape — never by parsing message words. **19/19 live checks passed** across OpenAI / Anthropic / Google / xAI.
@@ -192,4 +232,4 @@ Per provider, two phases:
 
 ## Package checks (2026-06-10)
 
-`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 3148 Pest tests ✓** (incl. the full error-handling suite plus the new observability coverage: auth/authz provider messages, `responseBody()`/`rawResponse()`, transport-event correlation id + provider/model, and the `ProviderRequestContext` value object).
+`composer check` — **Pint ✓ · PHPStan 0 errors ✓ · 3166 Pest tests ✓** (incl. the full error-handling suite, the observability coverage — auth/authz provider messages, `responseBody()`/`rawResponse()`, transport-event correlation id + provider/model, the `ProviderRequestContext` value object — and the structured-output strict-mode normalizer: `StrictSchema` unit coverage plus builder-based handler assertions).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - New typed exceptions for specific provider failures: `ConnectionException` (network), `ModelNotFoundException` (unknown model), `InvalidRequestException` (bad request), and `ServerException` (provider error).
 - xAI now supports the `CodeInterpreter` provider tool.
 - `voice.route_middleware` config to protect the voice routes, e.g. `['auth:sanctum', 'throttle:60,1']`.
-- `ProviderException::responseBody()` and `rawResponse()` expose the provider's raw error response for debugging, without digging through the previous exception.
-- Provider request events (`ProviderRequestStarted` / `Completed` / `Failed` / `Retrying`) now carry a `correlationId` (stable across retries) plus the `provider` and `model`, so you can correlate and attribute every HTTP call to a provider.
+- `ProviderException::responseBody()` and `rawResponse()` expose the provider's raw error response for debugging, without unwrapping the previous exception.
+- Provider request events (`ProviderRequestStarted` / `Completed` / `Failed` / `Retrying`) now carry a `correlationId` (stable across retries) plus `provider` and `model`, so you can trace and attribute every HTTP call.
 
 ### Changed
 
+- `atlas.embeddings.dimensions` is now sent to OpenAI's `text-embedding-3-small`/`-large` as the `dimensions` parameter, so reduced-dimension (Matryoshka) embeddings work straight from the config key. An explicit `dimensions` provider option still wins; models that don't support it (e.g. `text-embedding-ada-002`) are unaffected.
 - A single `catch (ProviderException)` now handles every provider failure. Catch a subclass for specific cases.
 - "Overloaded" provider responses are now retried, like rate limits.
 - Attaching an unsupported provider-native tool (e.g. xAI's X Search on OpenAI) now throws `UnsupportedFeatureException` up front instead of failing at the provider.
@@ -34,21 +35,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Queued requests fail fast on unrecoverable errors (bad key, bad request, unknown model) instead of burning every retry.
 - Per-request middleware (`->withMiddleware()`) now runs on queued image, audio, video, speech, embedding, moderation, rerank, music, and sound-effect requests — previously it was silently dropped on queue (text and agent requests were unaffected).
 - Queuing a request with a closure middleware now fails fast with a clear error instead of crashing the worker; use class-based middleware for queued requests.
+- Batch embeddings are realigned by the provider's `index` field rather than response order, so an out-of-order batch can't attach the wrong vector to a chunk.
+- A mismatched embedding dimension now fails at embed time with a clear message (actual vs configured size, plus the fix) instead of a cryptic database error at write time.
+- Changing config at runtime and calling `AtlasConfig::refresh()` now applies to facade calls (`Atlas::embed()`, etc.) — previously the facade held a stale manager built from the old config, so runtime provider/model/dimension changes were silently ignored on facade-driven paths (embeddings, chunking).
 - Google tool calls missing a function name now degrade gracefully instead of erroring mid-parse.
 - Listing models and voices now reports failures like any other call.
-- Error messages now carry the provider's real reason across all providers.
-- Authentication (401) and authorization (403) failures now include the provider's real error message (e.g. "Incorrect API key provided") instead of a generic message.
+- Error messages now carry the provider's real reason across all providers — including auth failures (401/403), which previously showed a generic message instead of the provider's text (e.g. "Incorrect API key provided").
 - Queued failures cap their broadcast error so it can't exceed the socket limit and drop the event.
 
 ### Migration
 
-No breaking changes for most users. Check these only if they apply:
+**No breaking changes for most users**. Check these only if they apply:
 
+- **You hard-coded a `vector(3072)` column for `text-embedding-3-large` but left `ATLAS_EMBEDDING_DIMENSIONS` at the 1536 default** — that key is now forwarded to the API, so set it to `3072` to match your column. (Sizing the column from `config('atlas.embeddings.dimensions')` already handles this.)
 - **You catch specific exceptions** (auth, rate-limit) before `ProviderException` — keep those `catch` blocks first; `ProviderException` now catches them too.
 - **You use `reasoning_timeout`** — removed. Set a longer per-call timeout instead.
 - **You read streamed responses** — mid-stream errors now throw. Wrap your read loop in try/catch.
 - **You attach provider-native tools to providers that don't support them** — now throws `UnsupportedFeatureException` up front.
-- **You set voice config in a published config file** — `voice_route_prefix` and `voice_session_ttl` moved to `voice.route_prefix` / `voice.session_ttl`. Old keys still work; migrate when convenient.
 
 ---
 

--- a/docs/modalities/embeddings.md
+++ b/docs/modalities/embeddings.md
@@ -396,7 +396,7 @@ All knobs live under `config('atlas.embeddings')`:
 
 ```php
 'embeddings' => [
-    'dimensions' => 1536,           // vector size — must match your embedding model
+    'dimensions' => 1536,           // vector size — sizes the storage column AND is sent to OpenAI text-embedding-3-* models
     'chunker' => MarkdownChunker::class,    // changing this does NOT re-chunk existing rows
     'chunk_size' => 512,            // soft cap per chunk, in tokens (chars/4 heuristic) — does NOT re-chunk on change
     'chunk_overlap' => 50,          // tokens of overlap between adjacent chunks — does NOT re-chunk on change
@@ -409,6 +409,10 @@ All knobs live under `config('atlas.embeddings')`:
 
 ::: warning Re-chunk after changing chunker, chunk_size, or chunk_overlap
 None of these settings dirty existing rows on their own. Old chunks remain in place until each record is edited. To rebuild every row of a class against the new settings, run `php artisan atlas:rechunk "App\Models\Project"` after deploying the change.
+:::
+
+::: tip How `dimensions` is applied
+`dimensions` is the single source of truth for vector size. It sizes the `vector(N)` storage column in your migrations, and for OpenAI `text-embedding-3-small`/`text-embedding-3-large` it is also sent to the API as the `dimensions` request parameter — so reduced-dimension (Matryoshka) embeddings work by setting this one key. Models that don't accept the parameter (e.g. `text-embedding-ada-002`, Google `text-embedding-004`) ignore it and return their native size, so for those you must set `dimensions` to the model's native dimension (1536 / 768). If a returned vector ever doesn't match the configured size, atlas throws a clear error at embed time rather than letting the database reject the write. An explicit `dimensions` in a request's provider options always takes precedence.
 :::
 
 Internal hard limits (`HARD_MAX_TOKENS`, `MAX_CHUNKS_PER_RECORD`) are class constants on `MarkdownChunker`. If you need different values, ship a custom chunker.

--- a/src/AtlasConfig.php
+++ b/src/AtlasConfig.php
@@ -87,6 +87,13 @@ class AtlasConfig
         app()->forgetInstance(AtlasManager::class);
         app()->forgetInstance(MiddlewareResolver::class);
 
+        // Forgetting the container instance is not enough: the Atlas facade
+        // caches the AtlasManager it resolved on first use. Without clearing it,
+        // every Atlas:: call after a runtime config change keeps using the stale
+        // manager (built from the old config) — so facade-driven paths like
+        // EmbeddingResolver and ChunkContentService silently ignore the refresh.
+        Atlas::clearResolvedInstance(AtlasManager::class);
+
         // Rebuild ProviderRegistry with new config while preserving factories
         $container = app();
         if ($container->resolved(ProviderRegistryContract::class)) {

--- a/src/Exceptions/AtlasException.php
+++ b/src/Exceptions/AtlasException.php
@@ -31,4 +31,19 @@ class AtlasException extends RuntimeException
     {
         return new self("Unknown driver '{$driver}' for provider '{$key}'.");
     }
+
+    /**
+     * Create an exception for an embedding whose dimension does not match the
+     * configured (and column-sized) `atlas.embeddings.dimensions`.
+     */
+    public static function dimensionMismatch(int $expected, int $actual): self
+    {
+        return new self(
+            "Embedding provider returned a {$actual}-dimension vector but "
+            ."atlas.embeddings.dimensions is {$expected}. The vector column is "
+            ."sized to {$expected}, so this write would be rejected. Set "
+            ."ATLAS_EMBEDDING_DIMENSIONS to your embedding model's dimension, "
+            ."or pass a 'dimensions' provider option that matches the column."
+        );
+    }
 }

--- a/src/Persistence/Concerns/HasVectorEmbeddings.php
+++ b/src/Persistence/Concerns/HasVectorEmbeddings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Persistence\Concerns;
 
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Embeddings\EmbeddingResolver;
 use Atlasphp\Atlas\Embeddings\VectorEmbeddable;
 use Atlasphp\Atlas\Embeddings\VectorQueryMacros;
@@ -131,7 +132,7 @@ trait HasVectorEmbeddings
      */
     protected function storeEmbedding(array $vector): static
     {
-        $expected = (int) config('atlas.embeddings.dimensions');
+        $expected = app(AtlasConfig::class)->embeddingDimensions;
         if (count($vector) !== $expected) {
             throw AtlasException::dimensionMismatch($expected, count($vector));
         }

--- a/src/Persistence/Concerns/HasVectorEmbeddings.php
+++ b/src/Persistence/Concerns/HasVectorEmbeddings.php
@@ -7,6 +7,7 @@ namespace Atlasphp\Atlas\Persistence\Concerns;
 use Atlasphp\Atlas\Embeddings\EmbeddingResolver;
 use Atlasphp\Atlas\Embeddings\VectorEmbeddable;
 use Atlasphp\Atlas\Embeddings\VectorQueryMacros;
+use Atlasphp\Atlas\Exceptions\AtlasException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
@@ -99,17 +100,10 @@ trait HasVectorEmbeddings
      */
     public function generateEmbedding(): static
     {
-        $config = $this->embeddable();
-        $content = $this->getEmbeddableContent();
-
         /** @var EmbeddingResolver $resolver */
         $resolver = app(EmbeddingResolver::class);
-        $vector = $resolver->resolve($content);
 
-        $this->setAttribute($config['column'], VectorQueryMacros::toVectorLiteral($vector));
-        $this->setAttribute('embedding_at', now());
-
-        return $this;
+        return $this->storeEmbedding($resolver->resolve($this->getEmbeddableContent()));
     }
 
     /**
@@ -117,14 +111,32 @@ trait HasVectorEmbeddings
      */
     public function generateEmbeddingUsing(?string $provider = null, ?string $model = null): static
     {
-        $config = $this->embeddable();
-        $content = $this->getEmbeddableContent();
-
         /** @var EmbeddingResolver $resolver */
         $resolver = app(EmbeddingResolver::class);
-        $vector = $resolver->resolveUsing($content, $provider, $model);
 
-        $this->setAttribute($config['column'], VectorQueryMacros::toVectorLiteral($vector));
+        return $this->storeEmbedding(
+            $resolver->resolveUsing($this->getEmbeddableContent(), $provider, $model)
+        );
+    }
+
+    /**
+     * Validate the vector against the configured dimension, then write it to
+     * the embeddable column.
+     *
+     * The column is sized to atlas.embeddings.dimensions; a mismatched vector
+     * would be rejected by pgvector with a cryptic error, so fail early with
+     * actionable guidance instead.
+     *
+     * @param  array<int, float>  $vector
+     */
+    protected function storeEmbedding(array $vector): static
+    {
+        $expected = (int) config('atlas.embeddings.dimensions');
+        if (count($vector) !== $expected) {
+            throw AtlasException::dimensionMismatch($expected, count($vector));
+        }
+
+        $this->setAttribute($this->embeddable()['column'], VectorQueryMacros::toVectorLiteral($vector));
         $this->setAttribute('embedding_at', now());
 
         return $this;

--- a/src/Persistence/Services/ChunkContentService.php
+++ b/src/Persistence/Services/ChunkContentService.php
@@ -194,6 +194,17 @@ class ChunkContentService
             );
         }
 
+        // Fail with an actionable message before the cryptic pgvector
+        // "expected N dimensions, not M" error at insert time. The chunks
+        // column is sized to atlas.embeddings.dimensions, so any other length
+        // is guaranteed to be rejected by the database.
+        $expected = (int) $this->config->embeddingDimensions;
+        foreach ($vectors as $vector) {
+            if (count($vector) !== $expected) {
+                throw AtlasException::dimensionMismatch($expected, count($vector));
+            }
+        }
+
         return $vectors;
     }
 

--- a/src/Providers/OpenAi/Handlers/Embed.php
+++ b/src/Providers/OpenAi/Handlers/Embed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers\OpenAi\Handlers;
 
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Http\ProviderRequestContext;
 use Atlasphp\Atlas\Providers\Concerns\BuildsHeaders;
@@ -43,10 +44,7 @@ class Embed implements EmbedHandler
         // models reject `dimensions`, so they are left untouched.
         if (str_starts_with($request->model, 'text-embedding-3')
             && ! array_key_exists('dimensions', $request->providerOptions)) {
-            $dimensions = config('atlas.embeddings.dimensions');
-            if ($dimensions !== null) {
-                $body['dimensions'] = (int) $dimensions;
-            }
+            $body['dimensions'] = app(AtlasConfig::class)->embeddingDimensions;
         }
 
         $body = array_merge($body, $request->providerOptions);

--- a/src/Providers/OpenAi/Handlers/Embed.php
+++ b/src/Providers/OpenAi/Handlers/Embed.php
@@ -35,6 +35,20 @@ class Embed implements EmbedHandler
             'input' => $request->input,
         ];
 
+        // text-embedding-3-* models accept a `dimensions` param (Matryoshka
+        // truncation). Forward the configured embedding dimensions so the value
+        // that sizes the storage column also shapes the returned vector — they
+        // can no longer silently disagree. Only fill it when the model supports
+        // the param and the caller has not already set it; ada-002 and other
+        // models reject `dimensions`, so they are left untouched.
+        if (str_starts_with($request->model, 'text-embedding-3')
+            && ! array_key_exists('dimensions', $request->providerOptions)) {
+            $dimensions = config('atlas.embeddings.dimensions');
+            if ($dimensions !== null) {
+                $body['dimensions'] = (int) $dimensions;
+            }
+        }
+
         $body = array_merge($body, $request->providerOptions);
 
         $data = $this->http->post(
@@ -48,6 +62,16 @@ class Embed implements EmbedHandler
 
         /** @var array<int, array<string, mixed>> $items */
         $items = $data['data'] ?? [];
+
+        // Order by the response `index` rather than trusting array position.
+        // OpenAI documents an `index` per embedding precisely so batches can be
+        // realigned; the chunked pipeline assigns vectors to chunks positionally
+        // ($vectors[$i] → $insert[$i]), so an out-of-order batch would silently
+        // attach the wrong vector to every chunk. No-op when already ordered.
+        usort(
+            $items,
+            fn (array $a, array $b): int => ($a['index'] ?? 0) <=> ($b['index'] ?? 0),
+        );
 
         $embeddings = array_map(
             fn (array $item): array => $item['embedding'] ?? [],

--- a/tests/Unit/AtlasConfigTest.php
+++ b/tests/Unit/AtlasConfigTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Exceptions\ProviderNotFoundException;
 
@@ -48,6 +49,23 @@ it('returns sensible defaults when config keys are missing', function () {
     expect($config->storageDisk)->toBeNull();
     expect($config->storagePrefix)->toBe('atlas');
     expect($config->embeddingDimensions)->toBe(1536);
+});
+
+it('clears the Atlas facade on refresh so runtime config changes apply to facade calls', function () {
+    // The Atlas facade caches the AtlasManager it resolves on first use.
+    // refresh() forgets the container instance but must ALSO clear the facade,
+    // or facade-driven paths (EmbeddingResolver, ChunkContentService) keep using
+    // a stale manager and silently ignore runtime config changes.
+    config(['atlas.defaults.embed' => ['provider' => 'openai', 'model' => 'model-old']]);
+    AtlasConfig::refresh();
+
+    // Force the facade to cache a manager built from the old config.
+    expect(Atlas::embed()->buildRequest()->model)->toBe('model-old');
+
+    config(['atlas.defaults.embed' => ['provider' => 'openai', 'model' => 'model-new']]);
+    AtlasConfig::refresh();
+
+    expect(Atlas::embed()->buildRequest()->model)->toBe('model-new');
 });
 
 it('reads prompt_cache and media_replay_limit overrides', function () {

--- a/tests/Unit/Persistence/Concerns/HasVectorEmbeddingsTest.php
+++ b/tests/Unit/Persistence/Concerns/HasVectorEmbeddingsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Embeddings\EmbeddingResolver;
+use Atlasphp\Atlas\Exceptions\AtlasException;
 use Atlasphp\Atlas\Persistence\Concerns\HasVectorEmbeddings;
 use Illuminate\Database\Eloquent\Model;
 
@@ -143,7 +144,7 @@ it('returns false when content is empty', function () {
 });
 
 it('generates embedding and sets column and timestamp', function () {
-    config(['atlas.persistence.enabled' => true]);
+    config(['atlas.persistence.enabled' => true, 'atlas.embeddings.dimensions' => 3]);
     AtlasConfig::refresh();
 
     $vector = [0.1, 0.2, 0.3];
@@ -165,7 +166,7 @@ it('generates embedding and sets column and timestamp', function () {
 });
 
 it('generates embedding using explicit provider and model', function () {
-    config(['atlas.persistence.enabled' => true]);
+    config(['atlas.persistence.enabled' => true, 'atlas.embeddings.dimensions' => 3]);
     AtlasConfig::refresh();
 
     $vector = [0.4, 0.5, 0.6];
@@ -184,6 +185,26 @@ it('generates embedding using explicit provider and model', function () {
 
     expect($model->getAttribute('embedding'))->toBe('[0.4,0.5,0.6]');
     expect($model->getAttribute('embedding_at'))->not->toBeNull();
+});
+
+it('throws an actionable error when the vector dimension does not match the configured size', function () {
+    config(['atlas.persistence.enabled' => true, 'atlas.embeddings.dimensions' => 1536]);
+    AtlasConfig::refresh();
+
+    // Resolver returns a 3-dim vector but the column is sized to 1536 — the
+    // guard must fail with guidance instead of the cryptic pgvector error.
+    $resolver = Mockery::mock(EmbeddingResolver::class);
+    $resolver->shouldReceive('resolve')->once()->andReturn([0.1, 0.2, 0.3]);
+    app()->instance(EmbeddingResolver::class, $resolver);
+
+    $model = new FakeEmbeddableModel;
+    $model->content = 'Test content';
+
+    expect(fn () => $model->generateEmbedding())
+        ->toThrow(
+            AtlasException::class,
+            'returned a 3-dimension vector but atlas.embeddings.dimensions is 1536'
+        );
 });
 
 it('delegates scopeSimilarTo to whereVectorSimilarTo with correct column', function () {

--- a/tests/Unit/Persistence/Services/ChunkContentServiceTest.php
+++ b/tests/Unit/Persistence/Services/ChunkContentServiceTest.php
@@ -242,6 +242,25 @@ it('throws when the embedding provider returns a mismatched vector count', funct
         ->toThrow(AtlasException::class, 'returned 1 vectors for 2 chunks');
 });
 
+it('throws an actionable error when a vector dimension does not match the configured size', function () {
+    // Right count, wrong dimension: the fake returns 3-dim vectors but the
+    // column is sized to atlas.embeddings.dimensions. The guard must surface a
+    // clear message instead of letting the cryptic pgvector error fire.
+    Atlas::fake([
+        EmbeddingsResponseFake::make()->withEmbeddings([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]),
+    ]);
+    FakeServiceChunker::$next = [
+        makeChunk(0, 'Alpha', 'A'),
+        makeChunk(1, 'Beta', 'B'),
+    ];
+
+    $doc = FakeServiceDoc::create(['body' => 'body']);
+    $expected = (int) config('atlas.embeddings.dimensions');
+
+    expect(fn () => app(ChunkContentService::class)->reconcile($doc))
+        ->toThrow(AtlasException::class, "returned a 3-dimension vector but atlas.embeddings.dimensions is {$expected}");
+});
+
 it('increments failure counter and dispatches ContentChunkingFailed on exception', function () {
     Event::fake([ContentChunkingFailed::class]);
 

--- a/tests/Unit/Providers/OpenAi/Handlers/EmbedHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/EmbedHandlerTest.php
@@ -62,3 +62,94 @@ it('handles batch embedding input', function () {
 
     expect($response->embeddings)->toHaveCount(2);
 });
+
+it('realigns a batch response by the index field, not array position', function () {
+    // Provider returns the batch out of order — index 1 first, then 0, then 2.
+    // The handler must hand them back in index order so the chunked pipeline,
+    // which assigns vectors positionally, attaches the right vector per chunk.
+    Http::fake([
+        'api.openai.com/v1/embeddings' => Http::response([
+            'data' => [
+                ['embedding' => [1.1, 1.1], 'index' => 1],
+                ['embedding' => [0.5, 0.5], 'index' => 0],
+                ['embedding' => [2.2, 2.2], 'index' => 2],
+            ],
+            'usage' => ['prompt_tokens' => 9, 'total_tokens' => 9],
+        ]),
+    ]);
+
+    $handler = new Embed(
+        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.openai.com/v1']),
+        http: app(HttpClient::class),
+    );
+
+    $response = $handler->embed(
+        new EmbedRequest(model: 'text-embedding-3-small', input: ['a', 'b', 'c'])
+    );
+
+    expect($response->embeddings)->toBe([[0.5, 0.5], [1.1, 1.1], [2.2, 2.2]]);
+});
+
+it('forwards the configured dimensions for text-embedding-3 models', function () {
+    config()->set('atlas.embeddings.dimensions', 512);
+
+    Http::fake([
+        'api.openai.com/v1/embeddings' => Http::response([
+            'data' => [['embedding' => array_fill(0, 512, 0.1), 'index' => 0]],
+            'usage' => ['prompt_tokens' => 5, 'total_tokens' => 5],
+        ]),
+    ]);
+
+    $handler = new Embed(
+        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.openai.com/v1']),
+        http: app(HttpClient::class),
+    );
+
+    $handler->embed(new EmbedRequest(model: 'text-embedding-3-small', input: 'Hello'));
+
+    Http::assertSent(fn ($request) => $request['dimensions'] === 512);
+});
+
+it('does not send dimensions for models that do not support it', function () {
+    config()->set('atlas.embeddings.dimensions', 512);
+
+    Http::fake([
+        'api.openai.com/v1/embeddings' => Http::response([
+            'data' => [['embedding' => [0.1, 0.2], 'index' => 0]],
+            'usage' => ['prompt_tokens' => 5, 'total_tokens' => 5],
+        ]),
+    ]);
+
+    $handler = new Embed(
+        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.openai.com/v1']),
+        http: app(HttpClient::class),
+    );
+
+    $handler->embed(new EmbedRequest(model: 'text-embedding-ada-002', input: 'Hello'));
+
+    Http::assertSent(fn ($request) => ! isset($request['dimensions']));
+});
+
+it('preserves an explicit dimensions provider option', function () {
+    config()->set('atlas.embeddings.dimensions', 512);
+
+    Http::fake([
+        'api.openai.com/v1/embeddings' => Http::response([
+            'data' => [['embedding' => array_fill(0, 256, 0.1), 'index' => 0]],
+            'usage' => ['prompt_tokens' => 5, 'total_tokens' => 5],
+        ]),
+    ]);
+
+    $handler = new Embed(
+        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.openai.com/v1']),
+        http: app(HttpClient::class),
+    );
+
+    $handler->embed(new EmbedRequest(
+        model: 'text-embedding-3-large',
+        input: 'Hello',
+        providerOptions: ['dimensions' => 256],
+    ));
+
+    Http::assertSent(fn ($request) => $request['dimensions'] === 256);
+});

--- a/tests/Unit/Providers/OpenAi/Handlers/EmbedHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/EmbedHandlerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Embed;
 use Atlasphp\Atlas\Providers\ProviderConfig;
@@ -92,6 +93,7 @@ it('realigns a batch response by the index field, not array position', function 
 
 it('forwards the configured dimensions for text-embedding-3 models', function () {
     config()->set('atlas.embeddings.dimensions', 512);
+    AtlasConfig::refresh();
 
     Http::fake([
         'api.openai.com/v1/embeddings' => Http::response([


### PR DESCRIPTION
This pull request introduces several improvements and safeguards to the embeddings pipeline, particularly around dimension handling, provider alignment, and configuration refresh. The most significant changes ensure that the configured embedding vector size is consistently enforced and communicated to providers, preventing silent mismatches and database errors. Additionally, the documentation and changelog have been updated to clarify these behaviors and recent fixes.

**Embeddings dimension enforcement and provider alignment:**

- The configured `dimensions` value in `atlas.embeddings` is now sent as the `dimensions` parameter to OpenAI's `text-embedding-3-small` and `text-embedding-3-large` models, ensuring that the returned vector matches the expected size and enabling Matryoshka (reduced-dimension) embeddings out of the box. Models that don't support this parameter are unaffected. [[1]](diffhunk://#diff-4fa01386c8ffedbc539e26a96a2980b22cec17f49cd865ccb8d5da93d7ad2f14R38-R51) [[2]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L399-R399) [[3]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981R414-R417)
- All embedding vectors are now validated against the configured dimension before being stored or inserted, with clear, actionable error messages if there's a mismatch, instead of cryptic database errors. This applies to both single and batch embedding flows. [[1]](diffhunk://#diff-052852955648f9301f5561b45478a5e962c41ce702fe44f7fa3fd757b1fe2f92L102-R139) [[2]](diffhunk://#diff-c005cdd5153e0dd927a2c9bb4d98269e2d6fe83a145b0fe4f51f47aef1f00f11R34-R48) [[3]](diffhunk://#diff-6ae09bf3b282671ec3a94366a169b6d213dffa95bfee68146b1d1b45b1304bf5R197-R207)
- Batch embeddings are now realigned according to the provider's `index` field rather than response order, preventing out-of-order vectors from being attached to the wrong chunks.

**Configuration and runtime behavior:**

- Calling `AtlasConfig::refresh()` now properly clears cached manager instances held by the `Atlas` facade, so runtime configuration changes (such as provider, model, or dimension) are correctly applied to all facade-driven embedding operations.

**Documentation and changelog updates:**

- The documentation (`docs/modalities/embeddings.md`) and changelog (`CHANGELOG.md`) have been updated to clarify how the `dimensions` setting works, how errors are surfaced, and to document the new behaviors and fixes. [[1]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L399-R399) [[2]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981R414-R417) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL18-R23) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR38-L51)
- The audit log (`AUDIT.md`) now records the structured-output strict-mode schema normalization and the new embedding behaviors, including the bug fix and expanded test coverage. [[1]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L7-R7) [[2]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688R128-R167) [[3]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L195-R235)

These changes together make the embeddings pipeline more robust, transparent, and easier to configure, while preventing a class of subtle and hard-to-debug errors.

**References:** [[1]](diffhunk://#diff-4fa01386c8ffedbc539e26a96a2980b22cec17f49cd865ccb8d5da93d7ad2f14R38-R51) [[2]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981L399-R399) [[3]](diffhunk://#diff-65084922fabbf40cbb09b633faa561e4a03433380073996bc8543e49b70b9981R414-R417) [[4]](diffhunk://#diff-052852955648f9301f5561b45478a5e962c41ce702fe44f7fa3fd757b1fe2f92L102-R139) [[5]](diffhunk://#diff-c005cdd5153e0dd927a2c9bb4d98269e2d6fe83a145b0fe4f51f47aef1f00f11R34-R48) [[6]](diffhunk://#diff-6ae09bf3b282671ec3a94366a169b6d213dffa95bfee68146b1d1b45b1304bf5R197-R207) [[7]](diffhunk://#diff-4fa01386c8ffedbc539e26a96a2980b22cec17f49cd865ccb8d5da93d7ad2f14R66-R75) [[8]](diffhunk://#diff-e834b3cc47c055c2a26ca1034bbd07ec57c805ec1411bca66987383c588b256fR90-R96) [[9]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL18-R23) [[10]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR38-L51) [[11]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L7-R7) [[12]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688R128-R167) [[13]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L195-R235)