### PR TITLE
Add pre-flight token counting API and documentation

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Structured output strict-mode (builder, live OpenAI/Google/Anthropic): 2026-06-10** · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
+**Token counting (live, all 4 providers, 22/22): 2026-06-11** · **Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Structured output strict-mode (builder, live OpenAI/Google/Anthropic): 2026-06-10** · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
 
 Reproduce:
 - Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
@@ -215,6 +215,26 @@ Per provider, two phases:
 | xAI       | 400 | `InvalidRequestException` | "Incorrect API key provided: sk***ef. …" |
 
 > Google/xAI classify a bad key as **400** (not 401) — those already carried `providerMessage`; this release specifically restored the **401** auth message for OpenAI/Anthropic, which previously showed a generic "Authentication failed" with an empty `providerMessage`.
+
+## Token counting (live, 2026-06-11)
+
+Validates `Atlas::text(...)->countTokens()` against the **real provider count endpoints** via
+`sandbox/test-token-counting.php`. **22/22 live checks passed.** For each native provider the
+pre-flight count is compared to the billed `usage->inputTokens` from a real generation, and a
+multimodal (image) request confirms the endpoint counts media a local tokenizer cannot.
+
+| Provider  | Endpoint                              | estimated | Count vs billed (live)        | Multimodal (image) |
+|-----------|---------------------------------------|:---------:|-------------------------------|--------------------|
+| Anthropic | `POST /v1/messages/count_tokens`      | `false`   | 19 vs 19 (**Δ 0**)            | 19 → 324 tokens ✅ |
+| OpenAI    | `POST /v1/responses/input_tokens`     | `false`   | 19 vs 19 (**Δ 0**)            | 19 → 436 tokens ✅ |
+| Google    | `…/{model}:countTokens`               | `false`   | 13 vs 13 (**Δ 0**)            | 13 → 263 tokens ✅ |
+| xAI       | heuristic (no full-request endpoint)  | `true`    | n/a (estimate)                | — |
+
+Notes:
+- **Native counts are exact** — all three matched the billed input tokens with zero delta on a plain text turn.
+- **System prompt + tool schemas are counted**: adding a long system prompt and a client tool raised every provider's count (e.g. Anthropic 19 → 940, OpenAI 19 → 420, Google 13 → 385, xAI 16 → 422).
+- **xAI** has only a plain-text `tokenize-text` endpoint (no system/tools/images), so Atlas estimates and flags `estimated: true`. Ollama / LM Studio / custom Responses endpoints fall back the same way (OpenAI handler degrades to the heuristic on an unsupported `input_tokens` call).
+- Reproduce: `cd sandbox && php test-token-counting.php` (needs ANTHROPIC/OPENAI/GEMINI/XAI keys).
 
 ## Per-provider results
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ### Added
 
 - `->reasoning(ReasoningEffort)` on text and agent requests (and as an `Agent::reasoning()` default) enables extended thinking with one effort level (`Minimal`/`Low`/`Medium`/`High`), mapped to each provider's native format. Override with `budgetTokens:` or get thought summaries with `includeSummary:` where supported.
+- `->countTokens()` on text and agent requests counts a request's input tokens before sending — for cost estimates, context-window checks, or budgets. Uses each provider's native endpoint (Anthropic, OpenAI, Google — exact, free, and includes system prompt, tools, and images) and a heuristic estimate elsewhere (xAI, Ollama, LM Studio). Returns a `TokenCount` with an `estimated` flag. Runs only when called.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `->reasoning(ReasoningEffort)` on text and agent requests (and as an `Agent::reasoning()` default) enables extended thinking with one effort level (`Minimal`/`Low`/`Medium`/`High`), mapped to each provider's native format. Override with `budgetTokens:` or get thought summaries with `includeSummary:` where supported.
-- `->countTokens()` on text and agent requests counts a request's input tokens before sending — for cost estimates, context-window checks, or budgets. Uses each provider's native endpoint (Anthropic, OpenAI, Google — exact, free, and includes system prompt, tools, and images) and a heuristic estimate elsewhere (xAI, Ollama, LM Studio). Returns a `TokenCount` with an `estimated` flag. Runs only when called.
+- `->reasoning(ReasoningEffort)` on text and agent requests (and an `Agent::reasoning()` default) enables extended thinking at one effort level (`Minimal`/`Low`/`Medium`/`High`), mapped to each provider's format. Optional `budgetTokens:` and `includeSummary:`.
+- `->countTokens()` on text and agent requests returns input-token count before sending — exact on Anthropic/OpenAI/Google, estimated on xAI/Ollama/LM Studio. Returns a `TokenCount` with an `estimated` flag.
 
 ### Fixed
 
 - Extended thinking now works through multi-step tool calls and persisted-conversation reloads.
-- Google (Gemini) tool calls no longer 400 when a tool returns a non-object value (number, boolean, JSON array, or quoted string) — these are now wrapped into a valid object. Plain strings and JSON objects are unchanged.
+- Google (Gemini) tool calls no longer 400 on non-object results (number, boolean, array, quoted string) — these are now wrapped automatically. Plain strings and JSON objects are unchanged.
 
 ### Migration
 
-**No breaking changes** — drop-in upgrade. No consumer action required.
+**No breaking changes** — drop-in upgrade.
 
 ---
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -24,6 +24,7 @@ This page compares Atlas to the two other leading PHP AI libraries: **[Prism](ht
 | Multimodal tool results (tools return images/files the model sees) | ⚠️ | ✅ | ⚠️ |
 | Reasoning / thinking — configure, stream & persist | ✅ | ✅ | ⚠️ |
 | Prompt caching | ✅ | ✅ | ✅ |
+| Pre-flight token counting (count input — incl. tools & images — before sending) | ✅ | ❌ | ❌ |
 | **— Agent framework —** | | | |
 | Agents as first-class classes | ✅ | ❌ | ✅ |
 | Sub-agents (delegation, depth & cycle guards, lineage) | ✅ | ❌ | ✅ |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -284,6 +284,7 @@ gtag('config', 'G-JEV06LWG7N');`],
                 text: 'Guides',
                 items: [
                     { text: 'Conversations', link: '/guides/conversations' },
+                    { text: 'Token Counting', link: '/guides/token-counting' },
                     { text: 'Prompt Caching', link: '/guides/prompt-caching' },
                     { text: 'Streaming', link: '/guides/streaming' },
                     { text: 'Queue & Background Jobs', link: '/guides/queue' },

--- a/docs/guides/token-counting.md
+++ b/docs/guides/token-counting.md
@@ -58,6 +58,18 @@ Output tokens are **not** counted — they are unknowable until the model respon
 
 The native endpoints are exact (verified against the billed `usage->inputTokens`) and free, subject to each provider's own rate limit. Providers without a full-request count endpoint fall back to the `chars / 4` heuristic — always check the `estimated` flag if you need to know which you got. The heuristic walks the built payload, so base64-encoded media inflates the figure; treat estimated counts as approximate.
 
+## Quick local estimate
+
+Need a rough number for a raw string — with no provider, no model, and no network call? Use the `TokenCounter` utility directly. It's the same `chars / 4` heuristic Atlas uses for chunk sizing and for providers without a native endpoint:
+
+```php
+use Atlasphp\Atlas\Support\TokenCounter;
+
+TokenCounter::count($text); // e.g. 74 — instant, offline, model-agnostic
+```
+
+This is approximate and counts a plain string only (no message wrapper, tools, or media). Reach for it when you just want a fast sanity check; use `countTokens()` when you need a model-accurate number for an actual request.
+
 ## Estimating cost
 
 Atlas does **not** ship a price table — model prices change and a stale one is worse than none. Once you have a token count, apply your own current per-model rates:

--- a/docs/guides/token-counting.md
+++ b/docs/guides/token-counting.md
@@ -1,0 +1,128 @@
+# Token Counting
+
+Count the **input tokens** a request would consume **before** you send it — for free. Use it to estimate cost up front, reject context that won't fit the model's window, or enforce a per-user / per-tenant token budget.
+
+```php
+$count = Atlas::text('anthropic', 'claude-sonnet-4-5')
+    ->instructions('You are a helpful assistant.')
+    ->message('Summarize the attached report.')
+    ->countTokens();
+
+$count->inputTokens; // 1287
+```
+
+`countTokens()` runs **only when you call it**. It never fires as a side effect of generation, and it skips the middleware stack and tool loop — it is a single, cheap, read-only pre-flight call.
+
+## Why this beats a local tokenizer
+
+A local `strlen / 4` (or even a real BPE tokenizer) can only see plain text. It cannot count the tokens added by **images, PDFs, or tool schemas** — and those are often the largest part of a request. Atlas counts the **exact payload it would send** by asking the provider's own server-side endpoint, so the number includes the system prompt, every tool definition, and all attached media.
+
+```php
+// Counts the system prompt, the tool's JSON schema, and the image — all of it.
+$count = Atlas::text('openai', 'gpt-4o')
+    ->instructions($largeSystemPrompt)
+    ->withTools([WeatherTool::class])
+    ->message('What should I wear?', Image::fromPath('outfit.jpg'))
+    ->countTokens();
+```
+
+It works on agents too — the agent's instructions, model, and tools are resolved exactly as a real turn would be:
+
+```php
+$count = Atlas::agent('support')
+    ->message('My order never arrived.')
+    ->countTokens();
+```
+
+## The `TokenCount` object
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `inputTokens` | `int` | Input tokens the request would consume |
+| `estimated` | `bool` | `false` for an exact provider count, `true` for a heuristic estimate |
+| `provider` | `string` | Provider the count is for |
+| `model` | `string` | Model the count is for |
+| `breakdown` | `array<string, int>` | Optional per-category detail (e.g. `['cached_tokens' => 1200]` on Google) |
+
+Output tokens are **not** counted — they are unknowable until the model responds. This is a pre-flight *input* count.
+
+## Provider support
+
+| Provider | Source | `estimated` |
+|----------|--------|:-----------:|
+| **Anthropic** | `POST /v1/messages/count_tokens` (native) | `false` |
+| **OpenAI** | `POST /v1/responses/input_tokens` (native) | `false` |
+| **Google** | `…/{model}:countTokens` (native) | `false` |
+| **xAI** | heuristic estimate | `true` |
+| **Ollama / LM Studio / custom** | heuristic estimate | `true` |
+
+The native endpoints are exact (verified against the billed `usage->inputTokens`) and free, subject to each provider's own rate limit. Providers without a full-request count endpoint fall back to the `chars / 4` heuristic — always check the `estimated` flag if you need to know which you got. The heuristic walks the built payload, so base64-encoded media inflates the figure; treat estimated counts as approximate.
+
+## Estimating cost
+
+Atlas does **not** ship a price table — model prices change and a stale one is worse than none. Once you have a token count, apply your own current per-model rates:
+
+```php
+$count = Atlas::text('openai', 'gpt-4o')->message($prompt)->countTokens();
+
+$estimatedInputCost = $count->inputTokens * $yourInputRatePerToken;
+```
+
+## Enforcing a budget
+
+Atlas ships token counting, not a budget system — that way you stay in control of the policy. There are two clean ways to enforce a cap, both token-based so no stale pricing is involved.
+
+### Pre-flight gate
+
+Reject a request before it is ever sent:
+
+```php
+$count = Atlas::text('anthropic', 'claude-sonnet-4-5')
+    ->message($userInput)
+    ->countTokens();
+
+if ($count->inputTokens > $tenant->remainingTokenBudget()) {
+    throw new BudgetExceededException("Request would exceed the remaining token budget.");
+}
+
+$response = Atlas::text('anthropic', 'claude-sonnet-4-5')
+    ->message($userInput)
+    ->asText();
+```
+
+### Cumulative cap via middleware
+
+For agents and tool loops, enforce a running cap with a [step middleware](/features/middleware) that reads the accumulated usage and aborts the loop when it crosses your limit. Define your own exception and budget source:
+
+```php
+use Atlasphp\Atlas\Middleware\Contracts\StepMiddleware;
+use Atlasphp\Atlas\Middleware\StepContext;
+use Closure;
+
+class EnforceTokenBudget implements StepMiddleware
+{
+    public function __construct(private int $maxTokens) {}
+
+    public function handle(StepContext $context, Closure $next): mixed
+    {
+        if ($context->accumulatedUsage->totalTokens() > $this->maxTokens) {
+            throw new \App\Exceptions\BudgetExceededException(
+                "Token budget of {$this->maxTokens} exceeded for {$context->agentKey}."
+            );
+        }
+
+        return $next($context);
+    }
+}
+```
+
+Register it globally or per request — see [Middleware](/features/middleware) for registration and the full `StepContext` surface (`accumulatedUsage`, `stepNumber`, `meta`, `agentKey`). Combine the pre-flight gate (stop oversized requests up front) with the cumulative cap (stop runaway tool loops) for full coverage.
+
+## Checking the billed count
+
+After a call, the actual billed tokens are on the response's [`Usage`](/modalities/text) object — compare it to your pre-flight count to calibrate:
+
+```php
+$response = Atlas::text('google', 'gemini-2.5-flash')->message($prompt)->asText();
+$response->usage->inputTokens; // billed input tokens
+```

--- a/docs/modalities/text.md
+++ b/docs/modalities/text.md
@@ -94,6 +94,21 @@ $usage->cacheWriteTokens;  // Tokens written to provider cache
 | `cachedTokens` | `?int` | Input tokens served from the provider's prompt cache |
 | `cacheWriteTokens` | `?int` | Input tokens written to the provider's prompt cache |
 
+### Counting Tokens Before Sending
+
+`Usage` tells you what a call cost *after* it ran. To count the input tokens **before** sending — for cost estimates, context-window checks, or budget enforcement — call `countTokens()` on the builder. It uses each provider's native count endpoint where available (and a heuristic otherwise), counting the full payload including system prompt, tools, and media:
+
+```php
+$count = Atlas::text('openai', 'gpt-4o')
+    ->message('Explain quantum computing')
+    ->countTokens();
+
+$count->inputTokens; // 5
+$count->estimated;   // false (exact, from the provider)
+```
+
+See the [Token Counting guide](/guides/token-counting) for provider support, cost estimation, and enforcing your own budget via middleware.
+
 ### Cost Estimation
 
 ```php

--- a/sandbox/test-token-counting.php
+++ b/sandbox/test-token-counting.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Token Counting Live API Test
+ *
+ * Validates Atlas::text(...)->countTokens() against the real provider endpoints:
+ *   - Anthropic  POST /v1/messages/count_tokens   (native)
+ *   - OpenAI     POST /v1/responses/input_tokens   (native)
+ *   - Google     POST .../{model}:countTokens      (native)
+ *   - xAI        heuristic estimate (no full-request count endpoint)
+ *
+ * For each native provider it also runs a real generation and compares the
+ * pre-flight count to the post-call usage->inputTokens to prove accuracy, and
+ * exercises multimodal (image) + tool/system counting that no local tokenizer
+ * can do.
+ *
+ * Usage: php test-token-counting.php
+ * Requires ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, XAI_API_KEY in sandbox/.env
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'anthropic' => [
+        'api_key' => env('ANTHROPIC_API_KEY'),
+        'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1'),
+        'version' => env('ANTHROPIC_VERSION', '2023-06-01'),
+    ],
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+    ],
+    'google' => [
+        'api_key' => env('GEMINI_API_KEY', env('GOOGLE_API_KEY')),
+        'url' => env('GOOGLE_URL', 'https://generativelanguage.googleapis.com'),
+    ],
+    'xai' => [
+        'api_key' => env('XAI_API_KEY'),
+        'url' => env('XAI_URL', 'https://api.x.ai/v1'),
+    ],
+]);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Input\Image;
+use Atlasphp\Atlas\Tools\Tool;
+
+$passed = 0;
+$failed = 0;
+
+function check(string $name, bool $ok, string $detail = ''): void
+{
+    global $passed, $failed;
+
+    if ($ok) {
+        $passed++;
+        echo "\n  ✓ {$name}".($detail !== '' ? "  ({$detail})" : '');
+    } else {
+        $failed++;
+        echo "\n  ✗ {$name}".($detail !== '' ? "  ({$detail})" : '');
+    }
+}
+
+// A simple client tool — its name + description add tokens to the request,
+// which the native count endpoints include and a text-only count does not.
+$weatherTool = new class extends Tool
+{
+    public function name(): string
+    {
+        return 'get_current_weather';
+    }
+
+    public function description(): string
+    {
+        return 'Get the current weather conditions, temperature, humidity, and wind '
+            .'for a specific city and country. Use this whenever the user asks about weather.';
+    }
+
+    public function handle(array $args, array $context): mixed
+    {
+        return 'sunny';
+    }
+};
+
+$logo = __DIR__.'/public/atlas-logo.png';
+$longSystem = str_repeat('You are a precise, terse assistant. ', 40);
+
+echo '╔══════════════════════════════════════════════╗';
+echo "\n║   Token Counting Live API Tests              ║";
+echo "\n╚══════════════════════════════════════════════╝";
+
+/**
+ * Run the standard battery for one provider.
+ */
+function battery(string $label, Provider $provider, string $model, bool $native, bool $vision, $tool, string $logo, string $longSystem): void
+{
+    echo "\n\n── {$label} ({$model})";
+
+    try {
+        // 1) Plain text count
+        $text = Atlas::text($provider, $model)
+            ->message('What is the capital of France? Answer in one word.')
+            ->countTokens();
+
+        check("{$label}: text count > 0", $text->inputTokens > 0, "input={$text->inputTokens}");
+        check("{$label}: estimated flag", $text->estimated === ! $native, $native ? 'native (estimated=false)' : 'heuristic (estimated=true)');
+        check("{$label}: provider attributed", $text->provider !== '', $text->provider);
+
+        // 2) System prompt + tool should raise the count above text-only
+        $withTool = Atlas::text($provider, $model)
+            ->instructions($longSystem)
+            ->message('What is the capital of France? Answer in one word.')
+            ->withTools([$tool])
+            ->countTokens();
+
+        check("{$label}: system+tool raises count", $withTool->inputTokens > $text->inputTokens,
+            "text={$text->inputTokens} → +sys+tool={$withTool->inputTokens}");
+
+        // 3) Native accuracy: compare pre-flight count to real usage->inputTokens
+        if ($native) {
+            $resp = Atlas::text($provider, $model)
+                ->message('What is the capital of France? Answer in one word.')
+                ->asText();
+
+            $delta = abs($resp->usage->inputTokens - $text->inputTokens);
+            // Counting endpoints estimate within a few tokens of the billed input.
+            check("{$label}: count ≈ usage->inputTokens", $delta <= 5,
+                "count={$text->inputTokens} usage={$resp->usage->inputTokens} Δ={$delta}");
+        }
+
+        // 4) Multimodal: an image must add a large number of tokens
+        if ($vision) {
+            $withImage = Atlas::text($provider, $model)
+                ->message('Describe this image.', Image::fromPath($logo, 'image/png'))
+                ->countTokens();
+
+            check("{$label}: image adds tokens (multimodal)", $withImage->inputTokens > $text->inputTokens,
+                "text={$text->inputTokens} → +image={$withImage->inputTokens}");
+        }
+    } catch (Throwable $e) {
+        check("{$label}: battery completed", false, $e->getMessage());
+    }
+}
+
+battery('Anthropic', Provider::Anthropic, 'claude-sonnet-4-5-20250929', native: true, vision: true, tool: $weatherTool, logo: $logo, longSystem: $longSystem);
+battery('OpenAI', Provider::OpenAI, 'gpt-4o', native: true, vision: true, tool: $weatherTool, logo: $logo, longSystem: $longSystem);
+battery('Google', Provider::Google, 'gemini-2.5-flash', native: true, vision: true, tool: $weatherTool, logo: $logo, longSystem: $longSystem);
+battery('xAI', Provider::xAI, 'grok-3', native: false, vision: false, tool: $weatherTool, logo: $logo, longSystem: $longSystem);
+
+echo "\n\n──────────────────────────────────────────────";
+echo "\n  Passed: {$passed}   Failed: {$failed}";
+echo "\n──────────────────────────────────────────────\n";
+
+exit($failed === 0 ? 0 : 1);

--- a/src/Pending/AgentRequest.php
+++ b/src/Pending/AgentRequest.php
@@ -56,6 +56,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\VoiceSession;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\AgentTool;
@@ -411,6 +412,24 @@ class AgentRequest implements QueueableRequest
     }
 
     // ─── Terminal ───────────────────────────────────────────────────
+
+    /**
+     * Count the input tokens this agent turn would send, without running it.
+     *
+     * Resolves the agent's instructions, model, tools, and message exactly as a
+     * real call would, then counts the input — using the provider's native
+     * count endpoint where available and a heuristic otherwise (see the returned
+     * TokenCount's `estimated` flag). Runs only when called; never fires as a
+     * side effect, and does not dispatch the agent middleware or tool loop.
+     */
+    public function countTokens(): TokenCount
+    {
+        $agent = $this->resolveAgent();
+        $tools = $this->resolveTools($agent);
+        $driver = $this->resolveDriver($agent);
+
+        return $driver->countTokens($this->buildRequest($agent, $tools));
+    }
 
     /**
      * Execute the agent and return a text response.

--- a/src/Pending/TextRequest.php
+++ b/src/Pending/TextRequest.php
@@ -37,6 +37,7 @@ use Atlasphp\Atlas\Requests\TextRequest as TextRequestObject;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Support\VariableInterpolator;
 use Atlasphp\Atlas\Tools\Tool;
@@ -411,6 +412,24 @@ class TextRequest implements QueueableRequest
 
             return $tool;
         }, $this->tools);
+    }
+
+    /**
+     * Count the input tokens this request would send, without running it.
+     *
+     * Uses the provider's native count endpoint where available (Anthropic,
+     * OpenAI, Google) and a heuristic estimate otherwise (xAI, Ollama, LM
+     * Studio) — see the returned TokenCount's `estimated` flag. Counts the full
+     * payload including system prompt, tools, and media. Runs only when called;
+     * it never fires as a side effect of generation, and skips the middleware
+     * stack and executor.
+     */
+    public function countTokens(): TokenCount
+    {
+        $driver = $this->resolveDriver();
+        $this->ensureCapability($driver, 'text');
+
+        return $driver->countTokens($this->buildRequest());
     }
 
     public function buildRequest(): TextRequestObject

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -21,6 +21,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 use Generator;
 
@@ -118,6 +119,32 @@ class Text implements TextHandler
             usage: $textResponse->usage,
             finishReason: $textResponse->finishReason,
             meta: $textResponse->meta,
+        );
+    }
+
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        $body = $this->buildBody($request);
+
+        // The count_tokens endpoint accepts the Messages shape but not the
+        // generation controls; strip them so it counts only the input. `thinking`
+        // is a generation hint (and bumps max_tokens) — drop it too.
+        unset($body['max_tokens'], $body['temperature'], $body['stream'], $body['thinking']);
+
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/messages/count_tokens",
+            headers: $this->headers(),
+            body: $body,
+            timeout: $this->config->timeout,
+            config: $request->requestConfig,
+            context: new ProviderRequestContext($this->config->provider, $request->model),
+        );
+
+        return new TokenCount(
+            inputTokens: (int) ($data['input_tokens'] ?? 0),
+            estimated: false,
+            provider: $this->config->provider,
+            model: $request->model,
         );
     }
 

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -13,6 +13,7 @@ use Atlasphp\Atlas\Providers\ChatCompletions\MessageFactory;
 use Atlasphp\Atlas\Providers\ChatCompletions\ResponseParser;
 use Atlasphp\Atlas\Providers\ChatCompletions\ToolMapper;
 use Atlasphp\Atlas\Providers\Concerns\AppliesToolChoice;
+use Atlasphp\Atlas\Providers\Concerns\CountsTokens;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Providers\SseParser;
@@ -21,6 +22,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Schema\StrictSchema;
 use Generator;
 
@@ -33,6 +35,7 @@ use Generator;
 class Text implements TextHandler
 {
     use AppliesToolChoice;
+    use CountsTokens;
 
     public function __construct(
         protected readonly ProviderConfig $config,
@@ -107,6 +110,17 @@ class Text implements TextHandler
             finishReason: $textResponse->finishReason,
             meta: $textResponse->meta,
         );
+    }
+
+    /**
+     * Estimate input tokens with the heuristic.
+     *
+     * OpenAI-compatible and local endpoints (Ollama, LM Studio) expose no
+     * server-side token-counting endpoint, so Atlas approximates the count.
+     */
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        return $this->estimateTokens($this->config->provider, $request->model, $this->buildBody($request));
     }
 
     /**

--- a/src/Providers/Concerns/CountsTokens.php
+++ b/src/Providers/Concerns/CountsTokens.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Concerns;
+
+use Atlasphp\Atlas\Responses\TokenCount;
+use Atlasphp\Atlas\Support\TokenCounter;
+
+/**
+ * Heuristic token estimation for providers without a native count endpoint.
+ *
+ * Walks a built request payload and sums the chars/4 estimate over every
+ * string leaf. Used by OpenAI-compatible and local providers (xAI, Ollama,
+ * LM Studio) and as a fallback when a native endpoint is unavailable. The
+ * resulting TokenCount is always flagged estimated:true — it is approximate,
+ * and base64-encoded media inflates the figure since the heuristic cannot
+ * distinguish encoded bytes from prose.
+ */
+trait CountsTokens
+{
+    /**
+     * Build an estimated TokenCount from a request payload.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    protected function estimateTokens(string $provider, string $model, array $payload): TokenCount
+    {
+        return new TokenCount(
+            inputTokens: $this->sumPayloadTokens($payload),
+            estimated: true,
+            provider: $provider,
+            model: $model,
+        );
+    }
+
+    /**
+     * Recursively sum the heuristic token count over a payload's string leaves.
+     *
+     * @param  array<int|string, mixed>  $payload
+     */
+    private function sumPayloadTokens(array $payload): int
+    {
+        $total = 0;
+
+        foreach ($payload as $value) {
+            if (is_array($value)) {
+                $total += $this->sumPayloadTokens($value);
+            } elseif (is_string($value)) {
+                $total += TokenCounter::count($value);
+            }
+        }
+
+        return $total;
+    }
+}

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -43,6 +43,7 @@ use Atlasphp\Atlas\Responses\RerankResponse;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\VideoResponse;
 use Atlasphp\Atlas\Responses\VoiceSession;
 use Closure;
@@ -113,6 +114,21 @@ abstract class Driver
     public function structured(TextRequest $request): StructuredResponse
     {
         return $this->dispatch('structured', $request, fn (TextRequest $r) => $this->resolveHandler('text', fn () => $this->textHandler())->structured($r));
+    }
+
+    /**
+     * Count the input tokens of a text request without running generation.
+     *
+     * Not routed through middleware — like the interrogation endpoints
+     * (models/voices), this is a cheap, read-only pre-flight call. Transport
+     * failures are translated to typed Atlas exceptions.
+     */
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        return $this->translating(
+            $request->model,
+            fn () => $this->resolveHandler('text', fn () => $this->textHandler())->countTokens($request),
+        );
     }
 
     public function image(ImageRequest $request): ImageResponse

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -21,6 +21,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Generator;
 
 /**
@@ -96,6 +97,42 @@ class Text implements TextHandler
             usage: $text->usage,
             finishReason: $text->finishReason,
             meta: $text->meta,
+        );
+    }
+
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        // The countTokens endpoint only counts system_instruction and tools when
+        // the full request is wrapped in generateContentRequest; the bare
+        // `contents` form silently ignores them.
+        $body = [
+            'generateContentRequest' => array_merge(
+                ['model' => "models/{$request->model}"],
+                $this->buildBody($request),
+            ),
+        ];
+
+        $data = $this->http->post(
+            url: $this->endpoint($request->model, 'countTokens'),
+            headers: $this->headers(),
+            body: $body,
+            timeout: $this->config->timeout,
+            config: $request->requestConfig,
+            context: new ProviderRequestContext($this->config->provider, $request->model),
+        );
+
+        $breakdown = [];
+
+        if (isset($data['cachedContentTokenCount'])) {
+            $breakdown['cached_tokens'] = (int) $data['cachedContentTokenCount'];
+        }
+
+        return new TokenCount(
+            inputTokens: (int) ($data['totalTokens'] ?? 0),
+            estimated: false,
+            provider: $this->config->provider,
+            model: $request->model,
+            breakdown: $breakdown,
         );
     }
 

--- a/src/Providers/Handlers/TextHandler.php
+++ b/src/Providers/Handlers/TextHandler.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 
 /**
  * Handler for text generation, streaming, and structured output.
@@ -19,4 +20,9 @@ interface TextHandler
     public function stream(TextRequest $request): StreamResponse;
 
     public function structured(TextRequest $request): StructuredResponse;
+
+    /**
+     * Count the input tokens of a request without running generation.
+     */
+    public function countTokens(TextRequest $request): TokenCount;
 }

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Http\ProviderRequestContext;
 use Atlasphp\Atlas\Providers\Concerns\AppliesToolChoice;
 use Atlasphp\Atlas\Providers\Concerns\BuildsHeaders;
+use Atlasphp\Atlas\Providers\Concerns\CountsTokens;
 use Atlasphp\Atlas\Providers\Contracts\MessageFactoryContract;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\OpenAi\Concerns\HasOrganizationHeader;
@@ -21,8 +22,10 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Schema\StrictSchema;
 use Generator;
+use Illuminate\Http\Client\RequestException;
 
 /**
  * OpenAI text handler using the Responses API.
@@ -36,6 +39,7 @@ class Text implements TextHandler
     use BuildsHeaders, HasOrganizationHeader {
         HasOrganizationHeader::extraHeaders insteadof BuildsHeaders;
     }
+    use CountsTokens;
 
     public function __construct(
         protected readonly ProviderConfig $config,
@@ -108,6 +112,50 @@ class Text implements TextHandler
             usage: $textResponse->usage,
             finishReason: $textResponse->finishReason,
             meta: $textResponse->meta,
+        );
+    }
+
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        $payload = $this->buildPayload($request);
+
+        // The input_tokens endpoint shares the Responses shape but rejects the
+        // generation controls; keep only what contributes to the input (model,
+        // input, instructions, tools).
+        unset(
+            $payload['max_output_tokens'],
+            $payload['temperature'],
+            $payload['stream'],
+            $payload['store'],
+            $payload['text'],
+            $payload['reasoning'],
+            $payload['include'],
+        );
+
+        try {
+            $data = $this->http->post(
+                url: "{$this->config->baseUrl}/responses/input_tokens",
+                headers: $this->headers(),
+                body: $payload,
+                timeout: $this->config->timeout,
+                config: $request->requestConfig,
+                context: new ProviderRequestContext($this->config->provider, $request->model),
+            );
+        } catch (RequestException $e) {
+            // OpenAI-compatible endpoints (Ollama, LM Studio) reuse this handler
+            // but may not implement input_tokens — fall back to a heuristic.
+            if (in_array($e->response->status(), [400, 404, 405], true)) {
+                return $this->estimateTokens($this->config->provider, $request->model, $payload);
+            }
+
+            throw $e;
+        }
+
+        return new TokenCount(
+            inputTokens: (int) ($data['input_tokens'] ?? 0),
+            estimated: false,
+            provider: $this->config->provider,
+            model: $request->model,
         );
     }
 

--- a/src/Providers/Xai/Handlers/Text.php
+++ b/src/Providers/Xai/Handlers/Text.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\Xai\Handlers;
 
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Text as OpenAiText;
 use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\TokenCount;
 
 /**
  * xAI text handler extending OpenAI's Responses API handler.
@@ -16,6 +17,18 @@ use Atlasphp\Atlas\Requests\TextRequest;
  */
 class Text extends OpenAiText
 {
+    /**
+     * Estimate input tokens with the heuristic.
+     *
+     * xAI exposes only a plain-text `tokenize-text` endpoint — it cannot count a
+     * full chat request (system, tools, images), so Atlas estimates instead of
+     * inheriting OpenAI's native /responses/input_tokens call.
+     */
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        return $this->estimateTokens($this->config->provider, $request->model, $this->buildPayload($request));
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Responses/TokenCount.php
+++ b/src/Responses/TokenCount.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Responses;
+
+/**
+ * Pre-flight input-token count for a text request.
+ *
+ * Returned by countTokens(). Reflects the input tokens of the exact payload
+ * Atlas would send (messages, system, tools, media). The $estimated flag is
+ * false when the number came from a provider's native count endpoint and true
+ * when it was approximated with the chars/4 heuristic (providers without a
+ * native endpoint). Output tokens are not counted — they are unknown until the
+ * model responds.
+ */
+final class TokenCount
+{
+    /**
+     * @param  array<string, int>  $breakdown  Optional per-category detail
+     *                                         (e.g. ['cached_tokens' => 1200]).
+     */
+    public function __construct(
+        public readonly int $inputTokens,
+        public readonly bool $estimated,
+        public readonly string $provider,
+        public readonly string $model,
+        public readonly array $breakdown = [],
+    ) {}
+
+    /**
+     * Convert to an array for JSON persistence or logging.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'input_tokens' => $this->inputTokens,
+            'estimated' => $this->estimated,
+            'provider' => $this->provider,
+            'model' => $this->model,
+        ];
+
+        if ($this->breakdown !== []) {
+            $data['breakdown'] = $this->breakdown;
+        }
+
+        return $data;
+    }
+}

--- a/src/Testing/FakeDriver.php
+++ b/src/Testing/FakeDriver.php
@@ -23,8 +23,10 @@ use Atlasphp\Atlas\Responses\RerankResponse;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\VideoResponse;
 use Atlasphp\Atlas\Responses\VoiceSession;
+use Atlasphp\Atlas\Support\TokenCounter;
 
 /**
  * A fake driver that records requests and returns responses from a sequence.
@@ -105,6 +107,28 @@ class FakeDriver extends Driver
         $this->record('structured', $request);
 
         return $this->nextResponseFor('structured')->toResponse();
+    }
+
+    /**
+     * Return a deterministic estimated count for the request.
+     *
+     * Estimates from the instructions + message only — it does NOT count tool
+     * schemas, attached media, or prior conversation turns. Use it to assert the
+     * call happened (`assertMethodCalled('countTokens')`), not to assert an exact
+     * token figure; real providers count the full payload.
+     */
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        $this->record('countTokens', $request);
+
+        $text = trim(($request->instructions ?? '').' '.($request->message ?? ''));
+
+        return new TokenCount(
+            inputTokens: TokenCounter::count($text),
+            estimated: true,
+            provider: $this->name(),
+            model: $request->model,
+        );
     }
 
     public function image(ImageRequest $request): ImageResponse

--- a/tests/Feature/CountTokensTest.php
+++ b/tests/Feature/CountTokensTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Responses\TokenCount;
+
+it('counts tokens through the text builder without running generation', function () {
+    $fake = Atlas::fake();
+
+    $count = Atlas::text('openai', 'gpt-4o')
+        ->message('Hello world')
+        ->countTokens();
+
+    expect($count)->toBeInstanceOf(TokenCount::class)
+        ->and($count->inputTokens)->toBeGreaterThan(0)
+        ->and($count->model)->toBe('gpt-4o');
+
+    // Exactly one driver interaction — the count — and no generation alongside it.
+    $fake->assertMethodCalled('countTokens');
+    $fake->assertSentCount(1);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -33,6 +33,7 @@ pest()->extend(TestCase::class)->in(
     'Feature/AtlasManagerMissingDefaultTest.php',
     'Feature/AtlasServiceProviderTest.php',
     'Feature/ConfigTest.php',
+    'Feature/CountTokensTest.php',
     'Feature/FacadeTest.php',
     'Feature/ProviderRegistryTest.php',
 );

--- a/tests/Unit/Middleware/MetaPassthroughTest.php
+++ b/tests/Unit/Middleware/MetaPassthroughTest.php
@@ -17,6 +17,7 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 
 function makeMetaTextRequest(array $meta = [], array $middleware = []): TextRequest
@@ -74,6 +75,11 @@ function makeMetaTestDriver(?MiddlewareStack $stack = null, ?MiddlewareResolver 
                 public function structured(TextRequest $request): StructuredResponse
                 {
                     return new StructuredResponse(structured: [], usage: new Usage(10, 5), finishReason: FinishReason::Stop);
+                }
+
+                public function countTokens(TextRequest $request): TokenCount
+                {
+                    return new TokenCount(inputTokens: 10, estimated: false, provider: 'test', model: $request->model);
                 }
             };
         }

--- a/tests/Unit/Pending/AgentRequestTest.php
+++ b/tests/Unit/Pending/AgentRequestTest.php
@@ -30,6 +30,7 @@ use Atlasphp\Atlas\Requests\Reasoning;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Responses\VoiceSession;
 use Atlasphp\Atlas\Schema\Schema;
@@ -265,6 +266,29 @@ it('executes asText without tools via direct driver call', function () {
 
     expect($response)->toBeInstanceOf(TextResponse::class);
     expect($response->text)->toBe('Hello!');
+});
+
+// ─── countTokens() ──────────────────────────────────────────────────────────
+
+it('counts tokens for an agent turn without running generation', function () {
+    registerTestAgent(RequestTestMinimalAgent::class);
+
+    $fake = new AtlasFake(app(ProviderRegistryContract::class), []);
+    app()->instance(AtlasFake::class, $fake);
+
+    config(['atlas.defaults.text' => ['provider' => 'openai', 'model' => 'gpt-4o-mini']]);
+    AtlasConfig::refresh();
+
+    $count = makeAgentRequest('minimal')
+        ->message('How many tokens is this agent turn?')
+        ->countTokens();
+
+    expect($count)->toBeInstanceOf(TokenCount::class)
+        ->and($count->inputTokens)->toBeGreaterThan(0)
+        ->and($count->model)->toBe('gpt-4o-mini');
+
+    $fake->assertMethodCalled('countTokens');
+    $fake->assertSentCount(1);
 });
 
 // ─── asText() — with configured agent ──────────────────────────────────────

--- a/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
@@ -456,3 +456,39 @@ it('omits the thinking block when reasoning is not set', function () {
 
     Http::assertSent(fn ($request) => ! isset($request['thinking']));
 });
+
+it('counts tokens via the count_tokens endpoint, stripping generation params', function () {
+    Http::fake([
+        'api.anthropic.com/v1/messages/count_tokens' => Http::response(['input_tokens' => 2095]),
+    ]);
+
+    $count = makeAnthropicTextHandler()->countTokens(makeAnthropicTextRequest([
+        'model' => 'claude-sonnet-4-5',
+        'maxTokens' => 1024,
+        'temperature' => 0.7,
+    ]));
+
+    expect($count->inputTokens)->toBe(2095)
+        ->and($count->estimated)->toBeFalse()
+        ->and($count->model)->toBe('claude-sonnet-4-5');
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.anthropic.com/v1/messages/count_tokens'
+            && $request['model'] === 'claude-sonnet-4-5'
+            && ! isset($request['max_tokens'])
+            && ! isset($request['temperature'])
+            && ! isset($request['stream']);
+    });
+});
+
+it('strips the thinking block when counting tokens for a reasoning request', function () {
+    Http::fake([
+        'api.anthropic.com/v1/messages/count_tokens' => Http::response(['input_tokens' => 50]),
+    ]);
+
+    makeAnthropicTextHandler()->countTokens(makeAnthropicTextRequest([
+        'reasoning' => new Reasoning(ReasoningEffort::Medium),
+    ]));
+
+    Http::assertSent(fn ($request) => ! isset($request['thinking']) && ! isset($request['max_tokens']));
+});

--- a/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ChatCompletionsHandlerTest.php
@@ -348,3 +348,18 @@ it('sends reasoning_effort when reasoning is set', function () {
 it('throws UnsupportedFeatureException for rerank', function () {
     makeChatCompletionsDriver()->rerank(new RerankRequest('model', 'query', ['doc']));
 })->throws(UnsupportedFeatureException::class, 'rerank');
+
+// ─── countTokens (heuristic) ────────────────────────────────────────────────
+
+it('countTokens returns a heuristic estimate for OpenAI-compatible endpoints', function () {
+    $request = new TextRequest(
+        model: 'llama3.2', instructions: 'You are helpful.', message: 'Estimate this please', messageMedia: [], messages: [],
+        maxTokens: null, temperature: null, schema: null, tools: [], providerTools: [], providerOptions: [],
+    );
+
+    $count = makeChatCompletionsDriver()->countTokens($request);
+
+    expect($count->estimated)->toBeTrue()
+        ->and($count->inputTokens)->toBeGreaterThan(0)
+        ->and($count->model)->toBe('llama3.2');
+});

--- a/tests/Unit/Providers/Concerns/CountsTokensTest.php
+++ b/tests/Unit/Providers/Concerns/CountsTokensTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Providers\Concerns\CountsTokens;
+use Atlasphp\Atlas\Responses\TokenCount;
+use Atlasphp\Atlas\Support\TokenCounter;
+
+function makeTokenEstimator(): object
+{
+    return new class
+    {
+        use CountsTokens;
+
+        /**
+         * @param  array<string, mixed>  $payload
+         */
+        public function estimate(string $provider, string $model, array $payload): TokenCount
+        {
+            return $this->estimateTokens($provider, $model, $payload);
+        }
+    };
+}
+
+it('flags the estimate and attributes provider/model', function () {
+    $count = makeTokenEstimator()->estimate('ollama', 'llama3', ['input' => 'Hello']);
+
+    expect($count->estimated)->toBeTrue()
+        ->and($count->provider)->toBe('ollama')
+        ->and($count->model)->toBe('llama3');
+});
+
+it('sums the chars/4 heuristic over every string leaf, recursively', function () {
+    $payload = [
+        'model' => 'ignored-but-counted',
+        'messages' => [
+            ['role' => 'user', 'content' => 'aaaaaaaa'],   // 8 chars -> 2
+            ['role' => 'system', 'content' => 'bbbb'],      // 4 chars -> 1
+        ],
+        'max_tokens' => 256, // non-string, ignored
+    ];
+
+    $expected = TokenCounter::count('ignored-but-counted')
+        + TokenCounter::count('user') + TokenCounter::count('aaaaaaaa')
+        + TokenCounter::count('system') + TokenCounter::count('bbbb');
+
+    expect(makeTokenEstimator()->estimate('x', 'y', $payload)->inputTokens)->toBe($expected);
+});

--- a/tests/Unit/Providers/DriverDispatchTest.php
+++ b/tests/Unit/Providers/DriverDispatchTest.php
@@ -35,6 +35,7 @@ use Atlasphp\Atlas\Responses\RerankResult;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Responses\VideoResponse;
 
@@ -92,6 +93,11 @@ function makeDispatchDriver(?MiddlewareStack $stack = null, ?MiddlewareResolver 
                 public function structured(TextRequest $request): StructuredResponse
                 {
                     return new StructuredResponse(structured: [], usage: new Usage(10, 5), finishReason: FinishReason::Stop);
+                }
+
+                public function countTokens(TextRequest $request): TokenCount
+                {
+                    return new TokenCount(inputTokens: 10, estimated: false, provider: 'test', model: $request->model);
                 }
             };
         }

--- a/tests/Unit/Providers/DriverWithHandlerTest.php
+++ b/tests/Unit/Providers/DriverWithHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Enums\VoiceTransport;
+use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Providers\Handlers\AudioHandler;
@@ -239,4 +240,28 @@ it('custom handler returns correct response types for each modality', function (
 
     $audioResponse = $customDriver->audio(makeHandlerTestAudioReq());
     expect($audioResponse)->toBeInstanceOf(AudioResponse::class);
+});
+
+// ─── countTokens ────────────────────────────────────────────────────────────
+
+it('routes countTokens to the text handler', function () {
+    $count = createConcreteDriverWithText()->countTokens(makeTextReq('concrete-model'));
+
+    expect($count->inputTokens)->toBe(10)
+        ->and($count->model)->toBe('concrete-model');
+});
+
+it('countTokens throws UnsupportedFeatureException on a driver with no text handler', function () {
+    makeBareDriver()->countTokens(makeTextReq());
+})->throws(UnsupportedFeatureException::class);
+
+it('countTokens uses an overridden text handler', function () {
+    $handler = Mockery::mock(TextHandler::class);
+    $handler->shouldReceive('countTokens')->once()->andReturn(
+        new TokenCount(inputTokens: 99, estimated: false, provider: 'test', model: 'model'),
+    );
+
+    $count = createConcreteDriverWithText()->withHandler('text', $handler)->countTokens(makeTextReq());
+
+    expect($count->inputTokens)->toBe(99);
 });

--- a/tests/Unit/Providers/DriverWithHandlerTest.php
+++ b/tests/Unit/Providers/DriverWithHandlerTest.php
@@ -21,6 +21,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 use Atlasphp\Atlas\Responses\VoiceSession;
 
@@ -95,6 +96,11 @@ function createConcreteDriverWithText(): Driver
                 public function structured(TextRequest $request): StructuredResponse
                 {
                     throw new RuntimeException('Not implemented');
+                }
+
+                public function countTokens(TextRequest $request): TokenCount
+                {
+                    return new TokenCount(inputTokens: 10, estimated: false, provider: 'test', model: $request->model);
                 }
             };
         }

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -307,3 +307,24 @@ it('omits thinkingConfig when reasoning is not set', function () {
 
     Http::assertSent(fn ($request) => ! isset($request['generationConfig']['thinkingConfig']));
 });
+
+it('counts tokens via the countTokens endpoint using a generateContentRequest wrapper', function () {
+    Http::fake([
+        '*:countTokens*' => Http::response([
+            'totalTokens' => 123,
+            'cachedContentTokenCount' => 10,
+        ]),
+    ]);
+
+    $count = makeGoogleTextHandler()->countTokens(makeGoogleTextRequest(['model' => 'gemini-2.5-flash']));
+
+    expect($count->inputTokens)->toBe(123)
+        ->and($count->estimated)->toBeFalse()
+        ->and($count->breakdown)->toBe(['cached_tokens' => 10]);
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), ':countTokens')
+            && isset($request['generateContentRequest'])
+            && isset($request['generateContentRequest']['contents']);
+    });
+});

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -395,3 +395,40 @@ it('requests encrypted reasoning content for stateless replay when reasoning is 
 
     Http::assertSent(fn ($request) => $request['include'] === ['reasoning.encrypted_content']);
 });
+
+it('counts tokens via the responses/input_tokens endpoint, stripping generation params', function () {
+    Http::fake([
+        'api.openai.com/v1/responses/input_tokens' => Http::response([
+            'object' => 'response.input_tokens',
+            'input_tokens' => 42,
+        ]),
+    ]);
+
+    $count = makeTextHandler()->countTokens(makeOpenAiTextRequest([
+        'maxTokens' => 256,
+        'temperature' => 0.5,
+    ]));
+
+    expect($count->inputTokens)->toBe(42)
+        ->and($count->estimated)->toBeFalse();
+
+    Http::assertSent(function ($request) {
+        return $request->url() === 'https://api.openai.com/v1/responses/input_tokens'
+            && ! isset($request['max_output_tokens'])
+            && ! isset($request['temperature'])
+            && ! isset($request['stream']);
+    });
+});
+
+it('falls back to a heuristic estimate when input_tokens is unsupported', function () {
+    Http::fake([
+        'api.openai.com/v1/responses/input_tokens' => Http::response(['error' => 'not found'], 404),
+    ]);
+
+    $count = makeTextHandler()->countTokens(makeOpenAiTextRequest([
+        'message' => 'Hello world, this is a heuristic fallback test.',
+    ]));
+
+    expect($count->estimated)->toBeTrue()
+        ->and($count->inputTokens)->toBeGreaterThan(0);
+});

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -20,6 +20,7 @@ use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Schema\Schema;
 use Atlasphp\Atlas\Tools\ToolChoice;
 use Atlasphp\Atlas\Tools\ToolDefinition;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 
@@ -431,4 +432,13 @@ it('falls back to a heuristic estimate when input_tokens is unsupported', functi
 
     expect($count->estimated)->toBeTrue()
         ->and($count->inputTokens)->toBeGreaterThan(0);
+});
+
+it('rethrows a non-fallback error from input_tokens instead of estimating', function () {
+    Http::fake([
+        'api.openai.com/v1/responses/input_tokens' => Http::response(['error' => 'unauthorized'], 401),
+    ]);
+
+    expect(fn () => makeTextHandler()->countTokens(makeOpenAiTextRequest()))
+        ->toThrow(RequestException::class);
 });

--- a/tests/Unit/Providers/Xai/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Xai/Handlers/TextHandlerTest.php
@@ -237,3 +237,13 @@ it('does not send the OpenAI reasoning include to xAI', function () {
 
     Http::assertSent(fn ($request) => ! isset($request['include']));
 });
+
+it('estimates tokens heuristically since xAI has no full-request count endpoint', function () {
+    $count = makeXaiTextHandler()->countTokens(makeXaiHandlerTextRequest([
+        'message' => 'Hello world, estimate me.',
+    ]));
+
+    expect($count->estimated)->toBeTrue()
+        ->and($count->inputTokens)->toBeGreaterThan(0)
+        ->and($count->model)->toBe('grok-3');
+});

--- a/tests/Unit/Responses/TokenCountTest.php
+++ b/tests/Unit/Responses/TokenCountTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Responses\TokenCount;
+
+it('exposes its fields', function () {
+    $count = new TokenCount(
+        inputTokens: 1234,
+        estimated: false,
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+    );
+
+    expect($count->inputTokens)->toBe(1234)
+        ->and($count->estimated)->toBeFalse()
+        ->and($count->provider)->toBe('anthropic')
+        ->and($count->model)->toBe('claude-sonnet-4-5')
+        ->and($count->breakdown)->toBe([]);
+});
+
+it('omits an empty breakdown from the array form', function () {
+    $count = new TokenCount(10, true, 'xai', 'grok-3');
+
+    expect($count->toArray())->toBe([
+        'input_tokens' => 10,
+        'estimated' => true,
+        'provider' => 'xai',
+        'model' => 'grok-3',
+    ]);
+});
+
+it('includes a non-empty breakdown in the array form', function () {
+    $count = new TokenCount(100, false, 'google', 'gemini-2.5-flash', ['cached_tokens' => 30]);
+
+    expect($count->toArray())->toBe([
+        'input_tokens' => 100,
+        'estimated' => false,
+        'provider' => 'google',
+        'model' => 'gemini-2.5-flash',
+        'breakdown' => ['cached_tokens' => 30],
+    ]);
+});


### PR DESCRIPTION
This pull request introduces a new feature for pre-flight token counting, allowing users to estimate the number of input tokens a request will consume before sending it to the provider. This is implemented across the codebase, documented thoroughly, and validated with live API tests. The feature supports native token count endpoints for Anthropic, OpenAI, and Google, with heuristic fallback for other providers. The documentation and changelogs have been updated, and a new guide and test script are included.

**New Feature: Pre-flight Token Counting**

* Added `countTokens()` method to both `TextRequest` and `AgentRequest` builders, enabling users to count input tokens before sending a request. This uses provider-native endpoints where available (Anthropic, OpenAI, Google) and a heuristic elsewhere (xAI, Ollama, LM Studio). The method returns a `TokenCount` object, which includes an `estimated` flag to indicate whether the count is exact or estimated. [[1]](diffhunk://#diff-6d87fabba941694aa1fb85525624c76f6d67d188bdf071d9d255eeeedb537ab4R417-R434) [[2]](diffhunk://#diff-1668325ecfaf9dfb0e9831a0bd5145ee595d13b66f9cb715f382ebfbd0c995abR416-R433)

* Introduced support for token counting in the codebase, including necessary imports and wiring for the new `TokenCount` response type. [[1]](diffhunk://#diff-6d87fabba941694aa1fb85525624c76f6d67d188bdf071d9d255eeeedb537ab4R40) [[2]](diffhunk://#diff-1668325ecfaf9dfb0e9831a0bd5145ee595d13b66f9cb715f382ebfbd0c995abR59) [[3]](diffhunk://#diff-508b2aea0146fffd530b0a67da72e06394447374097508f2b8f81eb20b68c1d3R24)

**Documentation & Guides**

* Added a comprehensive [Token Counting guide](docs/guides/token-counting.md) covering usage, rationale, provider support, cost estimation, and budget enforcement strategies.
* Updated the main documentation (`modalities/text.md`) to explain the new `countTokens()` method and how to use it for pre-flight estimation.
* Linked the new guide in the navigation sidebar.

**Testing & Validation**

* Added a new live test script (`sandbox/test-token-counting.php`) that validates the accuracy of `countTokens()` against real provider endpoints, including checks for multimodal requests and tool schema inclusion.
* Updated the audit log (`AUDIT.md`) with a new section and results for token counting, showing 22/22 live checks passed and describing the methodology and findings. [[1]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688L7-R7) [[2]](diffhunk://#diff-bf8286ac6afb95a1e97f872de3403c5f576d40ed7d08c76ee6647b3122efe688R219-R238)

**Changelog & Comparison**

* Documented the new feature in the changelog (`CHANGELOG.md`) and updated the feature comparison table to highlight pre-flight token counting as a unique capability. ([CHANGELOG.mdR16](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16), F3c42ecL24R24)