### PR TITLE
Add Batch API (jobs, polling, persistence)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -4,7 +4,7 @@ Status of each provider's modalities against **real provider APIs**, exercised v
 sandbox harness (`sandbox/test-{provider}-provider.php` and feature scripts). This file
 records the date each modality last **passed a live API test** — not unit-test coverage.
 
-**Token counting (live, all 4 providers, 22/22): 2026-06-11** · **Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Structured output strict-mode (builder, live OpenAI/Google/Anthropic): 2026-06-10** · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
+**Batch API (live, OpenAI/Anthropic/Google, both persistence modes): 2026-06-12** · **Token counting (live, all 4 providers, 22/22): 2026-06-11** · **Last full run: 2026-06-10** (all 4 providers — **97/97 green**; the two 2026-06-09 transient failures (OpenAI TTS, xAI voices) now pass) · **Structured output strict-mode (builder, live OpenAI/Google/Anthropic): 2026-06-10** · **Error handling & resilience (all 4 providers): 2026-06-10** · **Error & request context tracing (all 4 providers, 56/56): 2026-06-10** · **Forced tool choice (all 4 providers): 2026-06-09** · **Image-to-image (reference media): 2026-06-08** · **Prompt caching + media replay: 2026-06-07** · **Provider-tools run: 2026-06-06**
 
 Reproduce:
 - Per-provider suites: `cd sandbox && php test-{provider}-provider.php`
@@ -35,6 +35,20 @@ Both require the provider's API key in `sandbox/.env`.
 | LM Studio¹  | ⚠️   | ⚠️     | ⚠️         | ⚠️    | —          | —      | —     | —   | —   | —          | —          | —      | —     | —     | —              |
 
 ¹ OpenAI-compatible endpoints via the shared `chat_completions` driver.
+
+## Batch API (live, 2026-06-12)
+
+Deferred batch jobs at ~50% cost, exercised end-to-end against the real provider APIs via `sandbox/test-batch*.php`. Verified in **both** persistence modes (stateless = submit + poll the provider yourself; tracked = persisted `BatchJob`, hydrated by `atlas:batch-poll`).
+
+| Provider | Modalities | Stateless | Tracked (tables) | End-to-end results |
+|----------|------------|:---------:|:----------------:|--------------------|
+| OpenAI    | text, embeddings | ✅ | ✅ | ✅ text round-trip (ALPHA/BETA); embeddings submit+status (results verify-later) |
+| Anthropic | text             | ✅ | ✅ | ✅ submit+status both modes (results verify-later — slower turnaround) |
+| Google    | text             | ✅ | ✅ | ✅ full round-trip both modes — results + counts + rolled-up usage accurate in `atlas_batch_jobs`/`atlas_batch_results` |
+
+- ✅ Tables verified: per-line results correlated by `custom_id`, job counts accurate, token usage rolled up = sum of line usage. Prune (`atlas:batch-prune`) deletes jobs + results + empty groups past `atlas.batch.retention_days` (90).
+- Reproduce: `cd sandbox && php test-batch-modes.php` (both modes, OpenAI+Anthropic), `php test-batch-google-e2e.php` (Google both modes), `php test-batch-tables.php` (table accuracy + prune).
+- Anthropic/Google embeddings batch and image/video batch are a documented follow-up; xAI batch likewise.
 
 ## Provider tools (live, 2026-06-06; full coverage re-run 2026-06-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `Atlas::batch()` (OpenAI; text, vision, and embeddings) submits large request sets as deferred jobs for ~50% lower cost. With persistence, `atlas:batch-poll` pulls results in keyed to your records by `custom_id`, and `atlas:batch-prune` bounds history (`atlas.batch.retention_days`, default 90). Tools and per-request middleware aren't supported and are rejected up front.
+- `Atlas::batch()` submits large request sets as deferred jobs for ~50% lower cost — OpenAI (text, vision, embeddings), Anthropic and Google/Gemini (text, vision). With persistence on, `submit()` auto-tracks the job, `atlas:batch-poll` pulls results in keyed to your records by `custom_id`, and `atlas:batch-prune` bounds history (`atlas.batch.retention_days`, default 90); with it off, batching is stateless and you poll the provider yourself. Tools and per-request middleware aren't supported and are rejected up front.
 - `->reasoning(ReasoningEffort)` on text and agent requests (and an `Agent::reasoning()` default) enables extended thinking at one effort level (`Minimal`/`Low`/`Medium`/`High`), mapped to each provider's format. Optional `budgetTokens:` and `includeSummary:`.
 - `->countTokens()` on text and agent requests returns input-token count before sending — exact on Anthropic/OpenAI/Google, estimated on xAI/Ollama/LM Studio. Returns a `TokenCount` with an `estimated` flag.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
+- `Atlas::batch()` (OpenAI; text, vision, and embeddings) submits large request sets as deferred jobs for ~50% lower cost. With persistence, `atlas:batch-poll` pulls results in keyed to your records by `custom_id`, and `atlas:batch-prune` bounds history (`atlas.batch.retention_days`, default 90). Tools and per-request middleware aren't supported and are rejected up front.
 - `->reasoning(ReasoningEffort)` on text and agent requests (and an `Agent::reasoning()` default) enables extended thinking at one effort level (`Minimal`/`Low`/`Medium`/`High`), mapped to each provider's format. Optional `budgetTokens:` and `includeSummary:`.
 - `->countTokens()` on text and agent requests returns input-token count before sending — exact on Anthropic/OpenAI/Google, estimated on xAI/Ollama/LM Studio. Returns a `TokenCount` with an `estimated` flag.
 
 ### Fixed
 
 - Extended thinking now works through multi-step tool calls and persisted-conversation reloads.
-- Google (Gemini) tool calls no longer 400 on non-object results (number, boolean, array, quoted string) — these are now wrapped automatically. Plain strings and JSON objects are unchanged.
+- Google (Gemini) tool calls no longer 400 on non-object results (number, boolean, array, quoted string) — wrapped automatically. Plain strings and JSON objects are unchanged.
 
 ### Migration
 
-**No breaking changes** — drop-in upgrade.
+**No breaking changes** — drop-in upgrade. Stateless batching (submit, then poll the provider yourself) needs no setup. Tracked batching (auto-polled, persisted results) adds new tables — publish and migrate:
+
+```bash
+php artisan vendor:publish --tag=atlas-migrations
+php artisan migrate
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,48 +21,46 @@
 
 # 🪐 Atlas
 
-Atlas is a unified AI SDK for Laravel applications. It owns its own provider layer — no external AI package dependency. Atlas talks directly to AI provider APIs, manages the tool call loop, and provides optional persistence for conversations, execution tracking, and agent memory.
+**A unified AI SDK for Laravel — agents, tools, and 10 modalities across every major provider.**
 
-## ✨ Features
+One API for OpenAI, Anthropic, Google, xAI, ElevenLabs, and any OpenAI-compatible endpoint. Atlas owns its own provider layer — no external AI package dependency — talks directly to provider APIs, manages the tool call loop, and adds optional persistence for conversations, execution tracking, and agent memory.
 
-- **Agents**
-  - Reusable classes encapsulating provider, model, instructions, tools, and behavior
-- **Tools**
-  - Typed tool classes with parameter schemas and dependency injection
-- **Sub-agents**
-  - Delegate tasks to other agents as tools, with isolated context, depth/cycle guards, and an auditable parent → child execution tree. Fan out to multiple sub-agents **concurrently** (true parallel execution via forking) so independent work runs at the same time
-- **10 Modalities**
-  - Text, images, audio (speech, music, sound effects), video, voice, embeddings, reranking
-- **Similarity Search**
-  - Unified `Atlas::similaritySearch()` over whole-record or chunked embeddings; also available as an agent tool
-- **Chunked Embeddings**
-  - Index long-form, frequently-edited content with diff-based reconciliation — edits re-embed only what changed
-- **Variable Interpolation**
-  - `{variable}` placeholders in instructions resolved at runtime
-- **Middleware**
-  - Four layers (agent, step, tool, provider) for logging, auth, metrics, and control
-- **Structured Output**
-  - Schema-validated JSON responses from any provider
-- **Streaming**
-  - SSE and Laravel Broadcasting with real-time chunk delivery
-- **Voice**
-  - Real-time bidirectional voice conversations with tool support
-- **Conversations**
-  - Multi-turn chat with message history, retry, and sibling tracking
-- **Persistence**
-  - Optional execution tracking and asset storage
-- **Queue Support**
-  - Async execution with broadcasting and callbacks
-- **Testing**
-  - Full fake system with assertions — no API keys required
-- **Provider Tools**
-  - Web search, code interpreter, file search via provider-native tools
-- **Provider Discovery**
-  - List available models, voices, and run content moderation
-- **Custom Providers**
-  - OpenAI-compatible endpoints or fully custom drivers
-- **All Providers**
-  - OpenAI, Anthropic, Google (Gemini), xAI (Grok), ElevenLabs, Cohere, Jina, plus any OpenAI-compatible API (Ollama, Groq, DeepSeek, Together, OpenRouter, LM Studio)
+> Every provider modality is **live-tested against real provider APIs**. See the [API Audit](./AUDIT.md).
+
+## ⚡ It's this simple
+
+```php
+use Atlasphp\Atlas\Atlas;
+
+$response = Atlas::text('openai', 'gpt-4o-mini')
+    ->message('Draft a brief, friendly email letting a client know their project is running two days behind, and propose Thursday for delivery.')
+    ->asText();
+
+echo $response->text;
+//  Hi Jordan — a quick heads-up that we're running about two days behind
+//  on the project. We're aiming to have everything to you by Thursday..."
+```
+
+No agent classes, no config, no boilerplate. Add an `->instructions()` and `->withTools()` when you need them — or promote the whole thing into a reusable [Agent](#define-an-agent) when your app grows.
+
+## 🎯 Highlights
+
+- **The most complete modality coverage** — text, structured output, images, audio, music, sound effects, video, embeddings, reranking, moderation, and **realtime bidirectional voice**. Music, SFX, video, and voice are Atlas-only among Laravel AI libraries.
+- **A real agent framework** — first-class agent classes, sub-agents with delegation and depth/cycle guards, true parallel fan-out via forking, and an auditable parent → child execution tree.
+- **Production persistence** — conversation memory, execution tracking, retry & branch, and a dedicated media-asset model auto-stored to disk (S3/local) and linked to messages.
+- **Operational maturity** — pre-flight token counting (including tools & images), provider-call observability with correlation IDs across retries, and runtime model/voice discovery and capability checks.
+- **Control at every layer** — middleware across agent, step, tool, and provider boundaries for logging, auth, and metrics.
+- **Multi-provider, one API** — OpenAI, Anthropic, Google, xAI, ElevenLabs, Cohere, Jina, plus any OpenAI-compatible endpoint. Swap providers by changing a string.
+
+## 💡 Why Atlas?
+
+Plenty of AI libraries get you a response and stop there. Atlas is built for everything that happens after the happy path — the retries, errors, timeouts, and tracking that real applications run into.
+
+- **Tested for real, not mocked.** Every modality on every provider is exercised against the live API and published in the [API Audit](./AUDIT.md) — and every feature ships with automated tests (see the coverage badge above). What the docs say is what ships.
+- **Production-hardened.** Automatic retries with backoff, typed exceptions you can catch by case, observability with correlation IDs across retries, and cost tracking that survives an interrupted stream — the failure modes real apps hit are already handled.
+- **Keeps pace with the providers.** When they ship a new model, tool, or capability, Atlas moves nearly as fast — the [CHANGELOG](./CHANGELOG.md) shows the cadence.
+
+And where it counts, Atlas simply does more: realtime voice, video, retry & branch, and pre-flight token counting are all Atlas-only among Laravel AI libraries. **[See the full comparison →](./COMPARISON.md)**
 
 ## 🚀 Quick Start
 
@@ -81,7 +79,7 @@ php artisan vendor:publish --tag=atlas-config
 ```php
 use Atlasphp\Atlas\Agent;
 
-class SupportAgent extends Agent
+class PlantShopAgent extends Agent
 {
     public function provider(): ?string
     {
@@ -96,16 +94,17 @@ class SupportAgent extends Agent
     public function instructions(): ?string
     {
         return <<<'PROMPT'
-        You are a customer support specialist for {company_name}.
+        You are Fern, the friendly plant-care and order specialist for {shop_name}.
 
-        ## Customer Context
+        ## Customer
         - **Name:** {customer_name}
-        - **Account Tier:** {account_tier}
+        - **Member since:** {member_since}
 
-        ## Guidelines
-        - Always greet the customer by name
-        - For order inquiries, use `lookup_order` before providing details
-        - Before processing refunds, verify eligibility using order data
+        ## How you help
+        - Greet {customer_name} by name and keep it warm.
+        - For anything about an order, call `lookup_order` first — never guess a status.
+        - If a plant arrived damaged, use `start_return` to open a replacement, then reassure them.
+        - Drop in a genuinely useful care tip when it fits.
         PROMPT;
     }
 
@@ -113,7 +112,7 @@ class SupportAgent extends Agent
     {
         return [
             LookupOrderTool::class,
-            ProcessRefundTool::class,
+            StartReturnTool::class,
         ];
     }
 }
@@ -138,13 +137,13 @@ class LookupOrderTool extends Tool
 
     public function description(): string
     {
-        return 'Look up order details by order ID';
+        return 'Look up the status and contents of an order by its ID';
     }
 
     public function parameters(): array
     {
         return [
-            new StringField('order_id', 'The order ID to look up'),
+            new StringField('order_id', 'The order ID, e.g. "5512"'),
         ];
     }
 
@@ -152,7 +151,7 @@ class LookupOrderTool extends Tool
     {
         $order = $this->orders->find($args['order_id']);
 
-        return $order ? $order->toArray() : 'Order not found';
+        return $order ? $order->toArray() : 'No order found with that ID.';
     }
 }
 ```
@@ -160,32 +159,28 @@ class LookupOrderTool extends Tool
 ### Chat with the Agent
 
 ```php
-$response = Atlas::agent('support')
+$response = Atlas::agent('plant-shop')
     ->withVariables([
-        'company_name' => 'Acme',
+        'shop_name' => 'Leaf & Co.',
         'customer_name' => 'Sarah',
-        'account_tier' => 'Premium',
+        'member_since' => '2023',
     ])
-    ->withTools([
-        HelpDeskSearchTool::class,
-        OrderStatusTool::class,
-    ])
-    ->message('Where is my order #12345?')
+    ->message('My monstera arrived with a snapped leaf — order #5512. Can I get a replacement?')
     ->asText();
 
-$response->text;    // "Hello Sarah! Let me look that up..."
+$response->text;    // "Oh no, Sarah! Let me pull up #5512 for you..."
 $response->usage;   // Token usage
-$response->steps;   // Tool call loop history
+$response->steps;   // Tool call loop — lookup_order, then start_return
 ```
 
 ### Speak with the Agent (Voice to Voice)
 
 ```php
-$session = Atlas::agent('support')
+$session = Atlas::agent('plant-shop')
     ->withVariables([
-        'company_name' => 'Acme',
+        'shop_name' => 'Leaf & Co.',
         'customer_name' => 'Sarah',
-        'account_tier' => 'Premium',
+        'member_since' => '2023',
     ])
     ->asVoice();
 
@@ -195,16 +190,71 @@ return response()->json($session->toClientPayload());
 
 See the [Voice Integration Guide](https://atlasphp.org/guides/voice-integration/) for full setup instructions.
 
-## 💡 Why Atlas?
+### Optional: Enable Persistence
 
-**The problem:** Prompts scattered across controllers, duplicated configurations, business logic tightly coupled with AI calls, and no consistent way to add logging, validation, or error handling.
+Atlas runs fully stateless by default — no database required. To unlock conversation history, execution tracking, media-asset storage, and retry & branch, publish and run the migrations:
 
-**Atlas structures your AI layer:**
+```bash
+php artisan vendor:publish --tag=atlas-migrations
+php artisan migrate
+```
 
-- **Agents** — AI configurations live in dedicated classes, not inline across your codebase.
-- **Tools** — Business logic stays in tool classes with typed parameters. Agents call tools; tools call your services.
-- **Middleware** — Add logging, auth, or metrics at four execution layers without coupling the codebase.
-- **Testable** — Full fake system with per-modality assertions using standard Laravel testing patterns.
+Then turn it on in `.env`:
+
+```env
+ATLAS_PERSISTENCE_ENABLED=true
+```
+
+That's it — `->for($user)` and `->forConversation($id)` now load and persist history automatically.
+
+## ✨ Features
+
+### Core generation
+
+- **Text & structured output** — schema-validated JSON from any provider
+- **Streaming** — SSE + Laravel Broadcasting, real-time chunks
+- **Tool calling** — typed tools, multi-step loop, concurrent execution
+- **Reasoning** — configure, stream, and persist extended thinking
+- **Prompt caching** — cache long system prompts to cut cost
+- **Token counting** — count input (with tools & images) before sending
+
+### Agent framework
+
+- **Agents** — provider, model, instructions, and tools in one reusable class
+- **Sub-agents** — delegation with depth/cycle guards, lineage, and parallel fan-out
+- **Conversations & memory** — multi-turn history, retry & branch, agent memory
+- **Execution tracking** — steps, tools, usage, and assets persisted
+- **Media assets** — auto-stored to disk (S3/local), linked to messages
+- **Middleware** — agent, step, tool, and provider layers
+- **Variable interpolation** — `{var}` placeholders resolved at runtime
+- **Queues** — async execution with broadcasting and callbacks
+
+### Modalities
+
+- **10 modalities** — text, images, audio, music, sound effects, video, voice, embeddings, reranking, moderation
+- **Realtime voice** — bidirectional voice conversations with tools
+- **Similarity search** — whole-record or chunked embeddings, diff-based re-embedding
+
+### Ecosystem & tooling
+
+- **Provider tools** — web search, code interpreter, file search
+- **MCP** — composes with [Laravel MCP](https://github.com/laravel/mcp)
+- **Provider discovery** — list models/voices, validate keys, inspect capabilities
+- **Observability** — trace every provider call, correlation IDs across retries
+- **Testing** — full per-modality fakes, no API keys required
+- **Custom providers** — OpenAI-compatible endpoints or fully custom drivers
+
+## 🔌 Providers
+
+Atlas talks to every major provider through one interface. Switch by changing a string — your agents, tools, and middleware stay the same.
+
+**First-party drivers**
+
+OpenAI · Anthropic · Google (Gemini) · xAI (Grok) · ElevenLabs · Cohere · Jina
+
+**Any OpenAI-compatible API**
+
+Ollama · Groq · DeepSeek · Together · OpenRouter · LM Studio · Mistral · Perplexity
 
 ## 📖 Documentation
 

--- a/config/atlas.php
+++ b/config/atlas.php
@@ -217,6 +217,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Batch
+    |--------------------------------------------------------------------------
+    |
+    | Deferred batch jobs run at ~50% of synchronous cost and resolve within
+    | the provider's completion window. Tracked batches (persistence enabled)
+    | are advanced by the `atlas:batch-poll` command — schedule it to bring in
+    | results. There is no enable flag: batch only runs when you call
+    | Atlas::batch(), and polling is gated by persistence being enabled.
+    |
+    */
+
+    'batch' => [
+        // Max open jobs the `atlas:batch-poll` command advances per run.
+        'poll_limit' => (int) env('ATLAS_BATCH_POLL_LIMIT', 25),
+
+        // Provider completion window for submitted batches.
+        'completion_window' => env('ATLAS_BATCH_WINDOW', '24h'),
+
+        // Days of batch history (jobs + their results) to keep. The
+        // `atlas:batch-prune` command deletes anything older; schedule it daily.
+        'retention_days' => (int) env('ATLAS_BATCH_RETENTION_DAYS', 90),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Streaming
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/0017_create_atlas_batch_groups_table.php
+++ b/database/migrations/0017_create_atlas_batch_groups_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function tableName(string $name): string
+    {
+        return config('atlas.persistence.table_prefix', 'atlas_').$name;
+    }
+
+    public function up(): void
+    {
+        Schema::create($this->tableName('batch_groups'), function (Blueprint $table) {
+            $table->id();
+            $table->string('label')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->tableName('batch_groups'));
+    }
+};

--- a/database/migrations/0018_create_atlas_batch_jobs_table.php
+++ b/database/migrations/0018_create_atlas_batch_jobs_table.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function tableName(string $name): string
+    {
+        return config('atlas.persistence.table_prefix', 'atlas_').$name;
+    }
+
+    public function up(): void
+    {
+        Schema::create($this->tableName('batch_jobs'), function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('batch_group_id')->nullable()
+                ->constrained($this->tableName('batch_groups'))->nullOnDelete();
+            $table->string('provider', 50);
+            $table->string('modality', 30);
+            $table->string('batch_id', 191)->nullable();
+            $table->string('status', 30);
+            $table->unsignedInteger('total')->default(0);
+            $table->unsignedInteger('succeeded')->default(0);
+            $table->unsignedInteger('failed')->default(0);
+            $table->unsignedInteger('processing')->default(0);
+            $table->json('usage')->nullable();
+            $table->string('input_file_id', 191)->nullable();
+            $table->string('output_file_id', 191)->nullable();
+            $table->text('error')->nullable();
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            // Polling: the open() scope filters by status; the composite serves
+            // the --provider filter. Pruning sweeps by age, so created_at is
+            // indexed to keep that delete fast as the table grows to millions.
+            $table->index('batch_id');
+            $table->index('status');
+            $table->index(['provider', 'status']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->tableName('batch_jobs'));
+    }
+};

--- a/database/migrations/0019_create_atlas_batch_results_table.php
+++ b/database/migrations/0019_create_atlas_batch_results_table.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    protected function tableName(string $name): string
+    {
+        return config('atlas.persistence.table_prefix', 'atlas_').$name;
+    }
+
+    public function up(): void
+    {
+        Schema::create($this->tableName('batch_results'), function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('batch_job_id')
+                ->constrained($this->tableName('batch_jobs'))->cascadeOnDelete();
+            $table->string('custom_id', 191);
+            $table->string('status', 20);
+            $table->json('response')->nullable();
+            $table->json('usage')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamps();
+
+            // Unique: one result per (job, custom_id). Doubles as the trace-back
+            // lookup index and hard-stops any duplicate insert on a retry.
+            $table->unique(['batch_job_id', 'custom_id']);
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->tableName('batch_results'));
+    }
+};

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -276,6 +276,7 @@ gtag('config', 'G-JEV06LWG7N');`],
                     { text: 'Embeddings', link: '/modalities/embeddings' },
                     { text: 'Reranking', link: '/modalities/reranking' },
                     { text: 'Moderation', link: '/modalities/moderation' },
+                    { text: 'Batch', link: '/modalities/batch' },
                     { text: 'Models', link: '/modalities/models' },
                     { text: 'Voices', link: '/modalities/voices' },
                 ]

--- a/docs/modalities/batch.md
+++ b/docs/modalities/batch.md
@@ -9,9 +9,11 @@ Batch is ideal for latency-tolerant fan-out work — captioning thousands of ima
 | Provider | Batchable modalities |
 |----------|----------------------|
 | **OpenAI** | `text` (including vision input), `embeddings` |
+| **Anthropic** | `text` (including vision input) |
+| **Google** (Gemini) | `text` (including vision input) |
 
 ::: tip
-Anthropic, Google, and xAI also offer batch APIs; their Atlas handlers are a planned follow-up. Any provider that can't batch a request throws `UnsupportedFeatureException` up front.
+Asking a provider to batch a modality it doesn't support — or a non-batchable modality (audio, voice, rerank, …) — throws `UnsupportedFeatureException` up front. xAI batch, image/video batch, and embeddings batch for Anthropic/Google are a planned follow-up.
 :::
 
 ## What can and cannot be batched
@@ -31,7 +33,9 @@ What **cannot** be batched (and is rejected at build time, never silently droppe
 
 ## Stateless usage
 
-**No persistence required.** Submit and get a batch id back immediately, then poll the provider yourself — no database, no migrations, no `track()`. Use this when you manage batch state in your own app and just want Atlas for the provider API. (Everything below works with `atlas.persistence.enabled` off.)
+**No persistence required.** Submit and get a batch id back immediately, then poll the provider yourself — no database, no migrations, no setup. Use this when you manage batch state in your own app and just want Atlas for the provider API. (Everything below works with `atlas.persistence.enabled` off.)
+
+Batch works the same across providers — swap the string (`Atlas::batch('anthropic')`, `Atlas::batch('google')`); each maps to that provider's native batch endpoint.
 
 ```php
 use Atlasphp\Atlas\Atlas;
@@ -62,13 +66,12 @@ foreach ($results as $result) {
 
 ## Tracked usage (recommended)
 
-With [persistence](/guides/persistence) enabled, `track()` persists a `BatchJob` and Atlas brings the results in for you — schedule the poll command and listen for completion.
+Persistence is **ambient**: with [persistence](/guides/persistence) enabled, `submit()` automatically persists a `BatchJob` and Atlas brings the results in for you — no extra call. Just schedule the poll command and listen for completion. (With persistence off, the same `submit()` is stateless and returns a `BatchResponse`, as above.)
 
 ```php
 $job = Atlas::batch('openai')
     ->add(Atlas::embed()->fromInput($chunk->text), key: (string) $chunk->id)
-    ->track()
-    ->submit();                      // returns a BatchJob model
+    ->submit();                      // returns a BatchJob model (persistence on)
 ```
 
 Schedule the poller (it advances every open job and hydrates completed ones):
@@ -103,7 +106,7 @@ A single batch can hold tens of thousands of requests, but you'll often split a 
 $group = Atlas::batchGroup('caption-run');
 
 Image::whereNull('caption')->chunkById(1000, function ($images) use ($group) {
-    $batch = Atlas::batch('openai')->track()->group($group);
+    $batch = Atlas::batch('openai')->group($group); // groups require persistence
 
     foreach ($images as $image) {
         $batch->add(
@@ -136,4 +139,4 @@ Schedule::command('atlas:batch-prune')->daily();
 | Command | Purpose |
 |---------|---------|
 | `atlas:batch-poll` | Advance open jobs and hydrate completed ones. Schedule every few minutes. |
-| `atlas:batch-prune` | Delete jobs and results older than the retention window. Schedule daily. |
+| `atlas:batch-prune` | Delete jobs, their results, and empty groups older than the retention window. Schedule daily. |

--- a/docs/modalities/batch.md
+++ b/docs/modalities/batch.md
@@ -1,0 +1,139 @@
+# Batch
+
+Submit large sets of independent requests as one deferred job and pay **~50% less**. The provider processes the batch within its completion window (up to 24h, often much faster) and Atlas brings the results back for you.
+
+Batch is ideal for latency-tolerant fan-out work — captioning thousands of images, classifying a backlog, embedding a corpus, nightly summarization — anything where you don't need the answer *this second* and the requests don't depend on each other.
+
+## Provider & modality support
+
+| Provider | Batchable modalities |
+|----------|----------------------|
+| **OpenAI** | `text` (including vision input), `embeddings` |
+
+::: tip
+Anthropic, Google, and xAI also offer batch APIs; their Atlas handlers are a planned follow-up. Any provider that can't batch a request throws `UnsupportedFeatureException` up front.
+:::
+
+## What can and cannot be batched
+
+A batch line is a single, one-shot request resolved later and out of band. What survives into a batch is everything that's part of the request body:
+
+- ✅ Messages, instructions, **vision input**
+- ✅ **Structured output** (JSON schema)
+- ✅ **Reasoning** effort
+- ✅ Temperature, max tokens, provider options
+
+What **cannot** be batched (and is rejected at build time, never silently dropped):
+
+- ❌ **Tools** — the tool-execution loop needs synchronous round-trips. Use a synchronous request or an agent instead.
+- ❌ **Agents** — an agent *is* the tool loop.
+- ❌ **Per-request middleware** — batch bypasses the synchronous middleware pipeline.
+
+## Stateless usage
+
+**No persistence required.** Submit and get a batch id back immediately, then poll the provider yourself — no database, no migrations, no `track()`. Use this when you manage batch state in your own app and just want Atlas for the provider API. (Everything below works with `atlas.persistence.enabled` off.)
+
+```php
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Input\Image;
+
+$batch = Atlas::batch('openai');
+
+foreach ($images as $image) {
+    $batch->add(
+        Atlas::text()->model('gpt-5')->message('Caption this image.', [Image::fromUrl($image->url)]),
+        key: (string) $image->id, // echoed back on the result — your trace-back key
+    );
+}
+
+$response = $batch->submit();        // returns immediately
+$response->batchId;                  // e.g. "batch_abc123"
+
+// later…
+$status  = Atlas::provider('openai')->batchStatus($response->batchId);
+$results = Atlas::provider('openai')->batchResults($response->batchId);
+
+foreach ($results as $result) {
+    if ($result->succeeded()) {
+        Image::find($result->customId)?->update(['caption' => $result->response->text]);
+    }
+}
+```
+
+## Tracked usage (recommended)
+
+With [persistence](/guides/persistence) enabled, `track()` persists a `BatchJob` and Atlas brings the results in for you — schedule the poll command and listen for completion.
+
+```php
+$job = Atlas::batch('openai')
+    ->add(Atlas::embed()->fromInput($chunk->text), key: (string) $chunk->id)
+    ->track()
+    ->submit();                      // returns a BatchJob model
+```
+
+Schedule the poller (it advances every open job and hydrates completed ones):
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('atlas:batch-poll')->everyFiveMinutes();
+```
+
+React to completion and write results back to your own models:
+
+```php
+use Atlasphp\Atlas\Events\BatchCompleted;
+
+class WriteCaptionsBack
+{
+    public function handle(BatchCompleted $event): void
+    {
+        foreach ($event->job->results()->where('status', 'succeeded')->cursor() as $result) {
+            Image::where('id', $result->custom_id)->update(['caption' => $result->response['text']]);
+        }
+    }
+}
+```
+
+## Large jobs: chunking & groups
+
+A single batch can hold tens of thousands of requests, but you'll often split a large workload into several batches (for file-size limits, progress granularity, or isolated retries). The `custom_id` carries your record's key through *any* number of batches, so results always map back.
+
+```php
+$group = Atlas::batchGroup('caption-run');
+
+Image::whereNull('caption')->chunkById(1000, function ($images) use ($group) {
+    $batch = Atlas::batch('openai')->track()->group($group);
+
+    foreach ($images as $image) {
+        $batch->add(
+            Atlas::text()->model('gpt-5')->message('Caption this image.', [Image::fromUrl($image->url)]),
+            key: (string) $image->id,
+        );
+    }
+
+    $batch->submit();
+});
+
+$group->progress();   // ['total' => 4000, 'succeeded' => 3820, ... 'completed_jobs' => 3]
+$group->isComplete(); // true once every job in the group is terminal
+```
+
+## Where results are stored
+
+With tracking on, each line becomes a row in `batch_results` (keyed by `custom_id`), and the job's rolled-up token usage lands on the `batch_jobs` row — so batch spend shows up in your cost reporting. Text and embedding payloads are stored as JSON; the provider's raw output file is consumed during ingestion and discarded.
+
+## Retention
+
+Batch history is kept for `atlas.batch.retention_days` (default **90**). Schedule the prune command daily to keep the tables bounded as they grow:
+
+```php
+Schedule::command('atlas:batch-prune')->daily();
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `atlas:batch-poll` | Advance open jobs and hydrate completed ones. Schedule every few minutes. |
+| `atlas:batch-prune` | Delete jobs and results older than the retention window. Schedule daily. |

--- a/sandbox/test-batch-demo.php
+++ b/sandbox/test-batch-demo.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Batch demo (live) — populates the tables and LEAVES the data in place.
+ *
+ * Submits a tracked OpenAI text batch in a group, polls it to completion via
+ * atlas:batch-poll, then prints the rows. Unlike the audit scripts, it does NOT
+ * clean up or prune — so you can inspect atlas_batch_jobs / atlas_batch_results
+ * / atlas_batch_groups afterwards.
+ *
+ * Usage: php test-batch-demo.php   (needs OPENAI_API_KEY; persistence enabled)
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+]);
+$app['config']->set('atlas.persistence.enabled', true);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Illuminate\Support\Facades\Artisan;
+
+function line(string $msg): void
+{
+    echo $msg.PHP_EOL;
+}
+
+line('=== Batch demo — leaves data in the tables ===');
+line('Date: '.date('Y-m-d H:i:s'));
+
+$group = Atlas::batchGroup('demo-run');
+$job = Atlas::batch('openai')->group($group)
+    ->add(Atlas::text('openai', 'gpt-4o-mini')->message('Reply with exactly: ALPHA'), key: 'rec-1')
+    ->add(Atlas::text('openai', 'gpt-4o-mini')->message('Reply with exactly: BETA'), key: 'rec-2')
+    ->submit();
+
+line("Submitted job #{$job->id} (batch_id={$job->batch_id}) in group #{$group->id} — polling…");
+
+for ($i = 0; $i < 16; $i++) {
+    Artisan::call('atlas:batch-poll');
+    $job->refresh();
+    line('  poll: '.$job->status->value." ({$job->succeeded}/{$job->total})");
+    if ($job->status->isTerminal()) {
+        break;
+    }
+    sleep(15);
+}
+line('');
+
+line('atlas_batch_groups:');
+line("  #{$group->id} label={$group->label} progress=".json_encode($group->progress()).' complete='.($group->isComplete() ? 'yes' : 'no'));
+line('');
+
+line('atlas_batch_jobs:');
+line("  #{$job->id} provider={$job->provider} modality={$job->modality} status={$job->status->value} counts={$job->succeeded}/{$job->total} usage=".json_encode($job->usage));
+line('');
+
+line('atlas_batch_results:');
+foreach (BatchResult::query()->where('batch_job_id', $job->id)->orderBy('custom_id')->get() as $r) {
+    line("  custom_id={$r->custom_id} status={$r->status->value} response=".json_encode($r->response).' usage='.json_encode($r->usage));
+}
+line('');
+line('Data left in place. Inspect with:');
+line("  sqlite3 database/database.sqlite 'SELECT * FROM atlas_batch_results;'");

--- a/sandbox/test-batch-google-e2e.php
+++ b/sandbox/test-batch-google-e2e.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Google (Gemini) batch — full end-to-end audit, both persistence modes (live).
+ *
+ *   STATELESS: submit → poll provider → fetch results → verify text.
+ *   TRACKED:   submit (persisted) → atlas:batch-poll → verify batch_jobs +
+ *              batch_results rows are accurate.
+ *
+ * Usage: php test-batch-google-e2e.php   (needs GEMINI_API_KEY)
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'google' => [
+        'api_key' => env('GEMINI_API_KEY'),
+        'url' => env('GOOGLE_URL', 'https://generativelanguage.googleapis.com'),
+    ],
+]);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\AtlasManager;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Illuminate\Support\Facades\Artisan;
+
+function line(string $m): void
+{
+    echo $m.PHP_EOL;
+}
+$pass = true;
+function check(string $label, bool $ok): void
+{
+    global $pass;
+    $pass = $pass && $ok;
+    line('  ['.($ok ? 'PASS' : 'FAIL')."] {$label}");
+}
+function setPersistence(bool $on): void
+{
+    config(['atlas.persistence.enabled' => $on]);
+    app()->forgetInstance(AtlasConfig::class);
+    app()->forgetInstance(AtlasManager::class);
+    Atlas::clearResolvedInstances();
+}
+function googleBatch(): object
+{
+    return Atlas::batch('google')
+        ->add(Atlas::text('google', 'gemini-2.5-flash')->message('Reply with exactly: ALPHA'), key: 'request-1')
+        ->add(Atlas::text('google', 'gemini-2.5-flash')->message('Reply with exactly: BETA'), key: 'request-2');
+}
+
+line('=== Google (Gemini) batch — end-to-end, both modes ===');
+line('Date: '.date('Y-m-d H:i:s'));
+line('');
+
+// ── STATELESS ────────────────────────────────────────────────────────────────
+line('[STATELESS] (persistence off)');
+setPersistence(false);
+$resp = googleBatch()->submit();
+check('submit returns a BatchResponse', $resp instanceof BatchResponse);
+check('non-empty batch id', $resp->batchId !== '');
+line("  batch id: {$resp->batchId}");
+
+$status = $resp->status;
+for ($i = 0; $i < 14 && ! $status->isTerminal(); $i++) {
+    sleep(15);
+    $status = Atlas::provider('google')->batchStatus($resp->batchId)->status;
+    line('  poll #'.($i + 1).": {$status->value}");
+}
+check('reached completed', $status === BatchStatus::Completed);
+
+if ($status === BatchStatus::Completed) {
+    $results = [];
+    foreach (Atlas::provider('google')->batchResults($resp->batchId) as $r) {
+        $results[$r->customId] = $r->response !== null ? trim($r->response->text) : 'ERR';
+        line("    {$r->customId}: {$r->status->value} → \"{$results[$r->customId]}\"");
+    }
+    check('2 results returned', count($results) === 2);
+    check('request-1 → ALPHA', ($results['request-1'] ?? '') === 'ALPHA');
+    check('request-2 → BETA', ($results['request-2'] ?? '') === 'BETA');
+}
+line('');
+
+// ── TRACKED ──────────────────────────────────────────────────────────────────
+line('[TRACKED] (persistence on)');
+setPersistence(true);
+BatchResult::query()->delete();
+BatchJob::query()->delete();
+
+$job = googleBatch()->submit();
+check('submit returns a persisted BatchJob', $job instanceof BatchJob);
+check('job row persisted with batch id', $job instanceof BatchJob && BatchJob::query()->where('batch_id', $job->batch_id)->exists());
+line("  job #{$job->id} batch_id={$job->batch_id} status={$job->status->value}");
+
+for ($i = 0; $i < 14; $i++) {
+    Artisan::call('atlas:batch-poll', ['--provider' => 'google']);
+    $job->refresh();
+    if ($job->status->isTerminal()) {
+        break;
+    }
+    sleep(15);
+}
+line("  final job status: {$job->status->value}");
+
+if ($job->status === BatchStatus::Completed) {
+    line('  atlas_batch_jobs: status='.$job->status->value." total={$job->total} succeeded={$job->succeeded} usage=".json_encode($job->usage));
+    check('job completed via poll command', $job->status === BatchStatus::Completed);
+    check('counts accurate (2/2)', $job->total === 2 && $job->succeeded === 2);
+    check('usage rolled up', (int) ($job->usage['input_tokens'] ?? 0) > 0);
+
+    $rows = BatchResult::query()->where('batch_job_id', $job->id)->orderBy('custom_id')->get();
+    foreach ($rows as $r) {
+        line("  atlas_batch_results: {$r->custom_id} {$r->status->value} ".json_encode($r->response));
+    }
+    check('2 result rows (nothing missing)', $rows->count() === 2);
+    check('custom_ids correlate', $rows->pluck('custom_id')->all() === ['request-1', 'request-2']);
+    check('request-1 text = ALPHA', ($rows->firstWhere('custom_id', 'request-1')->response['text'] ?? '') === 'ALPHA');
+    check('request-2 text = BETA', ($rows->firstWhere('custom_id', 'request-2')->response['text'] ?? '') === 'BETA');
+}
+
+line('');
+line('=== '.($pass ? 'GOOGLE E2E PASSED (both modes)' : 'GOOGLE E2E FAILED').' ===');
+exit($pass ? 0 : 1);

--- a/sandbox/test-batch-google.php
+++ b/sandbox/test-batch-google.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Google (Gemini) batch — live verification.
+ *
+ * Submits a small inline text batch, polls to completion, and parses results.
+ * Verifies the real Gemini batchGenerateContent contract end-to-end.
+ *
+ * Usage: php test-batch-google.php   (needs GEMINI_API_KEY)
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'google' => [
+        'api_key' => env('GEMINI_API_KEY'),
+        'url' => env('GOOGLE_URL', 'https://generativelanguage.googleapis.com'),
+    ],
+]);
+$app['config']->set('atlas.persistence.enabled', false); // stateless: exercise the provider API directly
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\BatchStatus;
+
+function line(string $msg): void
+{
+    echo $msg.PHP_EOL;
+}
+
+line('=== Google (Gemini) batch — live ===');
+line('Date: '.date('Y-m-d H:i:s'));
+
+$response = Atlas::batch('google')
+    ->add(Atlas::text('google', 'gemini-2.5-flash')->message('Reply with exactly: ALPHA'), key: 'request-1')
+    ->add(Atlas::text('google', 'gemini-2.5-flash')->message('Reply with exactly: BETA'), key: 'request-2')
+    ->submit();
+
+line("submitted: {$response->batchId} — status {$response->status->value}");
+
+$status = $response->status;
+for ($i = 0; $i < 10 && ! $status->isTerminal(); $i++) {
+    sleep(15);
+    $r = Atlas::provider('google')->batchStatus($response->batchId);
+    $status = $r->status;
+    line('  poll #'.($i + 1).": {$status->value} ({$r->counts->succeeded}/{$r->counts->total})");
+}
+
+if ($status === BatchStatus::Completed) {
+    line('COMPLETED — results:');
+    foreach (Atlas::provider('google')->batchResults($response->batchId) as $result) {
+        $text = $result->response !== null ? trim($result->response->text) : ('ERR '.($result->error?->getMessage() ?? ''));
+        line("  {$result->customId}: {$result->status->value} → \"{$text}\"");
+    }
+} else {
+    line("still {$status->value} — VERIFY LATER: {$response->batchId}");
+}

--- a/sandbox/test-batch-modes.php
+++ b/sandbox/test-batch-modes.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Batch persistence-modes audit (live)
+ *
+ * Validates both submission modes against the real API for each implemented
+ * provider:
+ *   - STATELESS (persistence off): submit() returns a BatchResponse; you poll.
+ *   - TRACKED   (persistence on):  submit() returns a persisted BatchJob; the
+ *                                  atlas:batch-poll command brings results in.
+ *
+ * Batches resolve later, so this asserts the *mode behavior* and a live status
+ * read; result completion is verify-later.
+ *
+ * Usage: php test-batch-modes.php   (needs OPENAI_API_KEY + ANTHROPIC_API_KEY)
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+    'anthropic' => [
+        'api_key' => env('ANTHROPIC_API_KEY'),
+        'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1'),
+        'version' => env('ANTHROPIC_VERSION', '2023-06-01'),
+    ],
+]);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\AtlasManager;
+use Atlasphp\Atlas\Pending\BatchRequest;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Illuminate\Support\Facades\Artisan;
+
+function line(string $msg): void
+{
+    echo $msg.PHP_EOL;
+}
+
+/** Flip persistence and rebuild the config/manager singletons + facade root. */
+function setPersistence(bool $enabled): void
+{
+    config(['atlas.persistence.enabled' => $enabled]);
+    app()->forgetInstance(AtlasConfig::class);
+    app()->forgetInstance(AtlasManager::class);
+    Atlas::clearResolvedInstances();
+}
+
+/** @return array{0: BatchRequest} */
+function batchFor(string $provider): object
+{
+    if ($provider === 'openai') {
+        return Atlas::batch('openai')
+            ->add(Atlas::embed('openai', 'text-embedding-3-small')->fromInput('batch modes audit'), key: 'a');
+    }
+
+    return Atlas::batch('anthropic')
+        ->add(Atlas::text('anthropic', 'claude-sonnet-4-20250514')->message('Say OK'), key: 'a');
+}
+
+line('=== Atlas Batch — persistence-modes live audit ===');
+line('Date: '.date('Y-m-d H:i:s'));
+line('');
+
+$summary = [];
+
+foreach (['openai', 'anthropic'] as $provider) {
+    line("── {$provider} ──");
+
+    // STATELESS ----------------------------------------------------------------
+    setPersistence(false);
+    $stateless = batchFor($provider)->submit();
+    $okStateless = $stateless instanceof BatchResponse && $stateless->batchId !== '';
+    $statelessStatus = Atlas::provider($provider)->batchStatus($stateless->batchId)->status->value;
+    line('  stateless: '.($okStateless ? 'OK' : 'FAIL')
+        ." → returned BatchResponse, id={$stateless->batchId}, live status={$statelessStatus}");
+
+    // TRACKED ------------------------------------------------------------------
+    setPersistence(true);
+    $tracked = batchFor($provider)->submit();
+    $isJob = $tracked instanceof BatchJob;
+    $persisted = $isJob && BatchJob::query()->where('batch_id', $tracked->batch_id)->exists();
+    line('  tracked:   '.($isJob && $persisted ? 'OK' : 'FAIL')
+        ." → returned BatchJob #{$tracked->id}, persisted row batch_id={$tracked->batch_id}, status={$tracked->status->value}");
+
+    Artisan::call('atlas:batch-poll', ['--provider' => $provider]);
+    line('  poll cmd:  ran → '.trim(Artisan::output()));
+
+    $summary[$provider] = [
+        'stateless' => $okStateless,
+        'tracked' => $isJob && $persisted,
+        'stateless_id' => $stateless->batchId,
+        'tracked_id' => $tracked->batch_id,
+    ];
+    line('');
+}
+
+line('=== summary ===');
+foreach ($summary as $provider => $r) {
+    $verdict = ($r['stateless'] && $r['tracked']) ? 'PASS' : 'FAIL';
+    line(sprintf('%-10s %s — stateless %s (%s), tracked %s (%s)',
+        $provider, $verdict,
+        $r['stateless'] ? '✓' : '✗', $r['stateless_id'],
+        $r['tracked'] ? '✓' : '✗', $r['tracked_id'],
+    ));
+}

--- a/sandbox/test-batch-tables.php
+++ b/sandbox/test-batch-tables.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Batch persistence-tables audit (live)
+ *
+ * Submits a tracked batch in a group, polls it to completion via the real
+ * atlas:batch-poll command, then dumps and validates all three tables
+ * (atlas_batch_groups, atlas_batch_jobs, atlas_batch_results) for accuracy and
+ * completeness. Finally validates that atlas:batch-prune removes aged data.
+ *
+ * Usage: php test-batch-tables.php   (needs OPENAI_API_KEY; persistence enabled)
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+]);
+$app['config']->set('atlas.persistence.enabled', true);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Illuminate\Support\Facades\Artisan;
+
+function line(string $msg): void
+{
+    echo $msg.PHP_EOL;
+}
+
+$pass = true;
+function check(string $label, bool $ok): void
+{
+    global $pass;
+    $pass = $pass && $ok;
+    line('  ['.($ok ? 'PASS' : 'FAIL')."] {$label}");
+}
+
+// Clean slate so the dump is unambiguous.
+BatchResult::query()->delete();
+BatchJob::query()->delete();
+BatchGroup::query()->delete();
+
+line('=== Batch tables audit (live OpenAI) ===');
+line('Date: '.date('Y-m-d H:i:s'));
+line('');
+
+// ── Submit a tracked batch inside a group ────────────────────────────────────
+$group = Atlas::batchGroup('table-validation');
+$job = Atlas::batch('openai')->group($group)
+    ->add(Atlas::text('openai', 'gpt-4o-mini')->message('Reply with exactly: ALPHA'), key: 'rec-1')
+    ->add(Atlas::text('openai', 'gpt-4o-mini')->message('Reply with exactly: BETA'), key: 'rec-2')
+    ->submit();
+
+line("Submitted: job #{$job->id} (batch_id={$job->batch_id}) in group #{$group->id}");
+
+// ── Poll to completion via the real command ──────────────────────────────────
+for ($i = 0; $i < 12; $i++) {
+    Artisan::call('atlas:batch-poll');
+    $job->refresh();
+    if ($job->status->isTerminal()) {
+        break;
+    }
+    sleep(15);
+}
+line("Final job status: {$job->status->value} (after polling)");
+line('');
+
+if (! $job->status->isSuccessful()) {
+    line('Job did not complete within the window — re-run to validate tables. Batch id: '.$job->batch_id);
+    exit(0);
+}
+
+// ── atlas_batch_jobs ─────────────────────────────────────────────────────────
+line('atlas_batch_jobs:');
+line("  provider={$job->provider} modality={$job->modality} status={$job->status->value}");
+line("  counts: total={$job->total} succeeded={$job->succeeded} failed={$job->failed} processing={$job->processing}");
+line('  usage: '.json_encode($job->usage));
+line("  submitted_at={$job->submitted_at} completed_at={$job->completed_at}");
+check('provider/modality recorded', $job->provider === 'openai' && $job->modality === 'text');
+check('status completed', $job->status->value === 'completed');
+check('counts accurate (2 total / 2 succeeded)', $job->total === 2 && $job->succeeded === 2 && $job->failed === 0);
+check('usage rolled up (input+output > 0)', (int) ($job->usage['input_tokens'] ?? 0) > 0 && (int) ($job->usage['output_tokens'] ?? 0) > 0);
+check('timestamps set', $job->submitted_at !== null && $job->completed_at !== null);
+line('');
+
+// ── atlas_batch_results ──────────────────────────────────────────────────────
+line('atlas_batch_results:');
+$results = BatchResult::query()->where('batch_job_id', $job->id)->orderBy('custom_id')->get();
+foreach ($results as $r) {
+    line("  custom_id={$r->custom_id} status={$r->status->value} response=".json_encode($r->response).' usage='.json_encode($r->usage));
+}
+$keys = $results->pluck('custom_id')->all();
+check('one row per submitted line (nothing missing)', $results->count() === 2);
+check('custom_ids match the submitted keys', $keys === ['rec-1', 'rec-2']);
+check('responses carry text + finish_reason', isset($results[0]->response['text'], $results[0]->response['finish_reason']));
+check('per-line usage recorded', (int) ($results[0]->usage['input_tokens'] ?? 0) > 0);
+check('job.succeeded equals succeeded result rows', $job->succeeded === $results->where('status.value', 'succeeded')->count() || $job->succeeded === $results->filter(fn ($r) => $r->status->value === 'succeeded')->count());
+$rolled = array_sum($results->map(fn ($r) => (int) ($r->usage['input_tokens'] ?? 0))->all());
+check('rolled-up input tokens == sum of line input tokens', (int) ($job->usage['input_tokens'] ?? 0) === $rolled);
+line('');
+
+// ── atlas_batch_groups ───────────────────────────────────────────────────────
+line('atlas_batch_groups:');
+$progress = $group->progress();
+line("  label={$group->label} progress=".json_encode($progress).' isComplete='.($group->isComplete() ? 'true' : 'false'));
+check('group aggregates its jobs', $progress['total'] === 2 && $progress['succeeded'] === 2 && $progress['jobs'] === 1);
+check('group isComplete', $group->isComplete() === true);
+line('');
+
+// ── Prune ────────────────────────────────────────────────────────────────────
+line('Prune (backdate job + group 120 days, retention 90):');
+$job->forceFill(['created_at' => now()->subDays(120)])->save();
+$group->forceFill(['created_at' => now()->subDays(120)])->save();
+Artisan::call('atlas:batch-prune');
+line('  '.trim(Artisan::output()));
+check('job deleted', BatchJob::query()->where('id', $job->id)->doesntExist());
+check('results cascade-deleted', BatchResult::query()->where('batch_job_id', $job->id)->doesntExist());
+check('empty aged group deleted', BatchGroup::query()->where('id', $group->id)->doesntExist());
+line('');
+
+line('=== '.($pass ? 'ALL CHECKS PASSED' : 'SOME CHECKS FAILED').' ===');
+exit($pass ? 0 : 1);

--- a/sandbox/test-batch.php
+++ b/sandbox/test-batch.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Batch API Integration Test (live)
+ *
+ * Submits real OpenAI + Anthropic batch jobs and verifies submission, status
+ * polling, and — when a job finishes within the poll window — result hydration.
+ * Batch jobs may take minutes to hours; if a job is still running when the
+ * window elapses, the batch id is printed for later verification.
+ *
+ * Works whether persistence is on (submit() returns a tracked BatchJob) or off
+ * (submit() returns a BatchResponse) — polling uses the provider API either way.
+ *
+ * Usage: php test-batch.php
+ *
+ * Requires OPENAI_API_KEY and ANTHROPIC_API_KEY in sandbox/.env
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+$app['config']->set('atlas.providers', [
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+    'anthropic' => [
+        'api_key' => env('ANTHROPIC_API_KEY'),
+        'url' => env('ANTHROPIC_URL', 'https://api.anthropic.com/v1'),
+        'version' => env('ANTHROPIC_VERSION', '2023-06-01'),
+    ],
+]);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Responses\BatchResponse;
+
+function line(string $msg): void
+{
+    echo $msg.PHP_EOL;
+}
+
+/**
+ * Get the provider batch id from either submit() return type.
+ */
+function batchIdOf(BatchResponse|BatchJob $result): string
+{
+    return $result instanceof BatchResponse ? $result->batchId : (string) $result->batch_id;
+}
+
+function pollUntilTerminal(string $provider, string $batchId, int $maxAttempts = 6, int $sleepSeconds = 15): BatchStatus
+{
+    $response = Atlas::provider($provider)->batchStatus($batchId);
+
+    for ($i = 0; $i < $maxAttempts && ! $response->isTerminal(); $i++) {
+        sleep($sleepSeconds);
+        $response = Atlas::provider($provider)->batchStatus($batchId);
+        line('  poll #'.($i + 1).": {$response->status->value} ({$response->counts->succeeded}/{$response->counts->total})");
+    }
+
+    return $response->status;
+}
+
+function report(string $provider, string $batchId, BatchStatus $status): void
+{
+    if ($status === BatchStatus::Completed) {
+        $results = iterator_to_array(Atlas::provider($provider)->batchResults($batchId));
+        line('  COMPLETED — '.count($results).' results');
+        foreach ($results as $r) {
+            $detail = match (true) {
+                ! $r->succeeded() => 'ERROR '.($r->error?->getMessage() ?? ''),
+                isset($r->response->text) => '"'.trim($r->response->text).'"',
+                isset($r->response->embeddings) => count($r->response->embeddings[0] ?? []).' dims',
+                default => 'ok',
+            };
+            line("    {$r->customId}: {$r->status->value} → {$detail}");
+        }
+    } else {
+        line("  still {$status->value} — VERIFY LATER: batch id {$batchId}");
+    }
+}
+
+line('=== Atlas Batch API — live audit (OpenAI + Anthropic) ===');
+line('Date: '.date('Y-m-d H:i:s'));
+line('');
+
+// ── 1. OpenAI embeddings batch ───────────────────────────────────────────────
+line('[1] OpenAI embeddings batch (text-embedding-3-small, 3 inputs)');
+$embed = Atlas::batch('openai');
+foreach (['the quick brown fox', 'lorem ipsum dolor', 'batch processing is cheaper'] as $i => $text) {
+    $embed->add(Atlas::embed('openai', 'text-embedding-3-small')->fromInput($text), key: "embed-{$i}");
+}
+$embedId = batchIdOf($embed->submit());
+line("  submitted: {$embedId}");
+$embedStatus = pollUntilTerminal('openai', $embedId);
+report('openai', $embedId, $embedStatus);
+line('');
+
+// ── 2. OpenAI text batch ─────────────────────────────────────────────────────
+line('[2] OpenAI text batch (gpt-4o-mini, 2 prompts)');
+$openaiText = Atlas::batch('openai')
+    ->add(Atlas::text('openai', 'gpt-4o-mini')->message('Reply with exactly: ALPHA'), key: 'a')
+    ->add(Atlas::text('openai', 'gpt-4o-mini')->message('Reply with exactly: BETA'), key: 'b');
+$openaiTextId = batchIdOf($openaiText->submit());
+line("  submitted: {$openaiTextId}");
+$openaiTextStatus = pollUntilTerminal('openai', $openaiTextId);
+report('openai', $openaiTextId, $openaiTextStatus);
+line('');
+
+// ── 3. Anthropic text batch ──────────────────────────────────────────────────
+line('[3] Anthropic text batch (claude-sonnet-4-20250514, 2 prompts)');
+$anthropic = Atlas::batch('anthropic')
+    ->add(Atlas::text('anthropic', 'claude-sonnet-4-20250514')->message('Reply with exactly: ALPHA'), key: 'a')
+    ->add(Atlas::text('anthropic', 'claude-sonnet-4-20250514')->message('Reply with exactly: BETA'), key: 'b');
+$anthropicId = batchIdOf($anthropic->submit());
+line("  submitted: {$anthropicId}");
+$anthropicStatus = pollUntilTerminal('anthropic', $anthropicId);
+report('anthropic', $anthropicId, $anthropicStatus);
+line('');
+
+// ── 4. Guard rails (no network) ──────────────────────────────────────────────
+line('[4] Guard rails');
+try {
+    Atlas::batch('openai')->add(Atlas::audio('openai', 'whisper-1'), key: 'k');
+    line('  FAIL: a non-batchable modality was not rejected');
+} catch (BatchException $e) {
+    line('  non-batchable modality rejected: OK');
+}
+try {
+    Atlas::batch('openai')->submit();
+    line('  FAIL: empty batch was not rejected');
+} catch (BatchException $e) {
+    line('  empty batch rejected: OK');
+}
+
+line('');
+line('=== done ===');
+line("OpenAI embeddings: {$embedId} ({$embedStatus->value})");
+line("OpenAI text:       {$openaiTextId} ({$openaiTextStatus->value})");
+line("Anthropic text:    {$anthropicId} ({$anthropicStatus->value})");

--- a/src/Atlas.php
+++ b/src/Atlas.php
@@ -47,6 +47,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static VoiceRequest voice(Provider|string|null $provider = null, ?string $model = null)
  * @method static RerankRequest rerank(Provider|string|null $provider = null, ?string $model = null)
  * @method static ProviderRequest provider(Provider|string $provider)
+ * @method static \Atlasphp\Atlas\Pending\BatchRequest batch(Provider|string|null $provider = null)
+ * @method static \Atlasphp\Atlas\Persistence\Models\BatchGroup batchGroup(?string $label = null)
  * @method static AgentRequest agent(string $key)
  * @method static ProviderRegistryContract providers()
  * @method static void registerChunkable(class-string<\Illuminate\Database\Eloquent\Model> $modelClass)

--- a/src/AtlasManager.php
+++ b/src/AtlasManager.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas;
 
+use Atlasphp\Atlas\Batch\BatchService;
 use Atlasphp\Atlas\Embeddings\Chunkable;
 use Atlasphp\Atlas\Embeddings\ChunkableRegistry;
 use Atlasphp\Atlas\Embeddings\SearchResult;
 use Atlasphp\Atlas\Embeddings\VectorEmbeddable;
 use Atlasphp\Atlas\Enums\Provider;
 use Atlasphp\Atlas\Exceptions\AtlasException;
+use Atlasphp\Atlas\Exceptions\BatchException;
 use Atlasphp\Atlas\Pending\AgentRequest;
 use Atlasphp\Atlas\Pending\AudioRequest;
+use Atlasphp\Atlas\Pending\BatchRequest;
 use Atlasphp\Atlas\Pending\EmbedRequest;
 use Atlasphp\Atlas\Pending\ImageRequest;
 use Atlasphp\Atlas\Pending\ModerateRequest;
@@ -23,6 +26,7 @@ use Atlasphp\Atlas\Pending\SpeechRequest;
 use Atlasphp\Atlas\Pending\TextRequest;
 use Atlasphp\Atlas\Pending\VideoRequest;
 use Atlasphp\Atlas\Pending\VoiceRequest;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
 use Atlasphp\Atlas\Persistence\Services\ChunkSearchService;
 use Atlasphp\Atlas\Persistence\Services\RecordSearchService;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
@@ -130,6 +134,36 @@ class AtlasManager
     public function provider(Provider|string $provider): ProviderRequest
     {
         return new ProviderRequest($provider, $this->providerRegistry);
+    }
+
+    /**
+     * Begin assembling a batch job. Provider may be omitted and inferred from
+     * the first added request.
+     */
+    public function batch(Provider|string|null $provider = null): BatchRequest
+    {
+        $batchService = $this->config->persistenceEnabled
+            ? $this->app->make(BatchService::class)
+            : null;
+
+        return new BatchRequest($provider, $this->providerRegistry, $batchService);
+    }
+
+    /**
+     * Create a batch group to tie multiple batches into one logical operation.
+     *
+     * @throws BatchException When persistence is not enabled.
+     */
+    public function batchGroup(?string $label = null): BatchGroup
+    {
+        if (! $this->config->persistenceEnabled) {
+            throw BatchException::persistenceRequired();
+        }
+
+        /** @var class-string<BatchGroup> $model */
+        $model = $this->config->model('batch_group', BatchGroup::class);
+
+        return $model::create(['label' => $label]);
     }
 
     public function agent(string $key): AgentRequest

--- a/src/AtlasServiceProvider.php
+++ b/src/AtlasServiceProvider.php
@@ -116,6 +116,8 @@ class AtlasServiceProvider extends ServiceProvider
                 Console\ChunkCommand::class,
                 Console\PruneChunksCommand::class,
                 Console\RechunkCommand::class,
+                Console\PollBatchJobsCommand::class,
+                Console\PruneBatchJobsCommand::class,
             ]);
 
             $this->publishes([

--- a/src/Batch/BatchService.php
+++ b/src/Batch/BatchService.php
@@ -11,11 +11,13 @@ use Atlasphp\Atlas\Events\BatchGroupCompleted;
 use Atlasphp\Atlas\Events\BatchSubmitted;
 use Atlasphp\Atlas\Persistence\Models\BatchGroup;
 use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Persistence\Models\BatchResult;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Requests\Batch;
 use Atlasphp\Atlas\Responses\BatchResult as BatchResultData;
 use Atlasphp\Atlas\Responses\EmbeddingsResponse;
+use Atlasphp\Atlas\Responses\RequestCounts;
 use Atlasphp\Atlas\Responses\TextResponse;
 use Atlasphp\Atlas\Responses\Usage;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -82,14 +84,28 @@ class BatchService
         $driver = $this->registry->resolve($job->provider);
         $response = $driver->batchStatus($job->batch_id);
 
-        $job->applyStatus($response->status, $response->counts);
-
         if ($response->status->isSuccessful()) {
-            $this->hydrate($job, $driver->batchResults($job->batch_id));
+            // Fetch results BEFORE writing any terminal status. If this transport
+            // call throws, the job stays non-terminal and the next poll retries —
+            // never orphaned as "completed" with no results.
+            $results = iterator_to_array($driver->batchResults($job->batch_id), false);
+
+            if ($results === []) {
+                // Provider reports success but results aren't available yet (some
+                // providers, e.g. Gemini, deliver inline results shortly after the
+                // state flip). Keep the job open and retry on the next poll.
+                $job->applyStatus(BatchStatus::InProgress, $response->counts);
+
+                return $job->refresh();
+            }
+
+            $this->hydrate($job, $response->counts, $results);
         } elseif ($response->status->isTerminal()) {
             $job->markFailed($response->status, $response->error);
             $this->events->dispatch(new BatchFailed($job));
             $this->checkGroup($job);
+        } else {
+            $job->applyStatus($response->status, $response->counts);
         }
 
         return $job->refresh();
@@ -98,18 +114,20 @@ class BatchService
     /**
      * Store per-line results, roll up usage, and mark the job completed.
      *
-     * @param  iterable<int, BatchResultData>  $results
+     * The terminal "completed" status, the final counts, the rolled-up usage,
+     * and every result row commit together in one transaction or not at all — so
+     * the job only becomes terminal once its results are durably stored. A crash
+     * mid-hydration rolls back, leaving the job non-terminal for the next poll
+     * (no duplicate rows, no double-counted usage, no orphaned completion).
+     *
+     * @param  array<int, BatchResultData>  $results
      */
-    private function hydrate(BatchJob $job, iterable $results): void
+    private function hydrate(BatchJob $job, RequestCounts $counts, array $results): void
     {
         /** @var class-string<BatchResult> $model */
         $model = $this->config->model('batch_result', BatchResult::class);
 
-        // Atomic: the per-line inserts, the rolled-up usage, and the completed
-        // status all commit together or not at all. A crash mid-hydration rolls
-        // back, leaving the job non-terminal so the next poll re-runs it cleanly
-        // — no duplicate result rows, no double-counted usage.
-        DB::transaction(function () use ($job, $model, $results): void {
+        DB::transaction(function () use ($job, $model, $counts, $results): void {
             $usage = new Usage(0, 0);
 
             foreach ($results as $result) {
@@ -127,6 +145,7 @@ class BatchService
                 }
             }
 
+            $job->applyStatus(BatchStatus::Completed, $counts);
             $job->markCompleted($usage);
         });
 

--- a/src/Batch/BatchService.php
+++ b/src/Batch/BatchService.php
@@ -93,8 +93,10 @@ class BatchService
             if ($results === []) {
                 // Provider reports success but results aren't available yet (some
                 // providers, e.g. Gemini, deliver inline results shortly after the
-                // state flip). Keep the job open and retry on the next poll.
-                $job->applyStatus(BatchStatus::InProgress, $response->counts);
+                // state flip). Keep the job open and retry on the next poll — but
+                // don't overwrite the stored counts with this response's transient
+                // zero counts (its result set is empty for the same reason).
+                $job->update(['status' => BatchStatus::InProgress]);
 
                 return $job->refresh();
             }

--- a/src/Batch/BatchService.php
+++ b/src/Batch/BatchService.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Batch;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Events\BatchCompleted;
+use Atlasphp\Atlas\Events\BatchFailed;
+use Atlasphp\Atlas\Events\BatchGroupCompleted;
+use Atlasphp\Atlas\Events\BatchSubmitted;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Responses\BatchResult as BatchResultData;
+use Atlasphp\Atlas\Responses\EmbeddingsResponse;
+use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\Usage;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Class BatchService
+ *
+ * Orchestrates tracked batch jobs: submits and persists them, and syncs their
+ * state from the provider — the single hydration path shared by the poll
+ * command (and any future webhook). Keeps the synchronous submission and the
+ * deferred result ingestion cohesive in one place.
+ */
+class BatchService
+{
+    public function __construct(
+        private readonly ProviderRegistryContract $registry,
+        private readonly Dispatcher $events,
+        private readonly AtlasConfig $config,
+    ) {}
+
+    /**
+     * Submit a batch to the provider and persist a tracking record.
+     */
+    public function submitAndTrack(Batch $batch, ?BatchGroup $group = null): BatchJob
+    {
+        $response = $this->registry->resolve($batch->provider)->batch($batch);
+
+        /** @var class-string<BatchJob> $model */
+        $model = $this->config->model('batch_job', BatchJob::class);
+
+        $job = $model::create([
+            'batch_group_id' => $group?->getKey(),
+            'provider' => $batch->provider,
+            'modality' => $batch->modality->value,
+            'batch_id' => $response->batchId,
+            'status' => $response->status,
+            'total' => $response->counts->total,
+            'succeeded' => $response->counts->succeeded,
+            'failed' => $response->counts->failed,
+            'processing' => $response->counts->processing,
+            'input_file_id' => $response->inputFileId,
+            'output_file_id' => $response->outputFileId,
+            'submitted_at' => now(),
+        ]);
+
+        $this->events->dispatch(new BatchSubmitted($job));
+
+        return $job;
+    }
+
+    /**
+     * Advance a tracked job by syncing its state from the provider.
+     *
+     * No-op on already-terminal jobs (idempotent). On completion, fetches and
+     * stores every line result, rolls up usage, and fires events.
+     */
+    public function syncFromProvider(BatchJob $job): BatchJob
+    {
+        if ($job->status->isTerminal() || $job->batch_id === null) {
+            return $job;
+        }
+
+        $driver = $this->registry->resolve($job->provider);
+        $response = $driver->batchStatus($job->batch_id);
+
+        $job->applyStatus($response->status, $response->counts);
+
+        if ($response->status->isSuccessful()) {
+            $this->hydrate($job, $driver->batchResults($job->batch_id));
+        } elseif ($response->status->isTerminal()) {
+            $job->markFailed($response->status, $response->error);
+            $this->events->dispatch(new BatchFailed($job));
+            $this->checkGroup($job);
+        }
+
+        return $job->refresh();
+    }
+
+    /**
+     * Store per-line results, roll up usage, and mark the job completed.
+     *
+     * @param  iterable<int, BatchResultData>  $results
+     */
+    private function hydrate(BatchJob $job, iterable $results): void
+    {
+        /** @var class-string<BatchResult> $model */
+        $model = $this->config->model('batch_result', BatchResult::class);
+
+        // Atomic: the per-line inserts, the rolled-up usage, and the completed
+        // status all commit together or not at all. A crash mid-hydration rolls
+        // back, leaving the job non-terminal so the next poll re-runs it cleanly
+        // — no duplicate result rows, no double-counted usage.
+        DB::transaction(function () use ($job, $model, $results): void {
+            $usage = new Usage(0, 0);
+
+            foreach ($results as $result) {
+                $model::create([
+                    'batch_job_id' => $job->getKey(),
+                    'custom_id' => $result->customId,
+                    'status' => $result->status,
+                    'response' => $this->serializeResponse($result->response),
+                    'usage' => $result->usage?->toArray(),
+                    'error' => $result->error?->getMessage(),
+                ]);
+
+                if ($result->usage !== null) {
+                    $usage = $usage->merge($result->usage);
+                }
+            }
+
+            $job->markCompleted($usage);
+        });
+
+        $this->events->dispatch(new BatchCompleted($job));
+        $this->checkGroup($job);
+    }
+
+    /**
+     * Normalize a parsed line response into a storable array.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function serializeResponse(?object $response): ?array
+    {
+        if ($response instanceof TextResponse) {
+            return [
+                'text' => $response->text,
+                'finish_reason' => $response->finishReason->value,
+            ];
+        }
+
+        if ($response instanceof EmbeddingsResponse) {
+            return ['embedding' => $response->embeddings[0] ?? []];
+        }
+
+        return null;
+    }
+
+    /**
+     * Fire the group-completed event once all of a group's jobs are terminal.
+     */
+    private function checkGroup(BatchJob $job): void
+    {
+        if ($job->batch_group_id === null) {
+            return;
+        }
+
+        $group = $job->group;
+
+        if ($group !== null && $group->isComplete()) {
+            $this->events->dispatch(new BatchGroupCompleted($group));
+        }
+    }
+}

--- a/src/Batch/BatchService.php
+++ b/src/Batch/BatchService.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Batch;
 
 use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Events\BatchCompleted;
 use Atlasphp\Atlas\Events\BatchFailed;
 use Atlasphp\Atlas\Events\BatchGroupCompleted;
 use Atlasphp\Atlas\Events\BatchSubmitted;
 use Atlasphp\Atlas\Persistence\Models\BatchGroup;
 use Atlasphp\Atlas\Persistence\Models\BatchJob;
-use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Persistence\Models\BatchResult;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Requests\Batch;
@@ -145,8 +145,7 @@ class BatchService
                 }
             }
 
-            $job->applyStatus(BatchStatus::Completed, $counts);
-            $job->markCompleted($usage);
+            $job->markCompleted($counts, $usage);
         });
 
         $this->events->dispatch(new BatchCompleted($job));

--- a/src/Console/PollBatchJobsCommand.php
+++ b/src/Console/PollBatchJobsCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Console;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Batch\BatchService;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Illuminate\Console\Command;
+
+/**
+ * Polls open batch jobs and hydrates completed ones.
+ *
+ * Batch results are delivered by polling — the provider has no callback into
+ * your app. This command advances every non-terminal tracked job: it fetches
+ * the current status, updates counts, and on completion stores the per-line
+ * results. Idempotent and safe to run on a schedule.
+ *
+ * Schedule: $schedule->command('atlas:batch-poll')->everyFiveMinutes();
+ */
+class PollBatchJobsCommand extends Command
+{
+    protected $signature = 'atlas:batch-poll
+        {--limit= : Maximum number of open jobs to poll this run (default: config value)}
+        {--provider= : Only poll jobs for this provider}';
+
+    protected $description = 'Poll open batch jobs and hydrate completed ones';
+
+    public function handle(BatchService $service, AtlasConfig $config): int
+    {
+        if (! $config->persistenceEnabled) {
+            $this->info('Persistence is not enabled. Batch polling requires persistence.');
+
+            return self::SUCCESS;
+        }
+
+        /** @var class-string<BatchJob> $model */
+        $model = $config->model('batch_job', BatchJob::class);
+
+        $limit = (int) ($this->option('limit') ?? config('atlas.batch.poll_limit', 25));
+
+        $query = $model::query()->open()->limit($limit);
+
+        if (is_string($provider = $this->option('provider')) && $provider !== '') {
+            $query->forProvider($provider);
+        }
+
+        $jobs = $query->get();
+
+        if ($jobs->isEmpty()) {
+            $this->info('No open batch jobs to poll.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($jobs as $job) {
+            $service->syncFromProvider($job);
+        }
+
+        $this->info("Polled {$jobs->count()} batch job(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/PruneBatchJobsCommand.php
+++ b/src/Console/PruneBatchJobsCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Console;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Illuminate\Console\Command;
+
+/**
+ * Deletes batch jobs (and their results) older than the retention period.
+ *
+ * Batch history accumulates indefinitely — a high-volume app can reach millions
+ * of result rows. This command sweeps jobs past `atlas.batch.retention_days`
+ * (default 90) in id-ordered chunks, deleting each job's result rows first and
+ * then the jobs themselves (explicitly, not relying on a DB-level cascade that
+ * varies by driver). Deleting in bounded chunks keeps the sweep from locking
+ * the table on large backlogs.
+ *
+ * Schedule: Schedule::command('atlas:batch-prune')->daily();
+ */
+class PruneBatchJobsCommand extends Command
+{
+    protected $signature = 'atlas:batch-prune
+        {--days= : Override the retention window in days (default: config value)}
+        {--chunk=1000 : Number of jobs to delete per batch}';
+
+    protected $description = 'Delete batch jobs and results older than the retention period';
+
+    public function handle(AtlasConfig $config): int
+    {
+        if (! $config->persistenceEnabled) {
+            $this->info('Persistence is not enabled. Nothing to prune.');
+
+            return self::SUCCESS;
+        }
+
+        $days = (int) ($this->option('days') ?? config('atlas.batch.retention_days', 90));
+        $chunk = max(1, (int) $this->option('chunk'));
+        $cutoff = now()->subDays($days);
+
+        /** @var class-string<BatchJob> $model */
+        $model = $config->model('batch_job', BatchJob::class);
+        /** @var class-string<BatchResult> $resultModel */
+        $resultModel = $config->model('batch_result', BatchResult::class);
+
+        $deleted = 0;
+
+        do {
+            $ids = $model::query()
+                ->where('created_at', '<', $cutoff)
+                ->orderBy('id')
+                ->limit($chunk)
+                ->pluck('id');
+
+            if ($ids->isEmpty()) {
+                break;
+            }
+
+            // Delete children then parents explicitly — independent of whether
+            // the DB enforces the foreign-key cascade.
+            $resultModel::query()->whereIn('batch_job_id', $ids)->delete();
+            $deleted += $model::query()->whereIn('id', $ids)->delete();
+        } while ($ids->count() === $chunk);
+
+        // Sweep groups left empty by the prune (their FK nulls on job delete,
+        // so they'd otherwise accumulate forever).
+        /** @var class-string<BatchGroup> $groupModel */
+        $groupModel = $config->model('batch_group', BatchGroup::class);
+        $groups = $groupModel::query()
+            ->where('created_at', '<', $cutoff)
+            ->whereDoesntHave('jobs')
+            ->delete();
+
+        $this->info("Pruned {$deleted} batch job(s) and {$groups} empty group(s) older than {$days} day(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/PruneBatchJobsCommand.php
+++ b/src/Console/PruneBatchJobsCommand.php
@@ -67,13 +67,26 @@ class PruneBatchJobsCommand extends Command
         } while ($ids->count() === $chunk);
 
         // Sweep groups left empty by the prune (their FK nulls on job delete,
-        // so they'd otherwise accumulate forever).
+        // so they'd otherwise accumulate forever). Chunked like the jobs sweep so
+        // a large backlog can't lock the table in one statement.
         /** @var class-string<BatchGroup> $groupModel */
         $groupModel = $config->model('batch_group', BatchGroup::class);
-        $groups = $groupModel::query()
-            ->where('created_at', '<', $cutoff)
-            ->whereDoesntHave('jobs')
-            ->delete();
+        $groups = 0;
+
+        do {
+            $groupIds = $groupModel::query()
+                ->where('created_at', '<', $cutoff)
+                ->whereDoesntHave('jobs')
+                ->orderBy('id')
+                ->limit($chunk)
+                ->pluck('id');
+
+            if ($groupIds->isEmpty()) {
+                break;
+            }
+
+            $groups += $groupModel::query()->whereIn('id', $groupIds)->delete();
+        } while ($groupIds->count() === $chunk);
 
         $this->info("Pruned {$deleted} batch job(s) and {$groups} empty group(s) older than {$days} day(s).");
 

--- a/src/Enums/BatchResultStatus.php
+++ b/src/Enums/BatchResultStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Enums;
+
+/**
+ * Outcome of a single request line within a batch job.
+ *
+ * Independent per line: one errored line never affects the others. Each batch
+ * handler maps the provider's per-result outcome into this enum.
+ */
+enum BatchResultStatus: string
+{
+    case Succeeded = 'succeeded';
+    case Errored = 'errored';
+    case Expired = 'expired';
+    case Cancelled = 'cancelled';
+
+    /**
+     * Whether this line produced a usable response.
+     */
+    public function isSuccessful(): bool
+    {
+        return $this === self::Succeeded;
+    }
+}

--- a/src/Enums/BatchStatus.php
+++ b/src/Enums/BatchStatus.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Enums;
+
+/**
+ * Normalized lifecycle status for a provider batch job.
+ *
+ * Providers each use their own vocabulary (OpenAI `validating/in_progress/…`,
+ * Anthropic `in_progress/ended`, Gemini `JOB_STATE_*`, xAI counters). Each batch
+ * handler maps its native status into this enum so consumers and the poller
+ * reason about one set of states.
+ */
+enum BatchStatus: string
+{
+    case Validating = 'validating';
+    case InProgress = 'in_progress';
+    case Finalizing = 'finalizing';
+    case Completed = 'completed';
+    case Failed = 'failed';
+    case Expired = 'expired';
+    case Cancelling = 'cancelling';
+    case Cancelled = 'cancelled';
+
+    /**
+     * Whether the job has reached a state that will not change further.
+     *
+     * Terminal jobs are skipped by the poller and are safe to hydrate once.
+     */
+    public function isTerminal(): bool
+    {
+        return match ($this) {
+            self::Completed, self::Failed, self::Expired, self::Cancelled => true,
+            self::Validating, self::InProgress, self::Finalizing, self::Cancelling => false,
+        };
+    }
+
+    /**
+     * Whether the job finished successfully and its results can be ingested.
+     */
+    public function isSuccessful(): bool
+    {
+        return $this === self::Completed;
+    }
+}

--- a/src/Events/BatchCompleted.php
+++ b/src/Events/BatchCompleted.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Events;
+
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+
+/**
+ * Fired when a tracked batch job completes and its results are hydrated.
+ *
+ * Hook this to write results back to your own models by their custom id.
+ */
+class BatchCompleted
+{
+    public function __construct(public readonly BatchJob $job) {}
+}

--- a/src/Events/BatchFailed.php
+++ b/src/Events/BatchFailed.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Events;
+
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+
+/**
+ * Fired when a tracked batch job reaches a failed, expired, or cancelled state.
+ */
+class BatchFailed
+{
+    public function __construct(public readonly BatchJob $job) {}
+}

--- a/src/Events/BatchGroupCompleted.php
+++ b/src/Events/BatchGroupCompleted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Events;
+
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+
+/**
+ * Fired when every job in a batch group has reached a terminal state.
+ */
+class BatchGroupCompleted
+{
+    public function __construct(public readonly BatchGroup $group) {}
+}

--- a/src/Events/BatchSubmitted.php
+++ b/src/Events/BatchSubmitted.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Events;
+
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+
+/**
+ * Fired when a tracked batch job has been submitted to the provider.
+ */
+class BatchSubmitted
+{
+    public function __construct(public readonly BatchJob $job) {}
+}

--- a/src/Exceptions/BatchException.php
+++ b/src/Exceptions/BatchException.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Exceptions;
+
+/**
+ * Thrown for batch-assembly and batch-lifecycle errors.
+ *
+ * Batch lines are one-shot, fire-and-forget requests resolved hours later and
+ * out of band. Features that depend on the synchronous request pipeline — the
+ * tool-execution loop and the middleware stack — cannot apply to a batched
+ * line, so attaching them is rejected up front rather than silently ignored.
+ */
+class BatchException extends AtlasException
+{
+    /**
+     * The batch had no lines to submit.
+     */
+    public static function empty(): self
+    {
+        return new self('Cannot submit an empty batch — add at least one request first.');
+    }
+
+    /**
+     * A request type that cannot be batched was added.
+     */
+    public static function notBatchable(string $class): self
+    {
+        return new self(
+            "Requests of type [{$class}] cannot be batched. Only text and embeddings requests are batchable."
+        );
+    }
+
+    /**
+     * Two different modalities were mixed in one batch.
+     */
+    public static function mixedModality(string $expected, string $got): self
+    {
+        return new self(
+            "All requests in a batch must share one modality; expected [{$expected}], got [{$got}]."
+        );
+    }
+
+    /**
+     * Two different providers were mixed in one batch.
+     */
+    public static function mixedProvider(string $expected, string $got): self
+    {
+        return new self(
+            "All requests in a batch must target one provider; expected [{$expected}], got [{$got}]."
+        );
+    }
+
+    /**
+     * A request with tools was added to a batch.
+     */
+    public static function toolsUnsupported(): self
+    {
+        return new self(
+            'Tools cannot be used with batch processing. The tool-execution loop requires '
+            .'synchronous round-trips (model → tool → model), but a batch line is a single '
+            .'one-shot request resolved later. Run tool-using requests synchronously, or via an agent.'
+        );
+    }
+
+    /**
+     * A request with per-request middleware was added to a batch.
+     */
+    public static function middlewareUnsupported(): self
+    {
+        return new self(
+            'Per-request middleware does not run for batched requests. Batch bypasses the '
+            .'synchronous middleware pipeline — the line is serialized to its provider payload and '
+            .'submitted as a deferred job. Apply any transformation before adding the request, or '
+            .'process results when the batch completes.'
+        );
+    }
+
+    /**
+     * Batch tracking was requested without persistence enabled.
+     */
+    public static function persistenceRequired(): self
+    {
+        return new self(
+            'Batch tracking requires atlas persistence to be enabled. Enable '
+            .'atlas.persistence.enabled, or use stateless submit() and poll the provider yourself.'
+        );
+    }
+}

--- a/src/Pending/BatchRequest.php
+++ b/src/Pending/BatchRequest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Pending;
+
+use Atlasphp\Atlas\Batch\BatchService;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Pending\Contracts\Batchable;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Responses\BatchResponse;
+
+/**
+ * Fluent collector for assembling and submitting a batch job.
+ *
+ * Each added request is an ordinary pending modality builder (text or
+ * embeddings). A batch targets a single provider and a single modality; the
+ * first added request fixes both, and mismatched additions are rejected.
+ *
+ * Persistence is ambient: when `atlas.persistence.enabled` is on, submit()
+ * persists a {@see BatchJob} that the atlas:batch-poll command hydrates
+ * automatically; when off, submit() is stateless and returns a
+ * {@see BatchResponse} with the provider batch id for the caller to poll.
+ */
+class BatchRequest
+{
+    protected ?string $provider;
+
+    protected ?Modality $modality = null;
+
+    /** @var array<int, BatchLine> */
+    protected array $lines = [];
+
+    protected ?BatchGroup $group = null;
+
+    protected string $completionWindow = '24h';
+
+    public function __construct(
+        Provider|string|null $provider,
+        protected readonly ProviderRegistryContract $registry,
+        protected readonly ?BatchService $batchService = null,
+    ) {
+        $this->provider = $provider === null ? null : Provider::normalize($provider);
+        $this->completionWindow = (string) config('atlas.batch.completion_window', '24h');
+    }
+
+    /**
+     * Add a request to the batch, keyed for trace-back on results.
+     *
+     * The key is echoed by the provider on the matching result; use your own
+     * model's primary key so results map straight back to your records.
+     *
+     * @throws BatchException When the request is not batchable, mixes providers/
+     *                        modalities, or carries tools or middleware (neither
+     *                        survives a batch line).
+     */
+    public function add(object $request, string $key): static
+    {
+        if (! $request instanceof Batchable) {
+            throw BatchException::notBatchable($request::class);
+        }
+
+        $this->bindModalityAndProvider($request);
+
+        $dto = $request->buildRequest();
+        $this->assertNoLoopFeatures($dto);
+
+        $this->lines[] = new BatchLine($key, $dto);
+
+        return $this;
+    }
+
+    /**
+     * Add many requests via a factory returning [Batchable $request, string $key].
+     *
+     * @param  iterable<mixed>  $items
+     * @param  callable(mixed): array{0: object, 1: string}  $factory
+     */
+    public function addMany(iterable $items, callable $factory): static
+    {
+        foreach ($items as $item) {
+            [$request, $key] = $factory($item);
+            $this->add($request, $key);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Attach this batch to a group so progress can be tracked across batches.
+     *
+     * Groups are a persisted feature, so this requires persistence.
+     *
+     * @throws BatchException When persistence is not enabled.
+     */
+    public function group(BatchGroup $group): static
+    {
+        if ($this->batchService === null) {
+            throw BatchException::persistenceRequired();
+        }
+
+        $this->group = $group;
+
+        return $this;
+    }
+
+    /**
+     * Override the provider completion window (default "24h").
+     */
+    public function completionWindow(string $window): static
+    {
+        $this->completionWindow = $window;
+
+        return $this;
+    }
+
+    /**
+     * Submit the batch to the provider.
+     *
+     * When persistence is enabled, the batch is persisted as a {@see BatchJob}
+     * (auto-polled by atlas:batch-poll). Otherwise it's stateless and returns a
+     * {@see BatchResponse} with the provider batch id for you to poll.
+     *
+     * @throws BatchException When the batch is empty.
+     */
+    public function submit(): BatchResponse|BatchJob
+    {
+        if ($this->lines === [] || $this->provider === null || $this->modality === null) {
+            throw BatchException::empty();
+        }
+
+        $batch = new Batch($this->provider, $this->modality, $this->lines, $this->completionWindow);
+
+        if ($this->batchService !== null) {
+            return $this->batchService->submitAndTrack($batch, $this->group);
+        }
+
+        return $this->registry->resolve($this->provider)->batch($batch);
+    }
+
+    /**
+     * Number of requests currently in the batch.
+     */
+    public function count(): int
+    {
+        return count($this->lines);
+    }
+
+    /**
+     * Fix or validate the batch's modality and provider against an added request.
+     *
+     * @throws BatchException
+     */
+    protected function bindModalityAndProvider(Batchable $request): void
+    {
+        $modality = $request->batchModality();
+        $provider = $request->batchProvider();
+
+        $this->modality ??= $modality;
+        $this->provider ??= $provider;
+
+        if ($modality !== $this->modality) {
+            throw BatchException::mixedModality($this->modality->value, $modality->value);
+        }
+
+        if ($provider !== $this->provider) {
+            throw BatchException::mixedProvider($this->provider, $provider);
+        }
+    }
+
+    /**
+     * Reject features that cannot survive a one-shot batch line.
+     *
+     * Tools require the synchronous model→tool→model loop, and per-request
+     * middleware wraps the synchronous call — neither runs for a deferred batch
+     * line, so attaching them is an explicit error rather than a silent no-op.
+     * Everything that is part of the request body (messages, vision input,
+     * structured-output schema, reasoning effort, provider options) is preserved.
+     *
+     * @throws BatchException
+     */
+    protected function assertNoLoopFeatures(object $dto): void
+    {
+        if (property_exists($dto, 'tools') && $dto->tools !== []) {
+            throw BatchException::toolsUnsupported();
+        }
+
+        if (property_exists($dto, 'providerTools') && $dto->providerTools !== []) {
+            throw BatchException::toolsUnsupported();
+        }
+
+        if (property_exists($dto, 'middleware') && $dto->middleware !== []) {
+            throw BatchException::middlewareUnsupported();
+        }
+    }
+}

--- a/src/Pending/Contracts/Batchable.php
+++ b/src/Pending/Contracts/Batchable.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Pending\Contracts;
+
+use Atlasphp\Atlas\Enums\Modality;
+
+/**
+ * A pending modality builder that can be enqueued as a line in a batch job.
+ *
+ * Implemented only by the modality builders whose requests a provider batch
+ * endpoint accepts (text, embeddings). Builders that cannot be batched (audio,
+ * voice, rerank, …) deliberately do not implement this, so the batch builder's
+ * add() method rejects them at build time.
+ */
+interface Batchable
+{
+    /**
+     * The modality this request represents (determines the batch endpoint).
+     */
+    public function batchModality(): Modality;
+
+    /**
+     * The resolved provider key this request targets.
+     */
+    public function batchProvider(): string;
+
+    /**
+     * Build the immutable request DTO serialized into the batch payload.
+     */
+    public function buildRequest(): object;
+}

--- a/src/Pending/EmbedRequest.php
+++ b/src/Pending/EmbedRequest.php
@@ -15,6 +15,7 @@ use Atlasphp\Atlas\Pending\Concerns\HasProviderOptions;
 use Atlasphp\Atlas\Pending\Concerns\HasQueueDispatch;
 use Atlasphp\Atlas\Pending\Concerns\HasRequestConfig;
 use Atlasphp\Atlas\Pending\Concerns\ResolvesProvider;
+use Atlasphp\Atlas\Pending\Contracts\Batchable;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Queue\Contracts\QueueableRequest;
 use Atlasphp\Atlas\Queue\PendingExecution;
@@ -26,7 +27,7 @@ use Illuminate\Support\Str;
 /**
  * Fluent builder for embedding requests.
  */
-class EmbedRequest implements QueueableRequest
+class EmbedRequest implements Batchable, QueueableRequest
 {
     use HasMeta;
     use HasMiddleware;
@@ -84,6 +85,16 @@ class EmbedRequest implements QueueableRequest
         event(new ModalityCompleted(modality: Modality::Embed, provider: $provider, model: $model, usage: $response->usage, traceId: $traceId));
 
         return $response;
+    }
+
+    public function batchModality(): Modality
+    {
+        return Modality::Embed;
+    }
+
+    public function batchProvider(): string
+    {
+        return $this->resolveProviderKey();
     }
 
     public function buildRequest(): EmbedRequestObject

--- a/src/Pending/ProviderRequest.php
+++ b/src/Pending/ProviderRequest.php
@@ -10,6 +10,8 @@ use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Providers\ModelList;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
 use Atlasphp\Atlas\Providers\VoiceList;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
 
 /**
  * Provider interrogation — delegates to the resolved driver for metadata queries.
@@ -41,6 +43,32 @@ class ProviderRequest
     public function capabilities(): ProviderCapabilities
     {
         return $this->resolveDriver()->capabilities();
+    }
+
+    /**
+     * Fetch the current state of a batch job (stateless polling).
+     */
+    public function batchStatus(string $batchId): BatchResponse
+    {
+        return $this->resolveDriver()->batchStatus($batchId);
+    }
+
+    /**
+     * Stream the per-line results of a completed batch job.
+     *
+     * @return iterable<int, BatchResult>
+     */
+    public function batchResults(string $batchId): iterable
+    {
+        return $this->resolveDriver()->batchResults($batchId);
+    }
+
+    /**
+     * Request cancellation of an in-flight batch job.
+     */
+    public function batchCancel(string $batchId): BatchResponse
+    {
+        return $this->resolveDriver()->batchCancel($batchId);
     }
 
     public function name(): string

--- a/src/Pending/TextRequest.php
+++ b/src/Pending/TextRequest.php
@@ -28,6 +28,7 @@ use Atlasphp\Atlas\Pending\Concerns\HasRequestConfig;
 use Atlasphp\Atlas\Pending\Concerns\HasVariables;
 use Atlasphp\Atlas\Pending\Concerns\NormalizesMessages;
 use Atlasphp\Atlas\Pending\Concerns\ResolvesProvider;
+use Atlasphp\Atlas\Pending\Contracts\Batchable;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Providers\Tools\ProviderTool;
 use Atlasphp\Atlas\Queue\Contracts\QueueableRequest;
@@ -53,7 +54,7 @@ use Illuminate\Support\Str;
  * When tools are present, terminal methods route through the executor's step loop
  * for automatic tool call handling. Without tools, calls go directly to the driver.
  */
-class TextRequest implements QueueableRequest
+class TextRequest implements Batchable, QueueableRequest
 {
     use ConvertsResultToChunks;
     use HasMeta;
@@ -430,6 +431,16 @@ class TextRequest implements QueueableRequest
         $this->ensureCapability($driver, 'text');
 
         return $driver->countTokens($this->buildRequest());
+    }
+
+    public function batchModality(): Modality
+    {
+        return Modality::Text;
+    }
+
+    public function batchProvider(): string
+    {
+        return $this->resolveProviderKey();
     }
 
     public function buildRequest(): TextRequestObject

--- a/src/Persistence/Models/BatchGroup.php
+++ b/src/Persistence/Models/BatchGroup.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Persistence\Models;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Persistence\Concerns\HasAtlasTable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * Class BatchGroup
+ *
+ * Ties multiple batch jobs into one logical operation (e.g. 4,000 images split
+ * into four batches), so progress can be reported across all of them.
+ *
+ * @property int $id
+ * @property string|null $label
+ * @property array<string, mixed>|null $metadata
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class BatchGroup extends Model
+{
+    use HasAtlasTable;
+
+    protected $table = 'batch_groups';
+
+    protected $fillable = [
+        'label',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+        ];
+    }
+
+    /** @return HasMany<BatchJob, $this> */
+    public function jobs(): HasMany
+    {
+        /** @var class-string<BatchJob> $model */
+        $model = app(AtlasConfig::class)->model('batch_job', BatchJob::class);
+
+        return $this->hasMany($model, 'batch_group_id');
+    }
+
+    /**
+     * Aggregate progress across all jobs in the group.
+     *
+     * @return array{total: int, succeeded: int, failed: int, jobs: int, completed_jobs: int}
+     */
+    public function progress(): array
+    {
+        $jobs = $this->jobs()->get(['status', 'total', 'succeeded', 'failed']);
+
+        return [
+            'total' => (int) $jobs->sum('total'),
+            'succeeded' => (int) $jobs->sum('succeeded'),
+            'failed' => (int) $jobs->sum('failed'),
+            'jobs' => $jobs->count(),
+            'completed_jobs' => $jobs->filter(fn (BatchJob $j) => $j->status->isTerminal())->count(),
+        ];
+    }
+
+    /**
+     * Whether every job in the group has reached a terminal state.
+     */
+    public function isComplete(): bool
+    {
+        $progress = $this->progress();
+
+        return $progress['jobs'] > 0 && $progress['jobs'] === $progress['completed_jobs'];
+    }
+}

--- a/src/Persistence/Models/BatchJob.php
+++ b/src/Persistence/Models/BatchJob.php
@@ -110,12 +110,18 @@ class BatchJob extends Model
     }
 
     /**
-     * Mark the job completed and store the rolled-up usage.
+     * Mark the job completed with its final counts and rolled-up usage.
+     *
+     * One write: status, counts, usage, and completed_at together.
      */
-    public function markCompleted(Usage $usage): void
+    public function markCompleted(RequestCounts $counts, Usage $usage): void
     {
         $this->update([
             'status' => BatchStatus::Completed,
+            'total' => $counts->total,
+            'succeeded' => $counts->succeeded,
+            'failed' => $counts->failed,
+            'processing' => $counts->processing,
             'usage' => $usage->toArray(),
             'completed_at' => now(),
         ]);

--- a/src/Persistence/Models/BatchJob.php
+++ b/src/Persistence/Models/BatchJob.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Persistence\Models;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Persistence\Concerns\HasAtlasTable;
+use Atlasphp\Atlas\Responses\RequestCounts;
+use Atlasphp\Atlas\Responses\Usage;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * Class BatchJob
+ *
+ * Tracks one submitted provider batch — its normalized status, aggregate
+ * counts, rolled-up usage, and the provider batch id used for polling. Its
+ * per-line results live in the batch_results table.
+ *
+ * @property int $id
+ * @property int|null $batch_group_id
+ * @property string $provider
+ * @property string $modality
+ * @property string|null $batch_id
+ * @property BatchStatus $status
+ * @property int $total
+ * @property int $succeeded
+ * @property int $failed
+ * @property int $processing
+ * @property array<string, int>|null $usage
+ * @property string|null $input_file_id
+ * @property string|null $output_file_id
+ * @property string|null $error
+ * @property Carbon|null $submitted_at
+ * @property Carbon|null $completed_at
+ */
+class BatchJob extends Model
+{
+    use HasAtlasTable;
+
+    protected $table = 'batch_jobs';
+
+    protected $fillable = [
+        'batch_group_id',
+        'provider',
+        'modality',
+        'batch_id',
+        'status',
+        'total',
+        'succeeded',
+        'failed',
+        'processing',
+        'usage',
+        'input_file_id',
+        'output_file_id',
+        'error',
+        'submitted_at',
+        'completed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => BatchStatus::class,
+            'usage' => 'array',
+            'total' => 'integer',
+            'succeeded' => 'integer',
+            'failed' => 'integer',
+            'processing' => 'integer',
+            'submitted_at' => 'datetime',
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<BatchGroup, $this> */
+    public function group(): BelongsTo
+    {
+        /** @var class-string<BatchGroup> $model */
+        $model = app(AtlasConfig::class)->model('batch_group', BatchGroup::class);
+
+        return $this->belongsTo($model, 'batch_group_id');
+    }
+
+    /** @return HasMany<BatchResult, $this> */
+    public function results(): HasMany
+    {
+        /** @var class-string<BatchResult> $model */
+        $model = app(AtlasConfig::class)->model('batch_result', BatchResult::class);
+
+        return $this->hasMany($model);
+    }
+
+    /**
+     * Apply a provider status response to this job's columns.
+     */
+    public function applyStatus(BatchStatus $status, RequestCounts $counts): void
+    {
+        $this->update([
+            'status' => $status,
+            'total' => $counts->total,
+            'succeeded' => $counts->succeeded,
+            'failed' => $counts->failed,
+            'processing' => $counts->processing,
+        ]);
+    }
+
+    /**
+     * Mark the job completed and store the rolled-up usage.
+     */
+    public function markCompleted(Usage $usage): void
+    {
+        $this->update([
+            'status' => BatchStatus::Completed,
+            'usage' => $usage->toArray(),
+            'completed_at' => now(),
+        ]);
+    }
+
+    /**
+     * Mark the job failed/expired with a terminal status and message.
+     */
+    public function markFailed(BatchStatus $status, ?string $error = null): void
+    {
+        $this->update([
+            'status' => $status,
+            'error' => $error,
+            'completed_at' => now(),
+        ]);
+    }
+
+    /**
+     * Non-terminal jobs the poller should advance.
+     *
+     * Terminal states are derived from the enum so adding a new one can't drift
+     * out of sync with this scope.
+     *
+     * @param  Builder<static>  $query
+     */
+    public function scopeOpen(Builder $query): void
+    {
+        $terminal = array_map(
+            fn (BatchStatus $status): string => $status->value,
+            array_filter(BatchStatus::cases(), fn (BatchStatus $status): bool => $status->isTerminal()),
+        );
+
+        $query->whereNotNull('batch_id')->whereNotIn('status', $terminal);
+    }
+
+    /** @param Builder<static> $query */
+    public function scopeForProvider(Builder $query, string $provider): void
+    {
+        $query->where('provider', $provider);
+    }
+}

--- a/src/Persistence/Models/BatchResult.php
+++ b/src/Persistence/Models/BatchResult.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Persistence\Models;
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Persistence\Concerns\HasAtlasTable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * Class BatchResult
+ *
+ * One per-line outcome of a batch job, keyed by the consumer's custom id so a
+ * result maps straight back to the originating record.
+ *
+ * @property int $id
+ * @property int $batch_job_id
+ * @property string $custom_id
+ * @property BatchResultStatus $status
+ * @property array<string, mixed>|null $response
+ * @property array<string, int>|null $usage
+ * @property string|null $error
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class BatchResult extends Model
+{
+    use HasAtlasTable;
+
+    protected $table = 'batch_results';
+
+    protected $fillable = [
+        'batch_job_id',
+        'custom_id',
+        'status',
+        'response',
+        'usage',
+        'error',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => BatchResultStatus::class,
+            'response' => 'array',
+            'usage' => 'array',
+        ];
+    }
+
+    /** @return BelongsTo<BatchJob, $this> */
+    public function batchJob(): BelongsTo
+    {
+        /** @var class-string<BatchJob> $model */
+        $model = app(AtlasConfig::class)->model('batch_job', BatchJob::class);
+
+        return $this->belongsTo($model);
+    }
+}

--- a/src/Providers/Anthropic/AnthropicDriver.php
+++ b/src/Providers/Anthropic/AnthropicDriver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Providers\Anthropic;
 
 use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
 use Atlasphp\Atlas\Providers\Handlers\ProviderHandler;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
@@ -33,12 +34,22 @@ class AnthropicDriver extends Driver
                 toolCalling: true,
                 providerTools: true,
                 models: true,
+                batch: true,
+                batchModalities: ['text'],
             ),
             $this->config->capabilityOverrides,
         );
     }
 
     protected function textHandler(): TextHandler
+    {
+        return $this->buildTextHandler();
+    }
+
+    /**
+     * Construct the Anthropic text handler, shared by the text and batch handlers.
+     */
+    private function buildTextHandler(): Handlers\Text
     {
         $toolMapper = new ToolMapper;
 
@@ -50,6 +61,11 @@ class AnthropicDriver extends Driver
             tools: $toolMapper,
             parser: new ResponseParser($toolMapper),
         );
+    }
+
+    protected function batchHandler(): BatchHandler
+    {
+        return new Handlers\Batch($this->config, $this->http, $this->buildTextHandler());
     }
 
     protected function providerHandler(string $feature = 'provider'): ProviderHandler

--- a/src/Providers/Anthropic/Concerns/BuildsAnthropicHeaders.php
+++ b/src/Providers/Anthropic/Concerns/BuildsAnthropicHeaders.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Anthropic\Concerns;
+
+/**
+ * Shared header builder for Anthropic handlers.
+ *
+ * Anthropic uses x-api-key + anthropic-version instead of Bearer auth, so it
+ * can't use the shared BuildsHeaders trait. Expects the using class to have a
+ * $config property of type ProviderConfig.
+ */
+trait BuildsAnthropicHeaders
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function headers(): array
+    {
+        return $this->headersWithoutContentType() + ['Content-Type' => 'application/json'];
+    }
+
+    /**
+     * Headers without Content-Type, for multipart and GET requests.
+     *
+     * @return array<string, string>
+     */
+    protected function headersWithoutContentType(): array
+    {
+        return [
+            'x-api-key' => $this->config->apiKey,
+            'anthropic-version' => $this->config->extra['version'] ?? '2023-06-01',
+        ];
+    }
+}

--- a/src/Providers/Anthropic/Handlers/Batch.php
+++ b/src/Providers/Anthropic/Handlers/Batch.php
@@ -118,7 +118,7 @@ class Batch implements BatchHandler
             $result = is_array($row['result'] ?? null) ? $row['result'] : [];
             $type = (string) ($result['type'] ?? 'errored');
 
-            if ($type === 'succeeded' && is_array($result['message'] ?? null)) {
+            if ($type === 'succeeded' && is_array($result['message'] ?? null) && $result['message'] !== []) {
                 $parsed = $this->text->parse($result['message']);
                 $results[] = new BatchResult($customId, BatchResultStatus::Succeeded, response: $parsed, usage: $parsed->usage);
 

--- a/src/Providers/Anthropic/Handlers/Batch.php
+++ b/src/Providers/Anthropic/Handlers/Batch.php
@@ -9,6 +9,7 @@ use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Exceptions\BatchException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Http\ProviderRequestContext;
+use Atlasphp\Atlas\Providers\Anthropic\Concerns\BuildsAnthropicHeaders;
 use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Requests\Batch as BatchRequest;
@@ -27,6 +28,8 @@ use Atlasphp\Atlas\Responses\RequestCounts;
  */
 class Batch implements BatchHandler
 {
+    use BuildsAnthropicHeaders;
+
     public function __construct(
         protected readonly ProviderConfig $config,
         protected readonly HttpClient $http,
@@ -182,17 +185,5 @@ class Batch implements BatchHandler
             'ended' => BatchStatus::Completed,
             default => BatchStatus::InProgress,
         };
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function headers(): array
-    {
-        return [
-            'x-api-key' => $this->config->apiKey,
-            'anthropic-version' => $this->config->extra['version'] ?? '2023-06-01',
-            'content-type' => 'application/json',
-        ];
     }
 }

--- a/src/Providers/Anthropic/Handlers/Batch.php
+++ b/src/Providers/Anthropic/Handlers/Batch.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Anthropic\Handlers;
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Http\ProviderRequestContext;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch as BatchRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
+
+/**
+ * Anthropic batch handler using the Messages Batches API.
+ *
+ * Anthropic batches are submitted inline (no file upload): each line's params
+ * are built by the synchronous text handler's own body builder, so a batch line
+ * is identical to a live Messages request. Results stream from a results_url and
+ * are parsed back through the text handler's parser.
+ */
+class Batch implements BatchHandler
+{
+    public function __construct(
+        protected readonly ProviderConfig $config,
+        protected readonly HttpClient $http,
+        protected readonly Text $text,
+    ) {}
+
+    public function submit(BatchRequest $batch): BatchResponse
+    {
+        $requests = array_map(function ($line): array {
+            if (! $line->request instanceof TextRequest) {
+                throw BatchException::notBatchable($line->request::class);
+            }
+
+            return [
+                'custom_id' => $line->customId,
+                'params' => $this->text->buildBody($line->request),
+            ];
+        }, $batch->lines);
+
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/messages/batches",
+            headers: $this->headers(),
+            body: ['requests' => $requests],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        return $this->toResponse($data);
+    }
+
+    public function status(string $batchId): BatchResponse
+    {
+        return $this->toResponse($this->fetch($batchId));
+    }
+
+    public function results(string $batchId): iterable
+    {
+        $batch = $this->fetch($batchId);
+        $resultsUrl = $batch['results_url'] ?? null;
+
+        if (! is_string($resultsUrl) || $resultsUrl === '') {
+            return [];
+        }
+
+        return $this->parseResults($this->http->getRaw($resultsUrl, $this->headers(), $this->config->timeout));
+    }
+
+    public function cancel(string $batchId): BatchResponse
+    {
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/messages/batches/{$batchId}/cancel",
+            headers: $this->headers(),
+            body: [],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        return $this->toResponse($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetch(string $batchId): array
+    {
+        return $this->http->get(
+            "{$this->config->baseUrl}/messages/batches/{$batchId}",
+            $this->headers(),
+            $this->config->timeout,
+        );
+    }
+
+    /**
+     * @return iterable<int, BatchResult>
+     */
+    private function parseResults(string $body): iterable
+    {
+        $results = [];
+
+        foreach (explode("\n", trim($body)) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            /** @var array<string, mixed> $row */
+            $row = json_decode($line, true) ?: [];
+            $customId = (string) ($row['custom_id'] ?? '');
+            /** @var array<string, mixed> $result */
+            $result = is_array($row['result'] ?? null) ? $row['result'] : [];
+            $type = (string) ($result['type'] ?? 'errored');
+
+            if ($type === 'succeeded' && is_array($result['message'] ?? null)) {
+                $parsed = $this->text->parse($result['message']);
+                $results[] = new BatchResult($customId, BatchResultStatus::Succeeded, response: $parsed, usage: $parsed->usage);
+
+                continue;
+            }
+
+            $results[] = new BatchResult($customId, $this->mapResultStatus($type), error: new BatchException($this->resultError($result, $type)));
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function resultError(array $result, string $type): string
+    {
+        $error = is_array($result['error'] ?? null) ? $result['error'] : [];
+
+        return (string) ($error['message'] ?? "batch line {$type}");
+    }
+
+    private function mapResultStatus(string $type): BatchResultStatus
+    {
+        return match ($type) {
+            'canceled' => BatchResultStatus::Cancelled,
+            'expired' => BatchResultStatus::Expired,
+            default => BatchResultStatus::Errored,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function toResponse(array $data): BatchResponse
+    {
+        /** @var array<string, mixed> $counts */
+        $counts = is_array($data['request_counts'] ?? null) ? $data['request_counts'] : [];
+        $succeeded = (int) ($counts['succeeded'] ?? 0);
+        $failed = (int) ($counts['errored'] ?? 0);
+        $processing = (int) ($counts['processing'] ?? 0);
+        $total = $processing + $succeeded + $failed + (int) ($counts['canceled'] ?? 0) + (int) ($counts['expired'] ?? 0);
+
+        return new BatchResponse(
+            batchId: (string) ($data['id'] ?? ''),
+            status: $this->mapStatus((string) ($data['processing_status'] ?? '')),
+            counts: new RequestCounts(total: $total, succeeded: $succeeded, failed: $failed, processing: $processing),
+            outputFileId: isset($data['results_url']) ? (string) $data['results_url'] : null,
+        );
+    }
+
+    /**
+     * Map Anthropic's processing_status to the normalized enum. A finished batch
+     * ("ended") is Completed; per-line failures live in the results.
+     */
+    private function mapStatus(string $status): BatchStatus
+    {
+        return match ($status) {
+            'in_progress' => BatchStatus::InProgress,
+            'canceling' => BatchStatus::Cancelling,
+            'ended' => BatchStatus::Completed,
+            default => BatchStatus::InProgress,
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headers(): array
+    {
+        return [
+            'x-api-key' => $this->config->apiKey,
+            'anthropic-version' => $this->config->extra['version'] ?? '2023-06-01',
+            'content-type' => 'application/json',
+        ];
+    }
+}

--- a/src/Providers/Anthropic/Handlers/Provider.php
+++ b/src/Providers/Anthropic/Handlers/Provider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Providers\Anthropic\Handlers;
 
 use Atlasphp\Atlas\Http\ProviderRequestContext;
+use Atlasphp\Atlas\Providers\Anthropic\Concerns\BuildsAnthropicHeaders;
 use Atlasphp\Atlas\Providers\Handlers\AbstractProviderHandler;
 use Atlasphp\Atlas\Providers\ModelList;
 use Atlasphp\Atlas\Providers\VoiceList;
@@ -17,18 +18,7 @@ use Atlasphp\Atlas\Providers\VoiceList;
  */
 class Provider extends AbstractProviderHandler
 {
-    /**
-     * Anthropic uses x-api-key header, not Bearer.
-     *
-     * @return array<string, string>
-     */
-    protected function headersWithoutContentType(): array
-    {
-        return [
-            'x-api-key' => $this->config->apiKey,
-            'anthropic-version' => $this->config->extra['version'] ?? '2023-06-01',
-        ];
-    }
+    use BuildsAnthropicHeaders;
 
     /**
      * Fetch models from Anthropic's /v1/models endpoint.

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -58,6 +58,18 @@ class Text implements TextHandler
         return $this->parser->parseText($data);
     }
 
+    /**
+     * Parse a Messages API payload into a TextResponse.
+     *
+     * Public so the batch handler parses a batch line's result identically.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function parse(array $data): TextResponse
+    {
+        return $this->parser->parseText($data);
+    }
+
     public function stream(TextRequest $request): StreamResponse
     {
         $body = $this->buildBody($request);
@@ -151,9 +163,12 @@ class Text implements TextHandler
     /**
      * Build the Anthropic Messages API request body.
      *
+     * Public so the batch handler serializes a batch line's params identically
+     * to a synchronous call.
+     *
      * @return array<string, mixed>
      */
-    protected function buildBody(TextRequest $request): array
+    public function buildBody(TextRequest $request): array
     {
         $messageData = $this->messages->buildAll($request, $this->media);
 

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Enums\ChunkType;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Http\ProviderRequestContext;
 use Atlasphp\Atlas\Messages\ToolCall;
+use Atlasphp\Atlas\Providers\Anthropic\Concerns\BuildsAnthropicHeaders;
 use Atlasphp\Atlas\Providers\Anthropic\MediaResolver;
 use Atlasphp\Atlas\Providers\Anthropic\MessageFactory;
 use Atlasphp\Atlas\Providers\Anthropic\ResponseParser;
@@ -34,6 +35,7 @@ use Generator;
 class Text implements TextHandler
 {
     use AppliesToolChoice;
+    use BuildsAnthropicHeaders;
 
     public function __construct(
         protected readonly ProviderConfig $config,
@@ -336,12 +338,4 @@ class Text implements TextHandler
     /**
      * @return array<string, string>
      */
-    protected function headers(): array
-    {
-        return [
-            'x-api-key' => $this->config->apiKey,
-            'anthropic-version' => $this->config->extra['version'] ?? '2023-06-01',
-            'Content-Type' => 'application/json',
-        ];
-    }
 }

--- a/src/Providers/ChatCompletions/ChatCompletionsDriver.php
+++ b/src/Providers/ChatCompletions/ChatCompletionsDriver.php
@@ -53,6 +53,7 @@ class ChatCompletionsDriver extends Driver
                 vision: true,
                 toolCalling: true,
                 models: true,
+                batch: false,
             ),
             $this->config->capabilityOverrides,
         );

--- a/src/Providers/Cohere/CohereDriver.php
+++ b/src/Providers/Cohere/CohereDriver.php
@@ -21,7 +21,7 @@ class CohereDriver extends Driver
     public function capabilities(): ProviderCapabilities
     {
         return ProviderCapabilities::withOverrides(
-            new ProviderCapabilities(rerank: true),
+            new ProviderCapabilities(rerank: true, batch: false),
             $this->config->capabilityOverrides,
         );
     }

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -19,6 +19,7 @@ use Atlasphp\Atlas\Middleware\MiddlewareResolver;
 use Atlasphp\Atlas\Middleware\MiddlewareStack;
 use Atlasphp\Atlas\Middleware\ProviderContext;
 use Atlasphp\Atlas\Providers\Handlers\AudioHandler;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
 use Atlasphp\Atlas\Providers\Handlers\EmbedHandler;
 use Atlasphp\Atlas\Providers\Handlers\ImageHandler;
 use Atlasphp\Atlas\Providers\Handlers\ModerateHandler;
@@ -28,6 +29,7 @@ use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\Handlers\VideoHandler;
 use Atlasphp\Atlas\Providers\Handlers\VoiceHandler;
 use Atlasphp\Atlas\Requests\AudioRequest;
+use Atlasphp\Atlas\Requests\Batch;
 use Atlasphp\Atlas\Requests\EmbedRequest;
 use Atlasphp\Atlas\Requests\ImageRequest;
 use Atlasphp\Atlas\Requests\ModerateRequest;
@@ -36,6 +38,8 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Requests\VideoRequest;
 use Atlasphp\Atlas\Requests\VoiceRequest;
 use Atlasphp\Atlas\Responses\AudioResponse;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
 use Atlasphp\Atlas\Responses\EmbeddingsResponse;
 use Atlasphp\Atlas\Responses\ImageResponse;
 use Atlasphp\Atlas\Responses\ModerationResponse;
@@ -81,6 +85,7 @@ abstract class Driver
      * - 'moderate' → ModerateHandler
      * - 'rerank' → RerankHandler
      * - 'voice' → VoiceHandler (covers createVoiceSession, connectVoice)
+     * - 'batch' → BatchHandler (covers batch, batchStatus, batchResults, batchCancel)
      * - 'provider' → ProviderHandler (covers models, voices, validate)
      */
     public function withHandler(string $modality, object $handler): static
@@ -191,6 +196,53 @@ abstract class Driver
         return $this->resolveHandler('voice', fn () => $this->voiceHandler())->connect($session);
     }
 
+    // ─── Batch ───────────────────────────────────────────────────────────
+
+    /**
+     * Submit a batch job.
+     *
+     * Not routed through per-request middleware (a batch spans many models);
+     * like the interrogation endpoints it translates transport failures to
+     * typed Atlas exceptions. Validates that the provider can batch the
+     * requested modality before dispatching.
+     *
+     * @throws UnsupportedFeatureException When the provider cannot batch this modality.
+     */
+    public function batch(Batch $request): BatchResponse
+    {
+        if (! $this->capabilities()->canBatch($request->modality)) {
+            throw UnsupportedFeatureException::make('batch:'.$request->modality->value, $this->name());
+        }
+
+        return $this->translating('', fn () => $this->resolveHandler('batch', fn () => $this->batchHandler())->submit($request));
+    }
+
+    /**
+     * Fetch the current state of a submitted batch.
+     */
+    public function batchStatus(string $batchId): BatchResponse
+    {
+        return $this->translating('', fn () => $this->resolveHandler('batch', fn () => $this->batchHandler())->status($batchId));
+    }
+
+    /**
+     * Stream the per-line results of a completed batch.
+     *
+     * @return iterable<int, BatchResult>
+     */
+    public function batchResults(string $batchId): iterable
+    {
+        return $this->translating('', fn () => $this->resolveHandler('batch', fn () => $this->batchHandler())->results($batchId));
+    }
+
+    /**
+     * Request cancellation of an in-flight batch.
+     */
+    public function batchCancel(string $batchId): BatchResponse
+    {
+        return $this->translating('', fn () => $this->resolveHandler('batch', fn () => $this->batchHandler())->cancel($batchId));
+    }
+
     // ─── Middleware Dispatch ─────────────────────────────────────────────
 
     /**
@@ -289,6 +341,11 @@ abstract class Driver
     protected function voiceHandler(): VoiceHandler
     {
         throw UnsupportedFeatureException::make('voice', $this->name());
+    }
+
+    protected function batchHandler(): BatchHandler
+    {
+        throw UnsupportedFeatureException::make('batch', $this->name());
     }
 
     // ─── Provider Interrogation ──────────────────────────────────────────

--- a/src/Providers/ElevenLabs/ElevenLabsDriver.php
+++ b/src/Providers/ElevenLabs/ElevenLabsDriver.php
@@ -36,6 +36,7 @@ class ElevenLabsDriver extends Driver
                 voice: true,
                 models: true,
                 voices: true,
+                batch: false,
             ),
             $this->config->capabilityOverrides,
         );

--- a/src/Providers/Google/GoogleDriver.php
+++ b/src/Providers/Google/GoogleDriver.php
@@ -39,6 +39,7 @@ class GoogleDriver extends Driver
                 toolCalling: true,
                 providerTools: true,
                 models: true,
+                batch: false,
             ),
             $this->config->capabilityOverrides,
         );

--- a/src/Providers/Google/GoogleDriver.php
+++ b/src/Providers/Google/GoogleDriver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Atlasphp\Atlas\Providers\Google;
 
 use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
 use Atlasphp\Atlas\Providers\Handlers\EmbedHandler;
 use Atlasphp\Atlas\Providers\Handlers\ImageHandler;
 use Atlasphp\Atlas\Providers\Handlers\ProviderHandler;
@@ -39,13 +40,22 @@ class GoogleDriver extends Driver
                 toolCalling: true,
                 providerTools: true,
                 models: true,
-                batch: false,
+                batch: true,
+                batchModalities: ['text'],
             ),
             $this->config->capabilityOverrides,
         );
     }
 
     protected function textHandler(): TextHandler
+    {
+        return $this->buildTextHandler();
+    }
+
+    /**
+     * Construct the Google text handler, shared by the text and batch handlers.
+     */
+    private function buildTextHandler(): Handlers\Text
     {
         $toolMapper = new ToolMapper;
 
@@ -57,6 +67,11 @@ class GoogleDriver extends Driver
             tools: $toolMapper,
             parser: new ResponseParser($toolMapper),
         );
+    }
+
+    protected function batchHandler(): BatchHandler
+    {
+        return new Handlers\Batch($this->config, $this->http, $this->buildTextHandler());
     }
 
     protected function imageHandler(): ImageHandler

--- a/src/Providers/Google/Handlers/Batch.php
+++ b/src/Providers/Google/Handlers/Batch.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Google\Handlers;
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Http\ProviderRequestContext;
+use Atlasphp\Atlas\Providers\Google\Concerns\BuildsGoogleHeaders;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch as BatchRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
+
+/**
+ * Google (Gemini) batch handler using inline batchGenerateContent.
+ *
+ * Requests are submitted inline (no file upload); each line's request body is
+ * built by the synchronous text handler. The model lives in the URL and applies
+ * to every line, so a batch targets one model. The GET response is a
+ * long-running Operation: state lives at metadata.state (JOB_STATE_*) and
+ * results at response.inlinedResponses, correlated to each line by metadata.key.
+ */
+class Batch implements BatchHandler
+{
+    use BuildsGoogleHeaders;
+
+    public function __construct(
+        protected readonly ProviderConfig $config,
+        protected readonly HttpClient $http,
+        protected readonly Text $text,
+    ) {}
+
+    public function submit(BatchRequest $batch): BatchResponse
+    {
+        $requests = array_map(function ($line): array {
+            if (! $line->request instanceof TextRequest) {
+                throw BatchException::notBatchable($line->request::class);
+            }
+
+            return [
+                'request' => $this->text->buildBody($line->request),
+                'metadata' => ['key' => $line->customId],
+            ];
+        }, $batch->lines);
+
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/v1beta/models/{$this->modelFor($batch)}:batchGenerateContent",
+            headers: $this->headers(),
+            body: ['batch' => [
+                'display_name' => 'atlas-batch',
+                'input_config' => ['requests' => ['requests' => $requests]],
+            ]],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        return $this->toResponse($data);
+    }
+
+    public function status(string $batchId): BatchResponse
+    {
+        return $this->toResponse($this->fetch($batchId));
+    }
+
+    public function results(string $batchId): iterable
+    {
+        $data = $this->fetch($batchId);
+        /** @var array<int, array<string, mixed>> $inlined */
+        $inlined = $data['response']['inlinedResponses']['inlinedResponses'] ?? [];
+
+        $results = [];
+
+        foreach ($inlined as $entry) {
+            // Correlate to the submitted line by metadata.key — never by index
+            // (Gemini may return inlinedResponses out of order).
+            $key = (string) ($entry['metadata']['key'] ?? '');
+
+            if (isset($entry['error'])) {
+                $message = is_array($entry['error']) ? (string) ($entry['error']['message'] ?? 'batch line failed') : (string) $entry['error'];
+                $results[] = new BatchResult($key, BatchResultStatus::Errored, error: new BatchException($message));
+
+                continue;
+            }
+
+            /** @var array<string, mixed> $response */
+            $response = is_array($entry['response'] ?? null) ? $entry['response'] : [];
+            $parsed = $this->text->parse($response);
+            $results[] = new BatchResult($key, BatchResultStatus::Succeeded, response: $parsed, usage: $parsed->usage);
+        }
+
+        return $results;
+    }
+
+    public function cancel(string $batchId): BatchResponse
+    {
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/v1beta/{$batchId}:cancel",
+            headers: $this->headers(),
+            body: [],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        return $data === [] ? $this->status($batchId) : $this->toResponse($data);
+    }
+
+    /**
+     * The model for the batch URL — taken from the first line (Google applies
+     * one model to the whole batch).
+     */
+    private function modelFor(BatchRequest $batch): string
+    {
+        $first = $batch->lines[0] ?? null;
+
+        return $first !== null && $first->request instanceof TextRequest ? $first->request->model : '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetch(string $batchId): array
+    {
+        return $this->http->get(
+            "{$this->config->baseUrl}/v1beta/{$batchId}",
+            $this->headers(),
+            $this->config->timeout,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function toResponse(array $data): BatchResponse
+    {
+        $state = is_array($data['metadata'] ?? null) ? (string) ($data['metadata']['state'] ?? '') : '';
+        /** @var array<int, mixed> $inlined */
+        $inlined = $data['response']['inlinedResponses']['inlinedResponses'] ?? [];
+        $succeeded = 0;
+        $failed = 0;
+        foreach ($inlined as $entry) {
+            is_array($entry) && isset($entry['error']) ? $failed++ : $succeeded++;
+        }
+
+        return new BatchResponse(
+            batchId: (string) ($data['name'] ?? ''),
+            status: $this->mapStatus($state),
+            counts: new RequestCounts(total: count($inlined), succeeded: $succeeded, failed: $failed),
+            error: is_array($data['error'] ?? null) ? (string) ($data['error']['message'] ?? '') : null,
+        );
+    }
+
+    /**
+     * Map Gemini's job state to the normalized enum. Matches by suffix so it
+     * tolerates both `JOB_STATE_*` (operation metadata) and `BATCH_STATE_*`
+     * (resource) spellings the API inconsistently returns.
+     */
+    private function mapStatus(string $state): BatchStatus
+    {
+        return match (true) {
+            str_ends_with($state, 'SUCCEEDED') => BatchStatus::Completed,
+            str_ends_with($state, 'FAILED') => BatchStatus::Failed,
+            str_ends_with($state, 'CANCELLED') => BatchStatus::Cancelled,
+            str_ends_with($state, 'EXPIRED') => BatchStatus::Expired,
+            str_ends_with($state, 'PENDING') => BatchStatus::Validating,
+            default => BatchStatus::InProgress,
+        };
+    }
+}

--- a/src/Providers/Google/Handlers/Batch.php
+++ b/src/Providers/Google/Handlers/Batch.php
@@ -160,16 +160,32 @@ class Batch implements BatchHandler
      * Map Gemini's job state to the normalized enum. Matches by suffix so it
      * tolerates both `JOB_STATE_*` (operation metadata) and `BATCH_STATE_*`
      * (resource) spellings the API inconsistently returns.
+     *
+     * Written as explicit `if` returns rather than `match (true)` so coverage
+     * tools attribute each branch cleanly.
      */
     private function mapStatus(string $state): BatchStatus
     {
-        return match (true) {
-            str_ends_with($state, 'SUCCEEDED') => BatchStatus::Completed,
-            str_ends_with($state, 'FAILED') => BatchStatus::Failed,
-            str_ends_with($state, 'CANCELLED') => BatchStatus::Cancelled,
-            str_ends_with($state, 'EXPIRED') => BatchStatus::Expired,
-            str_ends_with($state, 'PENDING') => BatchStatus::Validating,
-            default => BatchStatus::InProgress,
-        };
+        if (str_ends_with($state, 'SUCCEEDED')) {
+            return BatchStatus::Completed;
+        }
+
+        if (str_ends_with($state, 'FAILED')) {
+            return BatchStatus::Failed;
+        }
+
+        if (str_ends_with($state, 'CANCELLED')) {
+            return BatchStatus::Cancelled;
+        }
+
+        if (str_ends_with($state, 'EXPIRED')) {
+            return BatchStatus::Expired;
+        }
+
+        if (str_ends_with($state, 'PENDING')) {
+            return BatchStatus::Validating;
+        }
+
+        return BatchStatus::InProgress;
     }
 }

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -58,6 +58,18 @@ class Text implements TextHandler
         return $this->parser->parseText($data);
     }
 
+    /**
+     * Parse a generateContent payload into a TextResponse.
+     *
+     * Public so the batch handler parses a batch line's result identically.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function parse(array $data): TextResponse
+    {
+        return $this->parser->parseText($data);
+    }
+
     public function stream(TextRequest $request): StreamResponse
     {
         $raw = $this->http->stream(
@@ -139,9 +151,12 @@ class Text implements TextHandler
     /**
      * Build the Gemini request body.
      *
+     * Public so the batch handler serializes a batch line identically to a
+     * synchronous call.
+     *
      * @return array<string, mixed>
      */
-    protected function buildBody(TextRequest $request): array
+    public function buildBody(TextRequest $request): array
     {
         $messageData = $this->messages->buildAll($request, $this->media);
 

--- a/src/Providers/Handlers/BatchHandler.php
+++ b/src/Providers/Handlers/BatchHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\Handlers;
+
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+
+/**
+ * Handler for submitting and managing provider batch jobs.
+ *
+ * Submission serializes each line using the provider's existing modality
+ * payload builder; result retrieval parses each line using the provider's
+ * existing response parser. Implementations own only the provider's batch
+ * transport (file upload vs inline, status mapping, result streaming).
+ */
+interface BatchHandler
+{
+    /**
+     * Submit a batch job and return its initial state.
+     */
+    public function submit(Batch $batch): BatchResponse;
+
+    /**
+     * Fetch the current state of a previously submitted batch.
+     */
+    public function status(string $batchId): BatchResponse;
+
+    /**
+     * Stream the per-line results of a completed batch.
+     *
+     * Implementations MUST perform the underlying fetch eagerly (so transport
+     * failures surface to the driver's exception translation) and yield parsed
+     * results. Per-line errors are captured on {@see BatchResult::$error}, not
+     * thrown.
+     *
+     * @return iterable<int, BatchResult>
+     */
+    public function results(string $batchId): iterable;
+
+    /**
+     * Request cancellation of an in-flight batch.
+     */
+    public function cancel(string $batchId): BatchResponse;
+}

--- a/src/Providers/Jina/JinaDriver.php
+++ b/src/Providers/Jina/JinaDriver.php
@@ -21,7 +21,7 @@ class JinaDriver extends Driver
     public function capabilities(): ProviderCapabilities
     {
         return ProviderCapabilities::withOverrides(
-            new ProviderCapabilities(rerank: true),
+            new ProviderCapabilities(rerank: true, batch: false),
             $this->config->capabilityOverrides,
         );
     }

--- a/src/Providers/OpenAi/Handlers/Batch.php
+++ b/src/Providers/OpenAi/Handlers/Batch.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Providers\OpenAi\Handlers;
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Http\ProviderRequestContext;
+use Atlasphp\Atlas\Providers\Concerns\BuildsHeaders;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
+use Atlasphp\Atlas\Providers\OpenAi\Concerns\HasOrganizationHeader;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch as BatchRequest;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
+
+/**
+ * OpenAI batch handler using the /v1/batches endpoint.
+ *
+ * Serializes each line into JSONL via the synchronous handlers' own payload
+ * builders (so a batch line is byte-identical to a live request), uploads it
+ * through the Files API, and submits the batch. Results are parsed back through
+ * those same handlers' parsers.
+ */
+class Batch implements BatchHandler
+{
+    use BuildsHeaders, HasOrganizationHeader {
+        HasOrganizationHeader::extraHeaders insteadof BuildsHeaders;
+    }
+
+    /** Maps a batchable modality to its synchronous endpoint path. */
+    private const ENDPOINTS = [
+        'text' => '/v1/responses',
+        'embed' => '/v1/embeddings',
+    ];
+
+    public function __construct(
+        protected readonly ProviderConfig $config,
+        protected readonly HttpClient $http,
+        protected readonly Text $text,
+        protected readonly Embed $embed,
+    ) {}
+
+    public function submit(BatchRequest $batch): BatchResponse
+    {
+        $fileId = $this->uploadInputFile($this->serialize($batch));
+
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/batches",
+            headers: $this->headers(),
+            body: [
+                'input_file_id' => $fileId,
+                'endpoint' => self::ENDPOINTS[$batch->modality->value],
+                'completion_window' => $batch->completionWindow,
+            ],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        return $this->toResponse($data);
+    }
+
+    public function status(string $batchId): BatchResponse
+    {
+        return $this->toResponse($this->fetch($batchId));
+    }
+
+    public function results(string $batchId): iterable
+    {
+        $batch = $this->fetch($batchId);
+        $outputFileId = $batch['output_file_id'] ?? null;
+
+        if (! is_string($outputFileId) || $outputFileId === '') {
+            return [];
+        }
+
+        $modality = $this->modalityFromEndpoint((string) ($batch['endpoint'] ?? ''));
+        $body = $this->http->getRaw(
+            "{$this->config->baseUrl}/files/{$outputFileId}/content",
+            $this->headers(),
+            $this->config->timeout,
+        );
+
+        return $this->parseResults($body, $modality);
+    }
+
+    public function cancel(string $batchId): BatchResponse
+    {
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/batches/{$batchId}/cancel",
+            headers: $this->headers(),
+            body: [],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        return $this->toResponse($data);
+    }
+
+    /**
+     * Build the JSONL payload, one line per request.
+     */
+    private function serialize(BatchRequest $batch): string
+    {
+        $url = self::ENDPOINTS[$batch->modality->value];
+
+        $lines = array_map(function ($line) use ($batch, $url): string {
+            return json_encode([
+                'custom_id' => $line->customId,
+                'method' => 'POST',
+                'url' => $url,
+                'body' => $this->bodyFor($batch->modality, $line->request),
+            ], JSON_THROW_ON_ERROR);
+        }, $batch->lines);
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Build a line body by delegating to the synchronous handler's builder.
+     *
+     * @return array<string, mixed>
+     */
+    private function bodyFor(Modality $modality, object $request): array
+    {
+        if ($modality === Modality::Embed && $request instanceof EmbedRequest) {
+            return $this->embed->buildBody($request);
+        }
+
+        if ($modality === Modality::Text && $request instanceof TextRequest) {
+            return $this->text->buildPayload($request);
+        }
+
+        throw BatchException::mixedModality($modality->value, $request::class);
+    }
+
+    /**
+     * Upload the JSONL as a batch input file and return its id.
+     */
+    private function uploadInputFile(string $jsonl): string
+    {
+        $data = $this->http->postMultipart(
+            url: "{$this->config->baseUrl}/files",
+            headers: $this->headersWithoutContentType(),
+            data: ['purpose' => 'batch'],
+            attachments: [[
+                'name' => 'file',
+                'contents' => $jsonl,
+                'filename' => 'batch.jsonl',
+            ]],
+            timeout: $this->config->timeout,
+            context: new ProviderRequestContext($this->config->provider, 'batch'),
+        );
+
+        $id = (string) ($data['id'] ?? '');
+
+        if ($id === '') {
+            throw new BatchException('Batch input-file upload returned no file id; cannot submit the batch.');
+        }
+
+        return $id;
+    }
+
+    /**
+     * Fetch the raw batch object.
+     *
+     * @return array<string, mixed>
+     */
+    private function fetch(string $batchId): array
+    {
+        return $this->http->get(
+            "{$this->config->baseUrl}/batches/{$batchId}",
+            $this->headers(),
+            $this->config->timeout,
+        );
+    }
+
+    /**
+     * Parse the downloaded output JSONL into per-line results.
+     *
+     * @return iterable<int, BatchResult>
+     */
+    private function parseResults(string $body, Modality $modality): iterable
+    {
+        $results = [];
+
+        foreach (explode("\n", trim($body)) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            /** @var array<string, mixed> $row */
+            $row = json_decode($line, true) ?: [];
+            $customId = (string) ($row['custom_id'] ?? '');
+
+            if (! empty($row['error'])) {
+                $message = is_array($row['error']) ? (string) ($row['error']['message'] ?? 'batch line failed') : (string) $row['error'];
+                $results[] = new BatchResult($customId, BatchResultStatus::Errored, error: new BatchException($message));
+
+                continue;
+            }
+
+            /** @var array<string, mixed> $response */
+            $response = is_array($row['response'] ?? null) ? $row['response'] : [];
+            /** @var array<string, mixed> $payload */
+            $payload = is_array($response['body'] ?? null) ? $response['body'] : [];
+
+            // A line can carry error: null yet a non-2xx HTTP status with an
+            // error body — treat that as a failed line, not a parsed success.
+            $statusCode = (int) ($response['status_code'] ?? 200);
+            if ($statusCode >= 400) {
+                $message = is_array($payload['error'] ?? null) ? (string) ($payload['error']['message'] ?? "HTTP {$statusCode}") : "HTTP {$statusCode}";
+                $results[] = new BatchResult($customId, BatchResultStatus::Errored, error: new BatchException($message));
+
+                continue;
+            }
+
+            $parsed = $modality === Modality::Embed
+                ? $this->embed->parse($payload)
+                : $this->text->parse($payload);
+
+            $results[] = new BatchResult($customId, BatchResultStatus::Succeeded, response: $parsed, usage: $parsed->usage);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Map a raw batch object to a BatchResponse.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function toResponse(array $data): BatchResponse
+    {
+        /** @var array<string, mixed> $counts */
+        $counts = is_array($data['request_counts'] ?? null) ? $data['request_counts'] : [];
+        $total = (int) ($counts['total'] ?? 0);
+        $succeeded = (int) ($counts['completed'] ?? 0);
+        $failed = (int) ($counts['failed'] ?? 0);
+
+        return new BatchResponse(
+            batchId: (string) ($data['id'] ?? ''),
+            status: $this->mapStatus((string) ($data['status'] ?? '')),
+            counts: new RequestCounts(
+                total: $total,
+                succeeded: $succeeded,
+                failed: $failed,
+                processing: max(0, $total - $succeeded - $failed),
+            ),
+            inputFileId: isset($data['input_file_id']) ? (string) $data['input_file_id'] : null,
+            outputFileId: isset($data['output_file_id']) ? (string) $data['output_file_id'] : null,
+            error: $this->extractError($data),
+        );
+    }
+
+    /**
+     * Pull the first job-level error message from a batch object, if any.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function extractError(array $data): ?string
+    {
+        $errors = is_array($data['errors'] ?? null) ? $data['errors'] : [];
+        $first = is_array($errors['data'][0] ?? null) ? $errors['data'][0] : null;
+
+        return $first !== null && isset($first['message']) ? (string) $first['message'] : null;
+    }
+
+    /**
+     * Map OpenAI's batch status vocabulary to the normalized enum.
+     */
+    private function mapStatus(string $status): BatchStatus
+    {
+        return match ($status) {
+            'validating' => BatchStatus::Validating,
+            'in_progress' => BatchStatus::InProgress,
+            'finalizing' => BatchStatus::Finalizing,
+            'completed' => BatchStatus::Completed,
+            'failed' => BatchStatus::Failed,
+            'expired' => BatchStatus::Expired,
+            'cancelling' => BatchStatus::Cancelling,
+            'cancelled' => BatchStatus::Cancelled,
+            default => BatchStatus::InProgress,
+        };
+    }
+
+    private function modalityFromEndpoint(string $endpoint): Modality
+    {
+        return str_contains($endpoint, 'embeddings') ? Modality::Embed : Modality::Text;
+    }
+}

--- a/src/Providers/OpenAi/Handlers/Batch.php
+++ b/src/Providers/OpenAi/Handlers/Batch.php
@@ -222,6 +222,14 @@ class Batch implements BatchHandler
                 continue;
             }
 
+            if ($payload === []) {
+                // 2xx but no body — a truncated/malformed line. Don't feed an
+                // empty payload to the parser; record it as a failed line.
+                $results[] = new BatchResult($customId, BatchResultStatus::Errored, error: new BatchException('empty response body'));
+
+                continue;
+            }
+
             $parsed = $modality === Modality::Embed
                 ? $this->embed->parse($payload)
                 : $this->text->parse($payload);

--- a/src/Providers/OpenAi/Handlers/Embed.php
+++ b/src/Providers/OpenAi/Handlers/Embed.php
@@ -31,6 +31,28 @@ class Embed implements EmbedHandler
 
     public function embed(EmbedRequest $request): EmbeddingsResponse
     {
+        $data = $this->http->post(
+            url: "{$this->config->baseUrl}/embeddings",
+            headers: $this->headers(),
+            body: $this->buildBody($request),
+            timeout: $this->config->timeout,
+            config: $request->requestConfig,
+            context: new ProviderRequestContext($this->config->provider, $request->model),
+        );
+
+        return $this->parse($data);
+    }
+
+    /**
+     * Build the /embeddings request body.
+     *
+     * Public so the batch handler serializes a batch line identically to a
+     * synchronous call.
+     *
+     * @return array<string, mixed>
+     */
+    public function buildBody(EmbedRequest $request): array
+    {
         $body = [
             'model' => $request->model,
             'input' => $request->input,
@@ -47,17 +69,18 @@ class Embed implements EmbedHandler
             $body['dimensions'] = app(AtlasConfig::class)->embeddingDimensions;
         }
 
-        $body = array_merge($body, $request->providerOptions);
+        return array_merge($body, $request->providerOptions);
+    }
 
-        $data = $this->http->post(
-            url: "{$this->config->baseUrl}/embeddings",
-            headers: $this->headers(),
-            body: $body,
-            timeout: $this->config->timeout,
-            config: $request->requestConfig,
-            context: new ProviderRequestContext($this->config->provider, $request->model),
-        );
-
+    /**
+     * Parse an /embeddings response into an EmbeddingsResponse.
+     *
+     * Public so the batch handler parses a batch line's result identically.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function parse(array $data): EmbeddingsResponse
+    {
         /** @var array<int, array<string, mixed>> $items */
         $items = $data['data'] ?? [];
 

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -64,6 +64,19 @@ class Text implements TextHandler
         return $this->parser->parseText($data);
     }
 
+    /**
+     * Parse a Responses API payload into a TextResponse.
+     *
+     * Public so the batch handler parses a batch line's result identically to a
+     * synchronous call.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function parse(array $data): TextResponse
+    {
+        return $this->parser->parseText($data);
+    }
+
     public function stream(TextRequest $request): StreamResponse
     {
         $body = $this->buildPayload($request);
@@ -162,9 +175,12 @@ class Text implements TextHandler
     /**
      * Build the Responses API request payload.
      *
+     * Public so the batch handler can serialize a batch line's body identically
+     * to a synchronous call — the two paths must never produce divergent bodies.
+     *
      * @return array<string, mixed>
      */
-    protected function buildPayload(TextRequest $request): array
+    public function buildPayload(TextRequest $request): array
     {
         $messageData = $this->messages->buildAll($request, $this->media);
 

--- a/src/Providers/OpenAi/OpenAiDriver.php
+++ b/src/Providers/OpenAi/OpenAiDriver.php
@@ -6,6 +6,7 @@ namespace Atlasphp\Atlas\Providers\OpenAi;
 
 use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Providers\Handlers\AudioHandler;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
 use Atlasphp\Atlas\Providers\Handlers\EmbedHandler;
 use Atlasphp\Atlas\Providers\Handlers\ImageHandler;
 use Atlasphp\Atlas\Providers\Handlers\ModerateHandler;
@@ -14,6 +15,7 @@ use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\Handlers\VideoHandler;
 use Atlasphp\Atlas\Providers\Handlers\VoiceHandler;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Audio;
+use Atlasphp\Atlas\Providers\OpenAi\Handlers\Batch;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Embed;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Image;
 use Atlasphp\Atlas\Providers\OpenAi\Handlers\Moderate;
@@ -58,6 +60,8 @@ class OpenAiDriver extends Driver
                 providerTools: true,
                 models: true,
                 voices: true,
+                batch: true,
+                batchModalities: ['text', 'embed'],
             ),
             $this->config->capabilityOverrides,
         );
@@ -69,6 +73,14 @@ class OpenAiDriver extends Driver
     }
 
     protected function textHandler(): TextHandler
+    {
+        return $this->buildTextHandler();
+    }
+
+    /**
+     * Construct the OpenAI text handler, shared by the text and batch handlers.
+     */
+    private function buildTextHandler(): Text
     {
         $toolMapper = new ToolMapper;
 
@@ -100,6 +112,27 @@ class OpenAiDriver extends Driver
     protected function embedHandler(): EmbedHandler
     {
         return new Embed($this->config, $this->http);
+    }
+
+    protected function batchHandler(): BatchHandler
+    {
+        $toolMapper = new ToolMapper;
+
+        $text = new Text(
+            config: $this->config,
+            http: $this->http,
+            messages: new MessageFactory,
+            media: new MediaResolver,
+            toolMapper: $toolMapper,
+            parser: new ResponseParser($toolMapper),
+        );
+
+        return new Batch(
+            config: $this->config,
+            http: $this->http,
+            text: $text,
+            embed: new Embed($this->config, $this->http),
+        );
     }
 
     protected function moderateHandler(): ModerateHandler

--- a/src/Providers/OpenAi/OpenAiDriver.php
+++ b/src/Providers/OpenAi/OpenAiDriver.php
@@ -116,21 +116,10 @@ class OpenAiDriver extends Driver
 
     protected function batchHandler(): BatchHandler
     {
-        $toolMapper = new ToolMapper;
-
-        $text = new Text(
-            config: $this->config,
-            http: $this->http,
-            messages: new MessageFactory,
-            media: new MediaResolver,
-            toolMapper: $toolMapper,
-            parser: new ResponseParser($toolMapper),
-        );
-
         return new Batch(
             config: $this->config,
             http: $this->http,
-            text: $text,
+            text: $this->buildTextHandler(),
             embed: new Embed($this->config, $this->http),
         );
     }

--- a/src/Providers/ProviderCapabilities.php
+++ b/src/Providers/ProviderCapabilities.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers;
 
+use Atlasphp\Atlas\Enums\Modality;
+
 /**
  * Declares what features a provider supports.
  */
 class ProviderCapabilities
 {
+    /**
+     * @param  array<int, string>  $batchModalities  Modality values (see {@see Modality})
+     *                                               this provider can submit as deferred batch jobs.
+     */
     public function __construct(
         public readonly bool $text = false,
         public readonly bool $stream = false,
@@ -29,6 +35,8 @@ class ProviderCapabilities
         public readonly bool $models = false,
         public readonly bool $voice = false,
         public readonly bool $voices = false,
+        public readonly bool $batch = false,
+        public readonly array $batchModalities = [],
     ) {}
 
     /**
@@ -36,7 +44,20 @@ class ProviderCapabilities
      */
     public function supports(string $feature): bool
     {
-        return property_exists($this, $feature) && $this->{$feature};
+        return property_exists($this, $feature) && $this->{$feature} === true;
+    }
+
+    /**
+     * Whether this provider can batch the given modality.
+     *
+     * Requires both the batch capability and the modality being in the
+     * provider's batchable allow-list.
+     */
+    public function canBatch(Modality|string $modality): bool
+    {
+        $value = $modality instanceof Modality ? $modality->value : $modality;
+
+        return $this->batch && in_array($value, $this->batchModalities, true);
     }
 
     /**

--- a/src/Providers/Xai/Handlers/Text.php
+++ b/src/Providers/Xai/Handlers/Text.php
@@ -32,7 +32,7 @@ class Text extends OpenAiText
     /**
      * @return array<string, mixed>
      */
-    protected function buildPayload(TextRequest $request): array
+    public function buildPayload(TextRequest $request): array
     {
         $body = parent::buildPayload($request);
 

--- a/src/Providers/Xai/XaiDriver.php
+++ b/src/Providers/Xai/XaiDriver.php
@@ -58,6 +58,7 @@ class XaiDriver extends Driver
                 providerTools: true,
                 models: true,
                 voices: true,
+                batch: false,
             ),
             $this->config->capabilityOverrides,
         );

--- a/src/Requests/Batch.php
+++ b/src/Requests/Batch.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Requests;
+
+use Atlasphp\Atlas\Enums\Modality;
+
+/**
+ * Immutable request object for submitting a batch job.
+ *
+ * A batch targets a single provider and a single modality (provider batch
+ * endpoints accept one endpoint/method per job); models may still vary per
+ * line. Each line is an independent request serialized into the provider's
+ * batch payload by the provider's batch handler.
+ */
+final class Batch
+{
+    /**
+     * @param  array<int, BatchLine>  $lines
+     */
+    public function __construct(
+        public readonly string $provider,
+        public readonly Modality $modality,
+        public readonly array $lines,
+        public readonly string $completionWindow = '24h',
+    ) {}
+
+    /**
+     * Number of request lines in the batch.
+     */
+    public function count(): int
+    {
+        return count($this->lines);
+    }
+}

--- a/src/Requests/BatchLine.php
+++ b/src/Requests/BatchLine.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Requests;
+
+/**
+ * A single request within a batch job.
+ *
+ * Pairs a consumer-supplied key with the immutable modality request DTO it
+ * wraps (a {@see TextRequest}, {@see EmbedRequest}, etc.). The key is echoed
+ * back by the provider on the matching result, so consumers trace each result
+ * to their own record regardless of completion order.
+ */
+final class BatchLine
+{
+    public function __construct(
+        public readonly string $customId,
+        public readonly object $request,
+    ) {}
+}

--- a/src/Responses/BatchResponse.php
+++ b/src/Responses/BatchResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Responses;
+
+use Atlasphp\Atlas\Enums\BatchStatus;
+
+/**
+ * The state of a batch job as reported by the provider.
+ *
+ * Returned by submission and status polling. Carries the provider batch id
+ * (the handle for all follow-up calls), the normalized status, and aggregate
+ * counts. Per-line results are fetched separately as {@see BatchResult} via the
+ * handler's results() method. Usage is the rolled-up token total, available
+ * once the job has produced results.
+ */
+final class BatchResponse
+{
+    public function __construct(
+        public readonly string $batchId,
+        public readonly BatchStatus $status,
+        public readonly RequestCounts $counts,
+        public readonly ?string $inputFileId = null,
+        public readonly ?string $outputFileId = null,
+        public readonly ?Usage $usage = null,
+        public readonly ?string $error = null,
+    ) {}
+
+    // isTerminal()/isSuccessful() deliberately forward to the status enum so a
+    // consumer holding a BatchResponse can ask the common questions directly
+    // (e.g. `$response->isTerminal()`) without reaching through `->status`.
+
+    /**
+     * Whether the job has reached a state that will not change further.
+     */
+    public function isTerminal(): bool
+    {
+        return $this->status->isTerminal();
+    }
+
+    /**
+     * Whether the job finished successfully and its results can be ingested.
+     */
+    public function isSuccessful(): bool
+    {
+        return $this->status->isSuccessful();
+    }
+}

--- a/src/Responses/BatchResult.php
+++ b/src/Responses/BatchResult.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Responses;
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Throwable;
+
+/**
+ * The outcome of a single request line within a batch job.
+ *
+ * On success, {@see $response} holds the parsed modality response
+ * (a {@see TextResponse}, {@see EmbeddingsResponse}, etc.) produced by the
+ * provider's normal response parser. On failure, {@see $error} holds the
+ * mapped exception. {@see $customId} is the consumer key for trace-back.
+ */
+final class BatchResult
+{
+    public function __construct(
+        public readonly string $customId,
+        public readonly BatchResultStatus $status,
+        public readonly ?object $response = null,
+        public readonly ?Throwable $error = null,
+        public readonly ?Usage $usage = null,
+    ) {}
+
+    /**
+     * Whether this line produced a usable response.
+     */
+    public function succeeded(): bool
+    {
+        return $this->status->isSuccessful();
+    }
+}

--- a/src/Responses/RequestCounts.php
+++ b/src/Responses/RequestCounts.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlasphp\Atlas\Responses;
+
+/**
+ * Aggregate per-line counts for a batch job.
+ */
+final class RequestCounts
+{
+    public function __construct(
+        public readonly int $total = 0,
+        public readonly int $succeeded = 0,
+        public readonly int $failed = 0,
+        public readonly int $processing = 0,
+    ) {}
+
+    /**
+     * Convert to an array for JSON persistence.
+     *
+     * @return array<string, int>
+     */
+    public function toArray(): array
+    {
+        return [
+            'total' => $this->total,
+            'succeeded' => $this->succeeded,
+            'failed' => $this->failed,
+            'processing' => $this->processing,
+        ];
+    }
+
+    /**
+     * Create from a persisted array.
+     *
+     * @param  array<string, int>|null  $data
+     */
+    public static function fromArray(?array $data): self
+    {
+        if ($data === null) {
+            return new self;
+        }
+
+        return new self(
+            total: $data['total'] ?? 0,
+            succeeded: $data['succeeded'] ?? 0,
+            failed: $data['failed'] ?? 0,
+            processing: $data['processing'] ?? 0,
+        );
+    }
+}

--- a/tests/Feature/Console/BatchCommandsDisabledTest.php
+++ b/tests/Feature/Console/BatchCommandsDisabledTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\AtlasConfig;
+
+// These run under the default TestCase, where persistence is disabled — so the
+// batch commands must no-op gracefully rather than touch a non-existent table.
+
+beforeEach(function () {
+    expect(app(AtlasConfig::class)->persistenceEnabled)->toBeFalse();
+});
+
+it('batch-poll is a no-op when persistence is disabled', function () {
+    $this->artisan('atlas:batch-poll')
+        ->expectsOutputToContain('Persistence is not enabled')
+        ->assertSuccessful();
+});
+
+it('batch-prune is a no-op when persistence is disabled', function () {
+    $this->artisan('atlas:batch-prune')
+        ->expectsOutputToContain('Persistence is not enabled')
+        ->assertSuccessful();
+});

--- a/tests/Feature/Persistence/BatchManagerTest.php
+++ b/tests/Feature/Persistence/BatchManagerTest.php
@@ -25,6 +25,14 @@ it('BatchJob results() returns the job\'s result rows', function () {
     expect($job->results->pluck('custom_id')->sort()->values()->all())->toBe(['rec-1', 'rec-2']);
 });
 
+it('BatchResult batchJob() returns its parent job', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::Completed]);
+    $result = BatchResult::create(['batch_job_id' => $job->id, 'custom_id' => 'a', 'status' => BatchResultStatus::Succeeded]);
+
+    expect($result->batchJob)->not->toBeNull();
+    expect($result->batchJob->id)->toBe($job->id);
+});
+
 it('BatchJob scopeForProvider filters by provider', function () {
     $openai = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'a', 'status' => BatchStatus::Completed]);
     BatchJob::create(['provider' => 'anthropic', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::Completed]);

--- a/tests/Feature/Persistence/BatchManagerTest.php
+++ b/tests/Feature/Persistence/BatchManagerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+
+it('Atlas::batchGroup() creates a persisted group when persistence is enabled', function () {
+    $group = Atlas::batchGroup('my-run');
+
+    expect($group)->toBeInstanceOf(BatchGroup::class);
+    expect(BatchGroup::find($group->id)?->label)->toBe('my-run');
+});
+
+it('BatchJob results() returns the job\'s result rows', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::Completed]);
+    BatchResult::create(['batch_job_id' => $job->id, 'custom_id' => 'rec-1', 'status' => BatchResultStatus::Succeeded]);
+    BatchResult::create(['batch_job_id' => $job->id, 'custom_id' => 'rec-2', 'status' => BatchResultStatus::Errored]);
+
+    expect($job->results)->toHaveCount(2);
+    expect($job->results->pluck('custom_id')->sort()->values()->all())->toBe(['rec-1', 'rec-2']);
+});
+
+it('BatchJob scopeForProvider filters by provider', function () {
+    $openai = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'a', 'status' => BatchStatus::Completed]);
+    BatchJob::create(['provider' => 'anthropic', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::Completed]);
+
+    $ids = BatchJob::query()->forProvider('openai')->pluck('id')->all();
+
+    expect($ids)->toBe([$openai->id]);
+});

--- a/tests/Feature/Persistence/BatchManagerTest.php
+++ b/tests/Feature/Persistence/BatchManagerTest.php
@@ -8,6 +8,7 @@ use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Persistence\Models\BatchGroup;
 use Atlasphp\Atlas\Persistence\Models\BatchJob;
 use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
 
 it('Atlas::batchGroup() creates a persisted group when persistence is enabled', function () {
     $group = Atlas::batchGroup('my-run');
@@ -23,6 +24,19 @@ it('BatchJob results() returns the job\'s result rows', function () {
 
     expect($job->results)->toHaveCount(2);
     expect($job->results->pluck('custom_id')->sort()->values()->all())->toBe(['rec-1', 'rec-2']);
+});
+
+it('BatchJob applyStatus updates the status and counts columns', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::Validating]);
+
+    $job->applyStatus(BatchStatus::InProgress, new RequestCounts(total: 5, succeeded: 2, failed: 1, processing: 2));
+
+    $fresh = $job->fresh();
+    expect($fresh->status)->toBe(BatchStatus::InProgress);
+    expect($fresh->total)->toBe(5);
+    expect($fresh->succeeded)->toBe(2);
+    expect($fresh->failed)->toBe(1);
+    expect($fresh->processing)->toBe(2);
 });
 
 it('BatchResult batchJob() returns its parent job', function () {

--- a/tests/Feature/Persistence/BatchManagerTest.php
+++ b/tests/Feature/Persistence/BatchManagerTest.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\Enums\BatchResultStatus;
 use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Pending\BatchRequest;
 use Atlasphp\Atlas\Persistence\Models\BatchGroup;
 use Atlasphp\Atlas\Persistence\Models\BatchJob;
 use Atlasphp\Atlas\Persistence\Models\BatchResult;
 use Atlasphp\Atlas\Responses\RequestCounts;
+
+it('Atlas::batch() resolves the batch service when persistence is enabled', function () {
+    // Hits the persistence-on branch of AtlasManager::batch() that resolves BatchService.
+    expect(Atlas::batch('openai'))->toBeInstanceOf(BatchRequest::class);
+});
 
 it('Atlas::batchGroup() creates a persisted group when persistence is enabled', function () {
     $group = Atlas::batchGroup('my-run');

--- a/tests/Feature/Persistence/BatchPersistenceTest.php
+++ b/tests/Feature/Persistence/BatchPersistenceTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\AtlasConfig;
+use Atlasphp\Atlas\Batch\BatchService;
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Events\BatchCompleted;
+use Atlasphp\Atlas\Events\BatchFailed;
+use Atlasphp\Atlas\Events\BatchGroupCompleted;
+use Atlasphp\Atlas\Events\BatchSubmitted;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
+use Atlasphp\Atlas\Persistence\Models\BatchResult;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult as BatchResultData;
+use Atlasphp\Atlas\Responses\EmbeddingsResponse;
+use Atlasphp\Atlas\Responses\RequestCounts;
+use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\Usage;
+use Illuminate\Contracts\Events\Dispatcher;
+
+function batchService(ProviderRegistryContract $registry): BatchService
+{
+    return new BatchService($registry, app(Dispatcher::class), app(AtlasConfig::class));
+}
+
+function embedBatchRequest(): Batch
+{
+    return new Batch('openai', Modality::Embed, [
+        new BatchLine('a', new EmbedRequest('text-embedding-3-small', 'one')),
+    ]);
+}
+
+it('submits and persists a tracked batch job', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batch')->once()
+        ->andReturn(new BatchResponse('batch_1', BatchStatus::Validating, new RequestCounts(total: 1, processing: 1), inputFileId: 'file_in'));
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->with('openai')->andReturn($driver);
+
+    $job = batchService($registry)->submitAndTrack(embedBatchRequest());
+
+    expect($job)->toBeInstanceOf(BatchJob::class);
+    expect($job->batch_id)->toBe('batch_1');
+    expect($job->provider)->toBe('openai');
+    expect($job->modality)->toBe('embed');
+    expect($job->status)->toBe(BatchStatus::Validating);
+    expect($job->total)->toBe(1);
+    expect($job->input_file_id)->toBe('file_in');
+    expect($job->submitted_at)->not->toBeNull();
+});
+
+it('hydrates results, rolls up usage, and fires BatchCompleted on sync', function () {
+    Event::fake([BatchCompleted::class]);
+
+    $job = BatchJob::create([
+        'provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'batch_1', 'status' => BatchStatus::InProgress,
+    ]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->once()->with('batch_1')
+        ->andReturn(new BatchResponse('batch_1', BatchStatus::Completed, new RequestCounts(total: 2, succeeded: 2)));
+    $driver->shouldReceive('batchResults')->once()->with('batch_1')->andReturn([
+        new BatchResultData('a', BatchResultStatus::Succeeded, response: new EmbeddingsResponse([[0.1]], new Usage(3, 0)), usage: new Usage(3, 0)),
+        new BatchResultData('b', BatchResultStatus::Succeeded, response: new EmbeddingsResponse([[0.2]], new Usage(4, 0)), usage: new Usage(4, 0)),
+    ]);
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->with('openai')->andReturn($driver);
+
+    $synced = batchService($registry)->syncFromProvider($job);
+
+    expect($synced->status)->toBe(BatchStatus::Completed);
+    expect($synced->completed_at)->not->toBeNull();
+    expect($synced->usage)->toBe(['input_tokens' => 7, 'output_tokens' => 0]);
+
+    $results = BatchResult::where('batch_job_id', $job->id)->orderBy('custom_id')->get();
+    expect($results)->toHaveCount(2);
+    expect($results[0]->custom_id)->toBe('a');
+    expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
+    expect($results[0]->response)->toBe(['embedding' => [0.1]]);
+
+    Event::assertDispatched(BatchCompleted::class);
+});
+
+it('stores text responses with finish reason', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::InProgress]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Completed, new RequestCounts(total: 1, succeeded: 1)));
+    $driver->shouldReceive('batchResults')->andReturn([
+        new BatchResultData('img-1', BatchResultStatus::Succeeded, response: new TextResponse('A dog.', new Usage(5, 2), FinishReason::Stop), usage: new Usage(5, 2)),
+    ]);
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+
+    batchService($registry)->syncFromProvider($job);
+
+    $result = BatchResult::where('batch_job_id', $job->id)->first();
+    expect($result->response)->toBe(['text' => 'A dog.', 'finish_reason' => 'stop']);
+});
+
+it('marks the job failed and fires BatchFailed on a terminal failure', function () {
+    Event::fake([BatchFailed::class]);
+
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'b', 'status' => BatchStatus::InProgress]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Expired, new RequestCounts(total: 1)));
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+
+    $synced = batchService($registry)->syncFromProvider($job);
+
+    expect($synced->status)->toBe(BatchStatus::Expired);
+    Event::assertDispatched(BatchFailed::class);
+});
+
+it('is idempotent — a terminal job is not re-synced', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'b', 'status' => BatchStatus::Completed]);
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldNotReceive('resolve');
+
+    expect(batchService($registry)->syncFromProvider($job)->status)->toBe(BatchStatus::Completed);
+});
+
+it('fires BatchGroupCompleted when the last job in a group completes', function () {
+    Event::fake([BatchGroupCompleted::class]);
+
+    $group = BatchGroup::create(['label' => 'captions']);
+    BatchJob::create(['batch_group_id' => $group->id, 'provider' => 'openai', 'modality' => 'text', 'batch_id' => 'done', 'status' => BatchStatus::Completed]);
+    $pending = BatchJob::create(['batch_group_id' => $group->id, 'provider' => 'openai', 'modality' => 'text', 'batch_id' => 'b2', 'status' => BatchStatus::InProgress]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b2', BatchStatus::Completed, new RequestCounts(total: 1, succeeded: 1)));
+    $driver->shouldReceive('batchResults')->andReturn([]);
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+
+    batchService($registry)->syncFromProvider($pending);
+
+    expect($group->fresh()->isComplete())->toBeTrue();
+    expect($group->progress()['completed_jobs'])->toBe(2);
+    Event::assertDispatched(BatchGroupCompleted::class);
+});
+
+it('the poll command advances open jobs and skips when none', function () {
+    // No open jobs → friendly no-op.
+    $this->artisan('atlas:batch-poll')->expectsOutputToContain('No open batch jobs')->assertSuccessful();
+
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'b', 'status' => BatchStatus::InProgress]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Completed, new RequestCounts(total: 1, succeeded: 1)));
+    $driver->shouldReceive('batchResults')->andReturn([]);
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+    app()->instance(ProviderRegistryContract::class, $registry);
+
+    $this->artisan('atlas:batch-poll')->expectsOutputToContain('Polled 1 batch job')->assertSuccessful();
+
+    expect($job->fresh()->status)->toBe(BatchStatus::Completed);
+});
+
+it('prunes batch jobs and their results older than the retention window', function () {
+    config()->set('atlas.batch.retention_days', 90);
+
+    $old = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'old', 'status' => BatchStatus::Completed]);
+    $old->forceFill(['created_at' => now()->subDays(120)])->save();
+    BatchResult::create(['batch_job_id' => $old->id, 'custom_id' => 'a', 'status' => BatchResultStatus::Succeeded]);
+
+    $recent = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'new', 'status' => BatchStatus::Completed]);
+    $recent->forceFill(['created_at' => now()->subDays(10)])->save();
+
+    $this->artisan('atlas:batch-prune')->expectsOutputToContain('Pruned 1 batch job')->assertSuccessful();
+
+    expect(BatchJob::find($old->id))->toBeNull();
+    expect(BatchJob::find($recent->id))->not->toBeNull();
+    expect(BatchResult::where('batch_job_id', $old->id)->count())->toBe(0);
+});
+
+it('honors a --days override when pruning', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'x', 'status' => BatchStatus::Completed]);
+    $job->forceFill(['created_at' => now()->subDays(20)])->save();
+
+    $this->artisan('atlas:batch-prune', ['--days' => 7])->assertSuccessful();
+
+    expect(BatchJob::find($job->id))->toBeNull();
+});
+
+it('BatchSubmitted fires on submit', function () {
+    Event::fake([BatchSubmitted::class]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batch')->andReturn(new BatchResponse('b', BatchStatus::Validating, new RequestCounts(total: 1)));
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+
+    batchService($registry)->submitAndTrack(embedBatchRequest());
+
+    Event::assertDispatched(BatchSubmitted::class);
+});

--- a/tests/Feature/Persistence/BatchPersistenceTest.php
+++ b/tests/Feature/Persistence/BatchPersistenceTest.php
@@ -128,6 +128,26 @@ it('marks the job failed and fires BatchFailed on a terminal failure', function 
     Event::assertDispatched(BatchFailed::class);
 });
 
+it('keeps a successful job open and preserves counts when results are not yet available', function () {
+    // Provider flips to success but inline results aren't ready yet (the Gemini
+    // race). The job must stay non-terminal, store no results, and NOT have its
+    // counts zeroed by the transient empty response.
+    $job = BatchJob::create(['provider' => 'google', 'modality' => 'text', 'batch_id' => 'b', 'status' => BatchStatus::InProgress, 'total' => 5, 'succeeded' => 0]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Completed, new RequestCounts(total: 0)));
+    $driver->shouldReceive('batchResults')->andReturn([]);
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+
+    $synced = batchService($registry)->syncFromProvider($job);
+
+    expect($synced->status)->toBe(BatchStatus::InProgress);
+    expect($synced->total)->toBe(5); // preserved, not overwritten with 0
+    expect(BatchResult::where('batch_job_id', $job->id)->count())->toBe(0);
+});
+
 it('is idempotent — a terminal job is not re-synced', function () {
     $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'b', 'status' => BatchStatus::Completed]);
 

--- a/tests/Feature/Persistence/BatchPersistenceTest.php
+++ b/tests/Feature/Persistence/BatchPersistenceTest.php
@@ -223,6 +223,69 @@ it('honors a --days override when pruning', function () {
     expect(BatchJob::find($job->id))->toBeNull();
 });
 
+it('updates counts and stays open on a non-terminal status', function () {
+    $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'b', 'status' => BatchStatus::Validating]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::InProgress, new RequestCounts(total: 3, processing: 3)));
+    // batchResults is NOT called for a non-successful status.
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->andReturn($driver);
+
+    $synced = batchService($registry)->syncFromProvider($job);
+
+    expect($synced->status)->toBe(BatchStatus::InProgress);
+    expect($synced->total)->toBe(3);
+    expect($synced->processing)->toBe(3);
+});
+
+it('the poll command filters by provider', function () {
+    BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'oa', 'status' => BatchStatus::InProgress]);
+    $anthropic = BatchJob::create(['provider' => 'anthropic', 'modality' => 'text', 'batch_id' => 'an', 'status' => BatchStatus::InProgress]);
+
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->once()->with('oa')->andReturn(new BatchResponse('oa', BatchStatus::InProgress, new RequestCounts(total: 1, processing: 1)));
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->with('openai')->andReturn($driver);
+    app()->instance(ProviderRegistryContract::class, $registry);
+
+    $this->artisan('atlas:batch-poll', ['--provider' => 'openai'])->expectsOutputToContain('Polled 1 batch job')->assertSuccessful();
+
+    expect($anthropic->fresh()->status)->toBe(BatchStatus::InProgress); // untouched
+});
+
+it('prune is a clean no-op when nothing is old enough', function () {
+    BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => 'recent', 'status' => BatchStatus::Completed]);
+
+    $this->artisan('atlas:batch-prune')->expectsOutputToContain('Pruned 0 batch job(s)')->assertSuccessful();
+
+    expect(BatchJob::count())->toBe(1);
+});
+
+it('prunes jobs, results and groups across multiple chunks', function () {
+    config()->set('atlas.batch.retention_days', 90);
+
+    foreach (['j1', 'j2'] as $bid) {
+        $job = BatchJob::create(['provider' => 'openai', 'modality' => 'text', 'batch_id' => $bid, 'status' => BatchStatus::Completed]);
+        $job->forceFill(['created_at' => now()->subDays(120)])->save();
+        BatchResult::create(['batch_job_id' => $job->id, 'custom_id' => 'a', 'status' => BatchResultStatus::Succeeded]);
+    }
+    foreach (['g1', 'g2'] as $label) {
+        BatchGroup::create(['label' => $label])->forceFill(['created_at' => now()->subDays(120)])->save();
+    }
+
+    // chunk=1 forces the do/while loops to iterate more than once for both jobs and groups.
+    $this->artisan('atlas:batch-prune', ['--chunk' => 1])
+        ->expectsOutputToContain('Pruned 2 batch job(s) and 2 empty group(s)')
+        ->assertSuccessful();
+
+    expect(BatchJob::count())->toBe(0);
+    expect(BatchResult::count())->toBe(0);
+    expect(BatchGroup::count())->toBe(0);
+});
+
 it('BatchSubmitted fires on submit', function () {
     Event::fake([BatchSubmitted::class]);
 

--- a/tests/Feature/Persistence/BatchPersistenceTest.php
+++ b/tests/Feature/Persistence/BatchPersistenceTest.php
@@ -146,7 +146,7 @@ it('fires BatchGroupCompleted when the last job in a group completes', function 
 
     $driver = Mockery::mock(Driver::class);
     $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b2', BatchStatus::Completed, new RequestCounts(total: 1, succeeded: 1)));
-    $driver->shouldReceive('batchResults')->andReturn([]);
+    $driver->shouldReceive('batchResults')->andReturn([new BatchResultData('x', BatchResultStatus::Succeeded)]);
 
     $registry = Mockery::mock(ProviderRegistryContract::class);
     $registry->shouldReceive('resolve')->andReturn($driver);
@@ -166,7 +166,7 @@ it('the poll command advances open jobs and skips when none', function () {
 
     $driver = Mockery::mock(Driver::class);
     $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Completed, new RequestCounts(total: 1, succeeded: 1)));
-    $driver->shouldReceive('batchResults')->andReturn([]);
+    $driver->shouldReceive('batchResults')->andReturn([new BatchResultData('x', BatchResultStatus::Succeeded)]);
 
     $registry = Mockery::mock(ProviderRegistryContract::class);
     $registry->shouldReceive('resolve')->andReturn($driver);

--- a/tests/Unit/Enums/BatchResultStatusTest.php
+++ b/tests/Unit/Enums/BatchResultStatusTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+
+it('reports only succeeded as successful', function () {
+    expect(BatchResultStatus::Succeeded->isSuccessful())->toBeTrue();
+
+    foreach ([BatchResultStatus::Errored, BatchResultStatus::Expired, BatchResultStatus::Cancelled] as $status) {
+        expect($status->isSuccessful())->toBeFalse();
+    }
+});
+
+it('exposes stable string values', function () {
+    expect(BatchResultStatus::Succeeded->value)->toBe('succeeded');
+    expect(BatchResultStatus::Errored->value)->toBe('errored');
+    expect(BatchResultStatus::from('expired'))->toBe(BatchResultStatus::Expired);
+});

--- a/tests/Unit/Enums/BatchStatusTest.php
+++ b/tests/Unit/Enums/BatchStatusTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchStatus;
+
+it('marks completed/failed/expired/cancelled as terminal', function (BatchStatus $status) {
+    expect($status->isTerminal())->toBeTrue();
+})->with([
+    BatchStatus::Completed,
+    BatchStatus::Failed,
+    BatchStatus::Expired,
+    BatchStatus::Cancelled,
+]);
+
+it('marks in-flight states as non-terminal', function (BatchStatus $status) {
+    expect($status->isTerminal())->toBeFalse();
+})->with([
+    BatchStatus::Validating,
+    BatchStatus::InProgress,
+    BatchStatus::Finalizing,
+    BatchStatus::Cancelling,
+]);
+
+it('reports only completed as successful', function () {
+    expect(BatchStatus::Completed->isSuccessful())->toBeTrue();
+
+    foreach ([BatchStatus::Validating, BatchStatus::InProgress, BatchStatus::Finalizing, BatchStatus::Failed, BatchStatus::Expired, BatchStatus::Cancelling, BatchStatus::Cancelled] as $status) {
+        expect($status->isSuccessful())->toBeFalse();
+    }
+});
+
+it('exposes stable string values', function () {
+    expect(BatchStatus::InProgress->value)->toBe('in_progress');
+    expect(BatchStatus::from('completed'))->toBe(BatchStatus::Completed);
+});

--- a/tests/Unit/Pending/BatchRequestTest.php
+++ b/tests/Unit/Pending/BatchRequestTest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\Batch\BatchService;
 use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Enums\Modality;
 use Atlasphp\Atlas\Exceptions\BatchException;
 use Atlasphp\Atlas\Pending\BatchRequest;
 use Atlasphp\Atlas\Pending\Contracts\Batchable;
 use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Persistence\Models\BatchJob;
 use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
 use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Requests\Batch;
@@ -127,6 +129,32 @@ it('submits statelessly through the resolved driver', function () {
 
     expect($response)->toBeInstanceOf(BatchResponse::class);
     expect($response->batchId)->toBe('batch_x');
+});
+
+it('tracks via the batch service and passes the group through', function () {
+    $job = new BatchJob;
+    $group = new BatchGroup;
+
+    $service = Mockery::mock(BatchService::class);
+    $service->shouldReceive('submitAndTrack')->once()
+        ->withArgs(fn (Batch $batch, $g) => $batch->modality === Modality::Text && $g === $group)
+        ->andReturn($job);
+
+    $builder = new BatchRequest('openai', Mockery::mock(ProviderRegistryContract::class), $service);
+
+    $result = $builder
+        ->group($group)
+        ->add(batchable(Modality::Text, 'openai', cleanText()), 'a')
+        ->submit();
+
+    expect($result)->toBe($job);
+});
+
+it('group() succeeds when persistence is available', function () {
+    $service = Mockery::mock(BatchService::class);
+    $builder = new BatchRequest('openai', Mockery::mock(ProviderRegistryContract::class), $service);
+
+    expect($builder->group(new BatchGroup))->toBe($builder);
 });
 
 it('applies a custom completion window', function () {

--- a/tests/Unit/Pending/BatchRequestTest.php
+++ b/tests/Unit/Pending/BatchRequestTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Pending\BatchRequest;
+use Atlasphp\Atlas\Pending\Contracts\Batchable;
+use Atlasphp\Atlas\Persistence\Models\BatchGroup;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\RequestCounts;
+
+/**
+ * A stub pending request that reports a fixed modality/provider and DTO.
+ */
+function batchable(Modality $modality, string $provider, object $dto): Batchable
+{
+    return new class($modality, $provider, $dto) implements Batchable
+    {
+        public function __construct(private Modality $modality, private string $provider, private object $dto) {}
+
+        public function batchModality(): Modality
+        {
+            return $this->modality;
+        }
+
+        public function batchProvider(): string
+        {
+            return $this->provider;
+        }
+
+        public function buildRequest(): object
+        {
+            return $this->dto;
+        }
+    };
+}
+
+function cleanText(): TextRequest
+{
+    return new TextRequest('gpt-5', null, 'Caption this.', [], [], null, null, null, [], [], []);
+}
+
+function builder(?ProviderRegistryContract $registry = null): BatchRequest
+{
+    return new BatchRequest('openai', $registry ?? Mockery::mock(ProviderRegistryContract::class));
+}
+
+it('accepts a clean text request and tracks the line', function () {
+    $b = builder()->add(batchable(Modality::Text, 'openai', cleanText()), 'img-1');
+
+    expect($b->count())->toBe(1);
+});
+
+it('rejects a non-batchable request type', function () {
+    builder()->add(new stdClass, 'k');
+})->throws(BatchException::class, 'cannot be batched');
+
+it('rejects a request carrying local tools', function () {
+    $withTools = new TextRequest('gpt-5', null, 'hi', [], [], null, null, null, ['a_tool'], [], []);
+
+    builder()->add(batchable(Modality::Text, 'openai', $withTools), 'k');
+})->throws(BatchException::class, 'Tools cannot be used with batch');
+
+it('rejects a request carrying provider tools', function () {
+    $withProviderTools = new TextRequest('gpt-5', null, 'hi', [], [], null, null, null, [], ['web_search'], []);
+
+    builder()->add(batchable(Modality::Text, 'openai', $withProviderTools), 'k');
+})->throws(BatchException::class, 'Tools cannot be used with batch');
+
+it('rejects a request carrying per-request middleware', function () {
+    $withMiddleware = new TextRequest('gpt-5', null, 'hi', [], [], null, null, null, [], [], [], middleware: ['some_mw']);
+
+    builder()->add(batchable(Modality::Text, 'openai', $withMiddleware), 'k');
+})->throws(BatchException::class, 'middleware does not run for batched requests');
+
+it('rejects mixing two modalities in one batch', function () {
+    builder()
+        ->add(batchable(Modality::Text, 'openai', cleanText()), 'a')
+        ->add(batchable(Modality::Embed, 'openai', new EmbedRequest('m', 'x')), 'b');
+})->throws(BatchException::class, 'must share one modality');
+
+it('rejects mixing two providers in one batch', function () {
+    builder()
+        ->add(batchable(Modality::Text, 'openai', cleanText()), 'a')
+        ->add(batchable(Modality::Text, 'anthropic', cleanText()), 'b');
+})->throws(BatchException::class, 'must target one provider');
+
+it('rejects submitting an empty batch', function () {
+    builder()->submit();
+})->throws(BatchException::class, 'empty batch');
+
+it('rejects group() when persistence is not enabled', function () {
+    builder()->group(new BatchGroup);
+})->throws(BatchException::class, 'requires atlas persistence');
+
+it('addMany adds each request via the factory', function () {
+    $items = ['x', 'y', 'z'];
+
+    $b = builder()->addMany($items, fn (string $s) => [batchable(Modality::Embed, 'openai', new EmbedRequest('m', $s)), $s]);
+
+    expect($b->count())->toBe(3);
+});
+
+it('submits statelessly through the resolved driver', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batch')
+        ->once()
+        ->withArgs(fn (Batch $batch) => $batch->provider === 'openai'
+            && $batch->modality === Modality::Embed
+            && $batch->count() === 2)
+        ->andReturn(new BatchResponse('batch_x', BatchStatus::Validating, new RequestCounts(total: 2)));
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->with('openai')->andReturn($driver);
+
+    $response = builder($registry)
+        ->add(batchable(Modality::Embed, 'openai', new EmbedRequest('m', 'a')), 'a')
+        ->add(batchable(Modality::Embed, 'openai', new EmbedRequest('m', 'b')), 'b')
+        ->submit();
+
+    expect($response)->toBeInstanceOf(BatchResponse::class);
+    expect($response->batchId)->toBe('batch_x');
+});
+
+it('applies a custom completion window', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batch')
+        ->once()
+        ->withArgs(fn (Batch $batch) => $batch->completionWindow === '12h')
+        ->andReturn(new BatchResponse('b', BatchStatus::Validating, new RequestCounts));
+
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->with('openai')->andReturn($driver);
+
+    builder($registry)
+        ->completionWindow('12h')
+        ->add(batchable(Modality::Text, 'openai', cleanText()), 'a')
+        ->submit();
+});

--- a/tests/Unit/Pending/ProviderRequestBatchTest.php
+++ b/tests/Unit/Pending/ProviderRequestBatchTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Pending\BatchRequest;
+use Atlasphp\Atlas\Pending\ProviderRequest;
+use Atlasphp\Atlas\Providers\Contracts\ProviderRegistryContract;
+use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
+
+function providerRequestWith(Driver $driver): ProviderRequest
+{
+    $registry = Mockery::mock(ProviderRegistryContract::class);
+    $registry->shouldReceive('resolve')->with('openai')->andReturn($driver);
+
+    return new ProviderRequest('openai', $registry);
+}
+
+// ─── ProviderRequest batch delegation ────────────────────────────────────────
+
+it('delegates batchStatus to the driver', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchStatus')->once()->with('b')
+        ->andReturn(new BatchResponse('b', BatchStatus::Completed, new RequestCounts));
+
+    expect(providerRequestWith($driver)->batchStatus('b')->status)->toBe(BatchStatus::Completed);
+});
+
+it('delegates batchResults to the driver', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchResults')->once()->with('b')
+        ->andReturn([new BatchResult('a', BatchResultStatus::Succeeded)]);
+
+    $results = iterator_to_array(providerRequestWith($driver)->batchResults('b'));
+
+    expect($results)->toHaveCount(1);
+    expect($results[0]->customId)->toBe('a');
+});
+
+it('delegates batchCancel to the driver', function () {
+    $driver = Mockery::mock(Driver::class);
+    $driver->shouldReceive('batchCancel')->once()->with('b')
+        ->andReturn(new BatchResponse('b', BatchStatus::Cancelling, new RequestCounts));
+
+    expect(providerRequestWith($driver)->batchCancel('b')->status)->toBe(BatchStatus::Cancelling);
+});
+
+// ─── Pending builders' Batchable methods ─────────────────────────────────────
+
+it('exposes batchModality and batchProvider on the text builder', function () {
+    $text = Atlas::text('openai', 'gpt-5');
+
+    expect($text->batchModality())->toBe(Modality::Text);
+    expect($text->batchProvider())->toBe('openai');
+});
+
+it('exposes batchModality and batchProvider on the embed builder', function () {
+    $embed = Atlas::embed('openai', 'text-embedding-3-small');
+
+    expect($embed->batchModality())->toBe(Modality::Embed);
+    expect($embed->batchProvider())->toBe('openai');
+});
+
+it('adds a real pending text builder to a batch (exercises batchModality/Provider/buildRequest)', function () {
+    $batch = Atlas::batch('openai')->add(Atlas::text('openai', 'gpt-5')->message('hi'), key: 'k');
+
+    expect($batch->count())->toBe(1);
+});
+
+// ─── AtlasManager batch()/batchGroup() (persistence disabled) ────────────────
+
+it('Atlas::batch() returns a stateless builder when persistence is off', function () {
+    expect(Atlas::batch('openai'))->toBeInstanceOf(BatchRequest::class);
+});
+
+it('Atlas::batchGroup() requires persistence', function () {
+    Atlas::batchGroup('x');
+})->throws(BatchException::class, 'requires atlas persistence');

--- a/tests/Unit/Providers/Anthropic/AnthropicDriverBatchTest.php
+++ b/tests/Unit/Providers/Anthropic/AnthropicDriverBatchTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Anthropic\AnthropicDriver;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+
+it('resolves the batch handler and submits through the driver', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->andReturn(['id' => 'msgbatch_1', 'processing_status' => 'in_progress', 'request_counts' => ['processing' => 1, 'succeeded' => 0, 'errored' => 0]]);
+
+    $driver = new AnthropicDriver(
+        new ProviderConfig(provider: 'anthropic', apiKey: 'test', baseUrl: 'https://api.anthropic.com/v1'),
+        $http,
+    );
+
+    $batch = new Batch('anthropic', Modality::Text, [
+        new BatchLine('a', new TextRequest('claude-sonnet-4-20250514', null, 'hi', [], [], 64, null, null, [], [], [])),
+    ]);
+
+    $response = $driver->batch($batch);
+
+    expect($response)->toBeInstanceOf(BatchResponse::class);
+    expect($response->batchId)->toBe('msgbatch_1');
+});
+
+it('still routes the synchronous text handler after the batch wiring extraction', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()->andReturn([
+        'id' => 'msg_1',
+        'content' => [['type' => 'text', 'text' => 'hello']],
+        'usage' => ['input_tokens' => 3, 'output_tokens' => 1],
+        'stop_reason' => 'end_turn',
+    ]);
+
+    $driver = new AnthropicDriver(
+        new ProviderConfig(provider: 'anthropic', apiKey: 'test', baseUrl: 'https://api.anthropic.com/v1'),
+        $http,
+    );
+
+    $response = $driver->text(new TextRequest('claude-sonnet-4-20250514', null, 'hi', [], [], 64, null, null, [], [], []));
+
+    expect(trim($response->text))->toBe('hello');
+});

--- a/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Anthropic\Handlers\Batch;
+use Atlasphp\Atlas\Providers\Anthropic\Handlers\Text;
+use Atlasphp\Atlas\Providers\Anthropic\MediaResolver;
+use Atlasphp\Atlas\Providers\Anthropic\MessageFactory;
+use Atlasphp\Atlas\Providers\Anthropic\ResponseParser;
+use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch as BatchRequest;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\TextRequest;
+
+function anthropicBatchHandler(HttpClient $http): Batch
+{
+    $config = new ProviderConfig(provider: 'anthropic', apiKey: 'test', baseUrl: 'https://api.anthropic.com/v1');
+    $toolMapper = new ToolMapper;
+    $text = new Text($config, $http, new MessageFactory, new MediaResolver, $toolMapper, new ResponseParser($toolMapper));
+
+    return new Batch($config, $http, $text);
+}
+
+function anthropicTextBatch(): BatchRequest
+{
+    return new BatchRequest('anthropic', Modality::Text, [
+        new BatchLine('a', new TextRequest('claude-sonnet-4-20250514', null, 'Say ALPHA', [], [], 64, null, null, [], [], [])),
+    ]);
+}
+
+it('submits inline requests built from the text body builder', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    $captured = null;
+    $http->shouldReceive('post')->once()
+        ->withArgs(function (string $url, array $headers, array $body) use (&$captured) {
+            $captured = $body;
+
+            return str_ends_with($url, '/messages/batches')
+                && $headers['x-api-key'] === 'test'
+                && isset($headers['anthropic-version']);
+        })
+        ->andReturn(['id' => 'msgbatch_1', 'processing_status' => 'in_progress', 'request_counts' => ['processing' => 1, 'succeeded' => 0, 'errored' => 0]]);
+
+    $response = anthropicBatchHandler($http)->submit(anthropicTextBatch());
+
+    expect($response->batchId)->toBe('msgbatch_1');
+    expect($response->status)->toBe(BatchStatus::InProgress);
+    expect($captured['requests'][0]['custom_id'])->toBe('a');
+    expect($captured['requests'][0]['params']['model'])->toBe('claude-sonnet-4-20250514');
+    expect($captured['requests'][0]['params'])->toHaveKey('messages');
+});
+
+it('maps processing_status to the normalized enum', function (string $raw, BatchStatus $expected) {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => $raw, 'request_counts' => ['succeeded' => 1, 'errored' => 0, 'processing' => 0]]);
+
+    expect(anthropicBatchHandler($http)->status('b')->status)->toBe($expected);
+})->with([
+    ['in_progress', BatchStatus::InProgress],
+    ['canceling', BatchStatus::Cancelling],
+    ['ended', BatchStatus::Completed],
+]);
+
+it('parses succeeded and errored line results', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => 'ended', 'results_url' => 'https://api.anthropic.com/v1/messages/batches/b/results']);
+
+    $jsonl = implode("\n", [
+        json_encode(['custom_id' => 'a', 'result' => ['type' => 'succeeded', 'message' => ['content' => [['type' => 'text', 'text' => 'ALPHA']], 'usage' => ['input_tokens' => 5, 'output_tokens' => 1], 'stop_reason' => 'end_turn']]]),
+        json_encode(['custom_id' => 'b', 'result' => ['type' => 'errored', 'error' => ['type' => 'invalid_request', 'message' => 'too long']]]),
+        json_encode(['custom_id' => 'c', 'result' => ['type' => 'expired']]),
+    ]);
+    $http->shouldReceive('getRaw')->once()->andReturn($jsonl);
+
+    $results = iterator_to_array(anthropicBatchHandler($http)->results('b'));
+
+    expect($results)->toHaveCount(3);
+    expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
+    expect(trim($results[0]->response->text))->toBe('ALPHA');
+    expect($results[1]->status)->toBe(BatchResultStatus::Errored);
+    expect($results[1]->error->getMessage())->toBe('too long');
+    expect($results[2]->status)->toBe(BatchResultStatus::Expired);
+});
+
+it('returns nothing while results_url is absent', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => 'in_progress']);
+
+    expect(iterator_to_array(anthropicBatchHandler($http)->results('b')))->toBe([]);
+});
+
+it('cancels a batch', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url) => str_ends_with($url, '/messages/batches/b/cancel'))
+        ->andReturn(['id' => 'b', 'processing_status' => 'canceling', 'request_counts' => ['processing' => 2]]);
+
+    expect(anthropicBatchHandler($http)->cancel('b')->status)->toBe(BatchStatus::Cancelling);
+});

--- a/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Enums\BatchResultStatus;
 use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\BatchException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Anthropic\Handlers\Batch;
 use Atlasphp\Atlas\Providers\Anthropic\Handlers\Text;
@@ -15,6 +16,7 @@ use Atlasphp\Atlas\Providers\Anthropic\ToolMapper;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Requests\Batch as BatchRequest;
 use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
 use Atlasphp\Atlas\Requests\TextRequest;
 
 function anthropicBatchHandler(HttpClient $http): Batch
@@ -88,21 +90,34 @@ it('parses succeeded and errored line results', function () {
     $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => 'ended', 'results_url' => 'https://api.anthropic.com/v1/messages/batches/b/results']);
 
     $jsonl = implode("\n", [
+        '', // blank line → skipped
         json_encode(['custom_id' => 'a', 'result' => ['type' => 'succeeded', 'message' => ['content' => [['type' => 'text', 'text' => 'ALPHA']], 'usage' => ['input_tokens' => 5, 'output_tokens' => 1], 'stop_reason' => 'end_turn']]]),
         json_encode(['custom_id' => 'b', 'result' => ['type' => 'errored', 'error' => ['type' => 'invalid_request', 'message' => 'too long']]]),
         json_encode(['custom_id' => 'c', 'result' => ['type' => 'expired']]),
+        json_encode(['custom_id' => 'd', 'result' => ['type' => 'canceled']]),
     ]);
     $http->shouldReceive('getRaw')->once()->andReturn($jsonl);
 
     $results = iterator_to_array(anthropicBatchHandler($http)->results('b'));
 
-    expect($results)->toHaveCount(3);
+    expect($results)->toHaveCount(4);
     expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
     expect(trim($results[0]->response->text))->toBe('ALPHA');
     expect($results[1]->status)->toBe(BatchResultStatus::Errored);
     expect($results[1]->error->getMessage())->toBe('too long');
     expect($results[2]->status)->toBe(BatchResultStatus::Expired);
+    expect($results[3]->status)->toBe(BatchResultStatus::Cancelled);
 });
+
+it('rejects a non-text request line at submit', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    $batch = new BatchRequest('anthropic', Modality::Text, [
+        new BatchLine('a', new EmbedRequest('m', 'x')),
+    ]);
+
+    anthropicBatchHandler($http)->submit($batch);
+})->throws(BatchException::class, 'cannot be batched');
 
 it('returns nothing while results_url is absent', function () {
     $http = Mockery::mock(HttpClient::class);

--- a/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
@@ -89,9 +89,11 @@ it('parses succeeded and errored line results', function () {
     $http = Mockery::mock(HttpClient::class);
     $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => 'ended', 'results_url' => 'https://api.anthropic.com/v1/messages/batches/b/results']);
 
+    // Blank line in the MIDDLE (a leading/trailing blank would be removed by
+    // trim() before the loop, so it must be interior to hit the skip branch).
     $jsonl = implode("\n", [
-        '', // blank line → skipped
         json_encode(['custom_id' => 'a', 'result' => ['type' => 'succeeded', 'message' => ['content' => [['type' => 'text', 'text' => 'ALPHA']], 'usage' => ['input_tokens' => 5, 'output_tokens' => 1], 'stop_reason' => 'end_turn']]]),
+        '', // blank line → skipped
         json_encode(['custom_id' => 'b', 'result' => ['type' => 'errored', 'error' => ['type' => 'invalid_request', 'message' => 'too long']]]),
         json_encode(['custom_id' => 'c', 'result' => ['type' => 'expired']]),
         json_encode(['custom_id' => 'd', 'result' => ['type' => 'canceled']]),

--- a/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/BatchHandlerTest.php
@@ -67,6 +67,22 @@ it('maps processing_status to the normalized enum', function (string $raw, Batch
     ['ended', BatchStatus::Completed],
 ]);
 
+it('maps the lifecycle with correct terminal/successful semantics', function (string $raw, bool $terminal, bool $successful) {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => $raw, 'request_counts' => ['succeeded' => 1, 'errored' => 0, 'processing' => 0]]);
+
+    $response = anthropicBatchHandler($http)->status('b');
+
+    expect($response->isTerminal())->toBe($terminal);
+    expect($response->isSuccessful())->toBe($successful);
+})->with([
+    // Anthropic has no "validating": a submitted batch is immediately in_progress.
+    'in progress (submitted)' => ['in_progress', false, false],
+    'canceling' => ['canceling', false, false],
+    'ended (completed)' => ['ended', true, true],
+    'unknown future' => ['some_new_state', false, false], // safe default: keep polling
+]);
+
 it('parses succeeded and errored line results', function () {
     $http = Mockery::mock(HttpClient::class);
     $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'processing_status' => 'ended', 'results_url' => 'https://api.anthropic.com/v1/messages/batches/b/results']);

--- a/tests/Unit/Providers/Anthropic/BuildsAnthropicHeadersTest.php
+++ b/tests/Unit/Providers/Anthropic/BuildsAnthropicHeadersTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Providers\Anthropic\Concerns\BuildsAnthropicHeaders;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+
+function anthropicHeaderUser(ProviderConfig $config): object
+{
+    return new class($config)
+    {
+        use BuildsAnthropicHeaders;
+
+        public function __construct(public ProviderConfig $config) {}
+
+        /** @return array<string, string> */
+        public function exposeHeaders(): array
+        {
+            return $this->headers();
+        }
+
+        /** @return array<string, string> */
+        public function exposeHeadersWithoutContentType(): array
+        {
+            return $this->headersWithoutContentType();
+        }
+    };
+}
+
+it('builds full headers with the configured version and content-type', function () {
+    $user = anthropicHeaderUser(new ProviderConfig(apiKey: 'sk-test', baseUrl: 'https://api.anthropic.com/v1', extra: ['version' => '2099-01-01']));
+
+    expect($user->exposeHeaders())->toBe([
+        'x-api-key' => 'sk-test',
+        'anthropic-version' => '2099-01-01',
+        'Content-Type' => 'application/json',
+    ]);
+});
+
+it('builds headers without content-type for GET/multipart', function () {
+    $user = anthropicHeaderUser(new ProviderConfig(apiKey: 'sk-test', baseUrl: 'https://api.anthropic.com/v1', extra: ['version' => '2099-01-01']));
+
+    expect($user->exposeHeadersWithoutContentType())->toBe([
+        'x-api-key' => 'sk-test',
+        'anthropic-version' => '2099-01-01',
+    ]);
+});
+
+it('defaults the anthropic version when none is configured', function () {
+    $user = anthropicHeaderUser(new ProviderConfig(apiKey: 'sk-test', baseUrl: 'https://api.anthropic.com/v1'));
+
+    expect($user->exposeHeadersWithoutContentType()['anthropic-version'])->toBe('2023-06-01');
+});

--- a/tests/Unit/Providers/BatchCapabilityMatrixTest.php
+++ b/tests/Unit/Providers/BatchCapabilityMatrixTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Anthropic\AnthropicDriver;
+use Atlasphp\Atlas\Providers\ChatCompletions\ChatCompletionsDriver;
+use Atlasphp\Atlas\Providers\Cohere\CohereDriver;
+use Atlasphp\Atlas\Providers\ElevenLabs\ElevenLabsDriver;
+use Atlasphp\Atlas\Providers\Google\GoogleDriver;
+use Atlasphp\Atlas\Providers\Jina\JinaDriver;
+use Atlasphp\Atlas\Providers\OpenAi\OpenAiDriver;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Providers\Xai\XaiDriver;
+
+function driverFor(string $class): object
+{
+    $config = new ProviderConfig(apiKey: 'test', baseUrl: 'https://api.test.com');
+
+    return new $class($config, Mockery::mock(HttpClient::class));
+}
+
+it('declares the exact batch modality matrix per provider', function (string $class, array $expected) {
+    $caps = driverFor($class)->capabilities();
+
+    expect($caps->batchModalities)->toBe($expected);
+
+    foreach ($expected as $modality) {
+        expect($caps->canBatch($modality))->toBeTrue();
+    }
+})->with([
+    'openai' => [OpenAiDriver::class, ['text', 'embed']],
+    'anthropic' => [AnthropicDriver::class, ['text']],
+]);
+
+it('marks non-batch providers explicitly as not batchable', function (string $class) {
+    $caps = driverFor($class)->capabilities();
+
+    expect($caps->supports('batch'))->toBeFalse();
+    expect($caps->batchModalities)->toBe([]);
+    expect($caps->canBatch('text'))->toBeFalse();
+})->with([
+    // Google and xAI have batch APIs but their handlers are a documented
+    // follow-up; they are intentionally not advertised yet.
+    'google' => [GoogleDriver::class],
+    'xai' => [XaiDriver::class],
+    'elevenlabs' => [ElevenLabsDriver::class],
+    'cohere' => [CohereDriver::class],
+    'jina' => [JinaDriver::class],
+    'chatcompletions' => [ChatCompletionsDriver::class],
+]);
+
+it('rejects modalities outside the provider allow-list', function () {
+    $openai = driverFor(OpenAiDriver::class)->capabilities();
+
+    // OpenAI batches text + embed only in v1
+    expect($openai->canBatch('text'))->toBeTrue();
+    expect($openai->canBatch('embed'))->toBeTrue();
+    expect($openai->canBatch('voice'))->toBeFalse();
+    expect($openai->canBatch('rerank'))->toBeFalse();
+    expect($openai->canBatch('moderate'))->toBeFalse();
+    expect($openai->canBatch('image'))->toBeFalse();
+});

--- a/tests/Unit/Providers/BatchCapabilityMatrixTest.php
+++ b/tests/Unit/Providers/BatchCapabilityMatrixTest.php
@@ -31,6 +31,7 @@ it('declares the exact batch modality matrix per provider', function (string $cl
 })->with([
     'openai' => [OpenAiDriver::class, ['text', 'embed']],
     'anthropic' => [AnthropicDriver::class, ['text']],
+    'google' => [GoogleDriver::class, ['text']],
 ]);
 
 it('marks non-batch providers explicitly as not batchable', function (string $class) {
@@ -40,9 +41,8 @@ it('marks non-batch providers explicitly as not batchable', function (string $cl
     expect($caps->batchModalities)->toBe([]);
     expect($caps->canBatch('text'))->toBeFalse();
 })->with([
-    // Google and xAI have batch APIs but their handlers are a documented
-    // follow-up; they are intentionally not advertised yet.
-    'google' => [GoogleDriver::class],
+    // xAI has a batch API but its handler is a documented follow-up; not
+    // advertised yet.
     'xai' => [XaiDriver::class],
     'elevenlabs' => [ElevenLabsDriver::class],
     'cohere' => [CohereDriver::class],

--- a/tests/Unit/Providers/DriverBatchTest.php
+++ b/tests/Unit/Providers/DriverBatchTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Providers\Handlers\BatchHandler;
+use Atlasphp\Atlas\Providers\ProviderCapabilities;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
+
+/**
+ * A batch handler stub that records calls and returns canned responses.
+ */
+function fakeBatchHandler(): BatchHandler
+{
+    return new class implements BatchHandler
+    {
+        public function submit(Batch $batch): BatchResponse
+        {
+            return new BatchResponse('batch_'.$batch->modality->value, BatchStatus::Validating, new RequestCounts(total: $batch->count()));
+        }
+
+        public function status(string $batchId): BatchResponse
+        {
+            return new BatchResponse($batchId, BatchStatus::Completed, new RequestCounts(total: 1, succeeded: 1));
+        }
+
+        public function results(string $batchId): iterable
+        {
+            yield new BatchResult('a', BatchResultStatus::Succeeded);
+        }
+
+        public function cancel(string $batchId): BatchResponse
+        {
+            return new BatchResponse($batchId, BatchStatus::Cancelling, new RequestCounts);
+        }
+    };
+}
+
+function batchDriverWith(ProviderCapabilities $caps): Driver
+{
+    $config = new ProviderConfig(apiKey: 'test', baseUrl: 'https://api.test.com');
+    $http = Mockery::mock(HttpClient::class);
+
+    return new class($config, $http, $caps) extends Driver
+    {
+        public function __construct($config, $http, private ProviderCapabilities $declared)
+        {
+            parent::__construct($config, $http);
+        }
+
+        public function capabilities(): ProviderCapabilities
+        {
+            return $this->declared;
+        }
+
+        public function name(): string
+        {
+            return 'test';
+        }
+    };
+}
+
+it('rejects a modality the provider cannot batch', function () {
+    $caps = new ProviderCapabilities(batch: true, batchModalities: ['text']);
+    $batch = new Batch('test', Modality::Embed, []);
+
+    batchDriverWith($caps)->batch($batch);
+})->throws(UnsupportedFeatureException::class, 'batch:embed');
+
+it('rejects batch entirely when the provider has no batch handler', function () {
+    $caps = new ProviderCapabilities(batch: true, batchModalities: ['embed']);
+    $batch = new Batch('test', Modality::Embed, []);
+
+    // capability allows it, but the default driver has no batchHandler()
+    batchDriverWith($caps)->batch($batch);
+})->throws(UnsupportedFeatureException::class, 'batch');
+
+it('delegates submit/status/results/cancel to the batch handler', function () {
+    $caps = new ProviderCapabilities(batch: true, batchModalities: ['embed']);
+    $driver = batchDriverWith($caps)->withHandler('batch', fakeBatchHandler());
+
+    $batch = new Batch('test', Modality::Embed, [
+        new BatchLine('a', new EmbedRequest('m', 'x')),
+    ]);
+
+    $submit = $driver->batch($batch);
+    expect($submit->batchId)->toBe('batch_embed');
+    expect($submit->status)->toBe(BatchStatus::Validating);
+    expect($submit->counts->total)->toBe(1);
+
+    $status = $driver->batchStatus('batch_embed');
+    expect($status->status)->toBe(BatchStatus::Completed);
+
+    $results = iterator_to_array($driver->batchResults('batch_embed'));
+    expect($results)->toHaveCount(1);
+    expect($results[0]->customId)->toBe('a');
+
+    $cancel = $driver->batchCancel('batch_embed');
+    expect($cancel->status)->toBe(BatchStatus::Cancelling);
+});

--- a/tests/Unit/Providers/Google/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Google/BatchHandlerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Google\Handlers\Batch;
+use Atlasphp\Atlas\Providers\Google\Handlers\Text;
+use Atlasphp\Atlas\Providers\Google\MediaResolver;
+use Atlasphp\Atlas\Providers\Google\MessageFactory;
+use Atlasphp\Atlas\Providers\Google\ResponseParser;
+use Atlasphp\Atlas\Providers\Google\ToolMapper;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch as BatchRequest;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\TextRequest;
+
+function googleBatchHandler(HttpClient $http): Batch
+{
+    $config = new ProviderConfig(provider: 'google', apiKey: 'test', baseUrl: 'https://generativelanguage.googleapis.com');
+    $toolMapper = new ToolMapper;
+    $text = new Text($config, $http, new MessageFactory, new MediaResolver, $toolMapper, new ResponseParser($toolMapper));
+
+    return new Batch($config, $http, $text);
+}
+
+function googleTextBatch(): BatchRequest
+{
+    return new BatchRequest('google', Modality::Text, [
+        new BatchLine('request-1', new TextRequest('gemini-2.5-flash', null, 'Say ALPHA', [], [], null, null, null, [], [], [])),
+        new BatchLine('request-2', new TextRequest('gemini-2.5-flash', null, 'Say BETA', [], [], null, null, null, [], [], [])),
+    ]);
+}
+
+it('submits inline requests with the documented nesting and model in the URL', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    $captured = null;
+    $capturedUrl = null;
+    $http->shouldReceive('post')->once()
+        ->withArgs(function (string $url, array $headers, array $body) use (&$captured, &$capturedUrl) {
+            $capturedUrl = $url;
+            $captured = $body;
+
+            return $headers['x-goog-api-key'] === 'test';
+        })
+        ->andReturn(['name' => 'batches/123', 'metadata' => ['state' => 'JOB_STATE_PENDING'], 'done' => false]);
+
+    $response = googleBatchHandler($http)->submit(googleTextBatch());
+
+    expect($capturedUrl)->toBe('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:batchGenerateContent');
+    expect($response->batchId)->toBe('batches/123');
+    expect($response->status)->toBe(BatchStatus::Validating);
+
+    // batch.input_config.requests.requests[] with metadata.key per line.
+    $requests = $captured['batch']['input_config']['requests']['requests'];
+    expect($requests)->toHaveCount(2);
+    expect($requests[0]['metadata']['key'])->toBe('request-1');
+    expect($requests[0]['request'])->toHaveKey('contents');
+});
+
+it('maps job state by suffix, tolerating JOB_STATE_* and BATCH_STATE_*', function (string $state, BatchStatus $expected) {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['name' => 'batches/1', 'metadata' => ['state' => $state]]);
+
+    expect(googleBatchHandler($http)->status('batches/1')->status)->toBe($expected);
+})->with([
+    ['JOB_STATE_PENDING', BatchStatus::Validating],
+    ['JOB_STATE_RUNNING', BatchStatus::InProgress],
+    ['JOB_STATE_SUCCEEDED', BatchStatus::Completed],
+    ['JOB_STATE_FAILED', BatchStatus::Failed],
+    ['JOB_STATE_CANCELLED', BatchStatus::Cancelled],
+    ['JOB_STATE_EXPIRED', BatchStatus::Expired],
+    ['BATCH_STATE_RUNNING', BatchStatus::InProgress],   // leaked spelling, still handled
+    ['BATCH_STATE_SUCCEEDED', BatchStatus::Completed],
+]);
+
+it('correlates results by metadata.key, not array order', function () {
+    $http = Mockery::mock(HttpClient::class);
+    // Note: returned OUT OF ORDER (request-2 first) to prove key-based join.
+    $http->shouldReceive('get')->once()->andReturn([
+        'name' => 'batches/1',
+        'metadata' => ['state' => 'JOB_STATE_SUCCEEDED'],
+        'response' => ['inlinedResponses' => ['inlinedResponses' => [
+            ['metadata' => ['key' => 'request-2'], 'response' => ['candidates' => [['content' => ['parts' => [['text' => 'BETA']]]]], 'usageMetadata' => ['promptTokenCount' => 4, 'candidatesTokenCount' => 1]]],
+            ['metadata' => ['key' => 'request-1'], 'error' => ['code' => 3, 'message' => 'bad request']],
+        ]]],
+    ]);
+
+    $results = iterator_to_array(googleBatchHandler($http)->results('batches/1'));
+
+    expect($results)->toHaveCount(2);
+    expect($results[0]->customId)->toBe('request-2');
+    expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
+    expect(trim($results[0]->response->text))->toBe('BETA');
+    expect($results[1]->customId)->toBe('request-1');
+    expect($results[1]->status)->toBe(BatchResultStatus::Errored);
+    expect($results[1]->error->getMessage())->toBe('bad request');
+});
+
+it('returns no results while still running', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['name' => 'batches/1', 'metadata' => ['state' => 'JOB_STATE_RUNNING']]);
+
+    expect(iterator_to_array(googleBatchHandler($http)->results('batches/1')))->toBe([]);
+});
+
+it('cancels a batch', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url) => str_ends_with($url, '/v1beta/batches/1:cancel'))
+        ->andReturn(['name' => 'batches/1', 'metadata' => ['state' => 'JOB_STATE_CANCELLED']]);
+
+    expect(googleBatchHandler($http)->cancel('batches/1')->status)->toBe(BatchStatus::Cancelled);
+});
+
+it('falls back to a status fetch when cancel returns an empty body', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()->andReturn([]); // empty cancel ack
+    $http->shouldReceive('get')->once()->andReturn(['name' => 'batches/1', 'metadata' => ['state' => 'JOB_STATE_CANCELLED']]);
+
+    expect(googleBatchHandler($http)->cancel('batches/1')->status)->toBe(BatchStatus::Cancelled);
+});
+
+it('surfaces a top-level operation error', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn([
+        'name' => 'batches/1',
+        'metadata' => ['state' => 'JOB_STATE_FAILED'],
+        'error' => ['code' => 13, 'message' => 'internal failure'],
+    ]);
+
+    $response = googleBatchHandler($http)->status('batches/1');
+
+    expect($response->status)->toBe(BatchStatus::Failed);
+    expect($response->error)->toBe('internal failure');
+});
+
+it('counts succeeded and failed inline responses', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn([
+        'name' => 'batches/1',
+        'metadata' => ['state' => 'JOB_STATE_SUCCEEDED'],
+        'response' => ['inlinedResponses' => ['inlinedResponses' => [
+            ['metadata' => ['key' => 'a'], 'response' => ['candidates' => []]],
+            ['metadata' => ['key' => 'b'], 'error' => ['message' => 'x']],
+        ]]],
+    ]);
+
+    $counts = googleBatchHandler($http)->status('batches/1')->counts;
+
+    expect($counts->total)->toBe(2);
+    expect($counts->succeeded)->toBe(1);
+    expect($counts->failed)->toBe(1);
+});

--- a/tests/Unit/Providers/Google/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Google/BatchHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Atlasphp\Atlas\Enums\BatchResultStatus;
 use Atlasphp\Atlas\Enums\BatchStatus;
 use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\BatchException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\Google\Handlers\Batch;
 use Atlasphp\Atlas\Providers\Google\Handlers\Text;
@@ -15,6 +16,7 @@ use Atlasphp\Atlas\Providers\Google\ToolMapper;
 use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Requests\Batch as BatchRequest;
 use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
 use Atlasphp\Atlas\Requests\TextRequest;
 
 function googleBatchHandler(HttpClient $http): Batch
@@ -75,7 +77,19 @@ it('maps job state by suffix, tolerating JOB_STATE_* and BATCH_STATE_*', functio
     ['JOB_STATE_EXPIRED', BatchStatus::Expired],
     ['BATCH_STATE_RUNNING', BatchStatus::InProgress],   // leaked spelling, still handled
     ['BATCH_STATE_SUCCEEDED', BatchStatus::Completed],
+    ['JOB_STATE_UNSPECIFIED', BatchStatus::InProgress], // unknown → safe default (keep polling)
+    ['', BatchStatus::InProgress],                      // empty → safe default
 ]);
+
+it('rejects a non-text request line at submit', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    $batch = new BatchRequest('google', Modality::Text, [
+        new BatchLine('a', new EmbedRequest('text-embedding-3-small', 'x')),
+    ]);
+
+    googleBatchHandler($http)->submit($batch);
+})->throws(BatchException::class, 'cannot be batched');
 
 it('correlates results by metadata.key, not array order', function () {
     $http = Mockery::mock(HttpClient::class);

--- a/tests/Unit/Providers/Google/GoogleDriverBatchTest.php
+++ b/tests/Unit/Providers/Google/GoogleDriverBatchTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Google\GoogleDriver;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+
+function googleDriverWith(HttpClient $http): GoogleDriver
+{
+    return new GoogleDriver(
+        new ProviderConfig(provider: 'google', apiKey: 'test', baseUrl: 'https://generativelanguage.googleapis.com'),
+        $http,
+    );
+}
+
+it('resolves the batch handler and submits through the driver', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->andReturn(['name' => 'batches/1', 'metadata' => ['state' => 'JOB_STATE_PENDING']]);
+
+    $batch = new Batch('google', Modality::Text, [
+        new BatchLine('a', new TextRequest('gemini-2.5-flash', null, 'hi', [], [], null, null, null, [], [], [])),
+    ]);
+
+    $response = googleDriverWith($http)->batch($batch);
+
+    expect($response)->toBeInstanceOf(BatchResponse::class);
+    expect($response->batchId)->toBe('batches/1');
+});
+
+it('still routes the synchronous text handler after the batch wiring extraction', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()->andReturn([
+        'candidates' => [['content' => ['parts' => [['text' => 'hello']]]]],
+        'usageMetadata' => ['promptTokenCount' => 3, 'candidatesTokenCount' => 1],
+    ]);
+
+    $response = googleDriverWith($http)->text(new TextRequest('gemini-2.5-flash', null, 'hi', [], [], null, null, null, [], [], []));
+
+    expect(trim($response->text))->toBe('hello');
+});

--- a/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
@@ -18,6 +18,7 @@ use Atlasphp\Atlas\Providers\ProviderConfig;
 use Atlasphp\Atlas\Requests\Batch as BatchRequest;
 use Atlasphp\Atlas\Requests\BatchLine;
 use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
 
 function openAiBatchHandler(HttpClient $http): Batch
 {
@@ -76,6 +77,44 @@ it('uploads JSONL and creates a batch, serializing each line via the embed body 
     expect($first['body']['input'])->toBe('hello');
 });
 
+it('serializes a text batch line via the text payload builder', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    $captured = null;
+    $http->shouldReceive('postMultipart')->once()
+        ->withArgs(function (string $url, array $headers, array $data, array $attachments) use (&$captured) {
+            $captured = $attachments[0]['contents'];
+
+            return true;
+        })
+        ->andReturn(['id' => 'file_t']);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $h, array $body) => $body['endpoint'] === '/v1/responses')
+        ->andReturn(['id' => 'batch_t', 'status' => 'validating', 'request_counts' => ['total' => 1, 'completed' => 0, 'failed' => 0]]);
+
+    $batch = new BatchRequest('openai', Modality::Text, [
+        new BatchLine('a', new TextRequest('gpt-5', null, 'Hi', [], [], null, null, null, [], [], [])),
+    ]);
+
+    $response = openAiBatchHandler($http)->submit($batch);
+
+    expect($response->batchId)->toBe('batch_t');
+    $first = json_decode(explode("\n", $captured)[0], true);
+    expect($first['url'])->toBe('/v1/responses');
+    expect($first['body']['model'])->toBe('gpt-5'); // built via Text::buildPayload
+});
+
+it('throws when a line request does not match the batch modality', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    // serialize() runs before any HTTP call, so the mismatch throws first.
+    $batch = new BatchRequest('openai', Modality::Text, [
+        new BatchLine('a', new EmbedRequest('m', 'x')),
+    ]);
+
+    openAiBatchHandler($http)->submit($batch);
+})->throws(BatchException::class, 'must share one modality');
+
 it('maps each provider status to the normalized enum', function (string $raw, BatchStatus $expected) {
     $http = Mockery::mock(HttpClient::class);
     $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'status' => $raw, 'request_counts' => ['total' => 1, 'completed' => 1, 'failed' => 0]]);
@@ -90,6 +129,25 @@ it('maps each provider status to the normalized enum', function (string $raw, Ba
     ['expired', BatchStatus::Expired],
     ['cancelling', BatchStatus::Cancelling],
     ['cancelled', BatchStatus::Cancelled],
+]);
+
+it('maps the lifecycle with correct terminal/successful semantics', function (string $raw, bool $terminal, bool $successful) {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'status' => $raw, 'request_counts' => ['total' => 1, 'completed' => 0, 'failed' => 0]]);
+
+    $response = openAiBatchHandler($http)->status('b');
+
+    expect($response->isTerminal())->toBe($terminal);
+    expect($response->isSuccessful())->toBe($successful);
+})->with([
+    'just submitted' => ['validating', false, false],
+    'in progress' => ['in_progress', false, false],
+    'finalizing' => ['finalizing', false, false],
+    'completed' => ['completed', true, true],
+    'failed' => ['failed', true, false],
+    'expired' => ['expired', true, false],
+    'cancelled' => ['cancelled', true, false],
+    'unknown future' => ['some_new_state', false, false], // safe default: keep polling
 ]);
 
 it('returns no results while the output file is not ready', function () {

--- a/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\BatchException;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\OpenAi\Handlers\Batch;
+use Atlasphp\Atlas\Providers\OpenAi\Handlers\Embed;
+use Atlasphp\Atlas\Providers\OpenAi\Handlers\Text;
+use Atlasphp\Atlas\Providers\OpenAi\MediaResolver;
+use Atlasphp\Atlas\Providers\OpenAi\MessageFactory;
+use Atlasphp\Atlas\Providers\OpenAi\ResponseParser;
+use Atlasphp\Atlas\Providers\OpenAi\ToolMapper;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch as BatchRequest;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+
+function openAiBatchHandler(HttpClient $http): Batch
+{
+    $config = new ProviderConfig(provider: 'openai', apiKey: 'test', baseUrl: 'https://api.openai.com/v1');
+    $toolMapper = new ToolMapper;
+
+    $text = new Text($config, $http, new MessageFactory, new MediaResolver, $toolMapper, new ResponseParser($toolMapper));
+    $embed = new Embed($config, $http);
+
+    return new Batch($config, $http, $text, $embed);
+}
+
+function embedBatch(): BatchRequest
+{
+    return new BatchRequest('openai', Modality::Embed, [
+        new BatchLine('chunk-1', new EmbedRequest('text-embedding-3-small', 'hello')),
+        new BatchLine('chunk-2', new EmbedRequest('text-embedding-3-small', 'world')),
+    ]);
+}
+
+it('uploads JSONL and creates a batch, serializing each line via the embed body builder', function () {
+    $http = Mockery::mock(HttpClient::class);
+
+    $capturedJsonl = null;
+    $http->shouldReceive('postMultipart')->once()
+        ->withArgs(function (string $url, array $headers, array $data, array $attachments) use (&$capturedJsonl) {
+            $capturedJsonl = $attachments[0]['contents'];
+
+            return str_ends_with($url, '/files')
+                && $data['purpose'] === 'batch'
+                && ! isset($headers['Content-Type']);
+        })
+        ->andReturn(['id' => 'file_abc']);
+
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url, array $h, array $body) => str_ends_with($url, '/batches')
+            && $body['input_file_id'] === 'file_abc'
+            && $body['endpoint'] === '/v1/embeddings'
+            && $body['completion_window'] === '24h')
+        ->andReturn(['id' => 'batch_xyz', 'status' => 'validating', 'request_counts' => ['total' => 2, 'completed' => 0, 'failed' => 0], 'input_file_id' => 'file_abc']);
+
+    $response = openAiBatchHandler($http)->submit(embedBatch());
+
+    expect($response->batchId)->toBe('batch_xyz');
+    expect($response->status)->toBe(BatchStatus::Validating);
+    expect($response->counts->total)->toBe(2);
+    expect($response->counts->processing)->toBe(2);
+
+    // Each JSONL line matches the synchronous embed body builder exactly.
+    $lines = explode("\n", $capturedJsonl);
+    expect($lines)->toHaveCount(2);
+    $first = json_decode($lines[0], true);
+    expect($first['custom_id'])->toBe('chunk-1');
+    expect($first['url'])->toBe('/v1/embeddings');
+    expect($first['body']['model'])->toBe('text-embedding-3-small');
+    expect($first['body']['input'])->toBe('hello');
+});
+
+it('maps each provider status to the normalized enum', function (string $raw, BatchStatus $expected) {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'status' => $raw, 'request_counts' => ['total' => 1, 'completed' => 1, 'failed' => 0]]);
+
+    expect(openAiBatchHandler($http)->status('b')->status)->toBe($expected);
+})->with([
+    ['validating', BatchStatus::Validating],
+    ['in_progress', BatchStatus::InProgress],
+    ['finalizing', BatchStatus::Finalizing],
+    ['completed', BatchStatus::Completed],
+    ['failed', BatchStatus::Failed],
+    ['expired', BatchStatus::Expired],
+    ['cancelling', BatchStatus::Cancelling],
+    ['cancelled', BatchStatus::Cancelled],
+]);
+
+it('returns no results while the output file is not ready', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'status' => 'in_progress', 'output_file_id' => null]);
+
+    expect(iterator_to_array(openAiBatchHandler($http)->results('b')))->toBe([]);
+});
+
+it('parses completed embedding results via the embed parser', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn([
+        'id' => 'b', 'status' => 'completed', 'endpoint' => '/v1/embeddings', 'output_file_id' => 'file_out',
+    ]);
+
+    $jsonl = implode("\n", [
+        json_encode(['custom_id' => 'chunk-1', 'response' => ['status_code' => 200, 'body' => ['data' => [['index' => 0, 'embedding' => [0.1, 0.2]]], 'usage' => ['prompt_tokens' => 3]]]]),
+        json_encode(['custom_id' => 'chunk-2', 'error' => ['message' => 'bad input']]),
+    ]);
+    $http->shouldReceive('getRaw')->once()->andReturn($jsonl);
+
+    $results = iterator_to_array(openAiBatchHandler($http)->results('b'));
+
+    expect($results)->toHaveCount(2);
+    expect($results[0]->customId)->toBe('chunk-1');
+    expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
+    expect($results[0]->response->embeddings[0])->toBe([0.1, 0.2]);
+    expect($results[1]->customId)->toBe('chunk-2');
+    expect($results[1]->status)->toBe(BatchResultStatus::Errored);
+    expect($results[1]->error->getMessage())->toBe('bad input');
+});
+
+it('throws when the input-file upload returns no id', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('postMultipart')->once()->andReturn(['object' => 'file']); // no 'id'
+
+    openAiBatchHandler($http)->submit(embedBatch());
+})->throws(BatchException::class, 'no file id');
+
+it('marks a line with a non-2xx status_code as errored', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn(['id' => 'b', 'status' => 'completed', 'endpoint' => '/v1/responses', 'output_file_id' => 'file_out']);
+    $http->shouldReceive('getRaw')->once()->andReturn(json_encode([
+        'custom_id' => 'x',
+        'response' => ['status_code' => 400, 'body' => ['error' => ['message' => 'context too long']]],
+        'error' => null,
+    ]));
+
+    $results = iterator_to_array(openAiBatchHandler($http)->results('b'));
+
+    expect($results[0]->status)->toBe(BatchResultStatus::Errored);
+    expect($results[0]->error->getMessage())->toBe('context too long');
+});
+
+it('surfaces a job-level error from the batch object', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn([
+        'id' => 'b', 'status' => 'failed',
+        'request_counts' => ['total' => 1, 'completed' => 0, 'failed' => 1],
+        'errors' => ['data' => [['code' => 'invalid', 'message' => 'input file malformed']]],
+    ]);
+
+    $response = openAiBatchHandler($http)->status('b');
+
+    expect($response->status)->toBe(BatchStatus::Failed);
+    expect($response->error)->toBe('input file malformed');
+});
+
+it('cancels a batch', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('post')->once()
+        ->withArgs(fn (string $url) => str_ends_with($url, '/batches/b/cancel'))
+        ->andReturn(['id' => 'b', 'status' => 'cancelling', 'request_counts' => ['total' => 5, 'completed' => 2, 'failed' => 0]]);
+
+    expect(openAiBatchHandler($http)->cancel('b')->status)->toBe(BatchStatus::Cancelling);
+});

--- a/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
@@ -216,6 +216,33 @@ it('surfaces a job-level error from the batch object', function () {
     expect($response->error)->toBe('input file malformed');
 });
 
+it('parses text results, skips blank lines, and errors empty-body lines', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn([
+        'id' => 'b', 'status' => 'completed', 'endpoint' => '/v1/responses', 'output_file_id' => 'file_out',
+    ]);
+
+    // Leading + interior blank lines (skipped), one good text line, one 2xx
+    // empty-body line (errored).
+    $jsonl = implode("\n", [
+        '',
+        json_encode(['custom_id' => 't1', 'response' => ['status_code' => 200, 'body' => ['output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'HELLO']]]], 'usage' => ['input_tokens' => 5, 'output_tokens' => 1]]]]),
+        '',
+        json_encode(['custom_id' => 't2', 'response' => ['status_code' => 200, 'body' => []]]),
+    ]);
+    $http->shouldReceive('getRaw')->once()->andReturn($jsonl);
+
+    $results = iterator_to_array(openAiBatchHandler($http)->results('b'));
+
+    expect($results)->toHaveCount(2);
+    expect($results[0]->customId)->toBe('t1');
+    expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
+    expect(trim($results[0]->response->text))->toBe('HELLO');
+    expect($results[1]->customId)->toBe('t2');
+    expect($results[1]->status)->toBe(BatchResultStatus::Errored);
+    expect($results[1]->error->getMessage())->toBe('empty response body');
+});
+
 it('cancels a batch', function () {
     $http = Mockery::mock(HttpClient::class);
     $http->shouldReceive('post')->once()

--- a/tests/Unit/Providers/OpenAi/OpenAiDriverBatchTest.php
+++ b/tests/Unit/Providers/OpenAi/OpenAiDriverBatchTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\OpenAi\OpenAiDriver;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Responses\BatchResponse;
+
+function openAiDriverWith(HttpClient $http): OpenAiDriver
+{
+    return new OpenAiDriver(
+        new ProviderConfig(provider: 'openai', apiKey: 'test', baseUrl: 'https://api.openai.com/v1'),
+        $http,
+    );
+}
+
+it('resolves the batch handler and submits through the driver', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('postMultipart')->once()->andReturn(['id' => 'file_x']);
+    $http->shouldReceive('post')->once()
+        ->andReturn(['id' => 'batch_x', 'status' => 'validating', 'request_counts' => ['total' => 1, 'completed' => 0, 'failed' => 0]]);
+
+    $batch = new Batch('openai', Modality::Embed, [
+        new BatchLine('a', new EmbedRequest('text-embedding-3-small', 'x')),
+    ]);
+
+    $response = openAiDriverWith($http)->batch($batch);
+
+    expect($response)->toBeInstanceOf(BatchResponse::class);
+    expect($response->batchId)->toBe('batch_x');
+});
+
+it('delegates batchStatus through the driver-resolved handler', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()
+        ->andReturn(['id' => 'b', 'status' => 'completed', 'request_counts' => ['total' => 1, 'completed' => 1, 'failed' => 0]]);
+
+    expect(openAiDriverWith($http)->batchStatus('b')->batchId)->toBe('b');
+});

--- a/tests/Unit/Providers/ProviderCapabilitiesTest.php
+++ b/tests/Unit/Providers/ProviderCapabilitiesTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\Enums\Modality;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
 
 it('returns true for supported features', function () {
@@ -68,4 +69,39 @@ it('withOverrides returns same instance when overrides are empty', function () {
     $result = ProviderCapabilities::withOverrides($base, []);
 
     expect($result)->toBe($base);
+});
+
+it('canBatch requires both the batch flag and the modality allow-list', function () {
+    $caps = new ProviderCapabilities(
+        batch: true,
+        batchModalities: ['text', 'embed'],
+    );
+
+    expect($caps->canBatch('text'))->toBeTrue();
+    expect($caps->canBatch(Modality::Embed))->toBeTrue();
+    expect($caps->canBatch('image'))->toBeFalse();
+    expect($caps->canBatch(Modality::Voice))->toBeFalse();
+});
+
+it('canBatch is false when the provider lacks the batch flag entirely', function () {
+    $caps = new ProviderCapabilities(text: true, batchModalities: ['text']);
+
+    expect($caps->canBatch('text'))->toBeFalse();
+});
+
+it('supports() ignores the non-bool batchModalities property', function () {
+    $caps = new ProviderCapabilities(batch: true, batchModalities: ['text']);
+
+    expect($caps->supports('batch'))->toBeTrue();
+    expect($caps->supports('batchModalities'))->toBeFalse();
+});
+
+it('withOverrides preserves batch capability fields', function () {
+    $base = new ProviderCapabilities(batch: true, batchModalities: ['text']);
+
+    $overridden = ProviderCapabilities::withOverrides($base, ['stream' => true]);
+
+    expect($overridden->supports('batch'))->toBeTrue();
+    expect($overridden->canBatch('text'))->toBeTrue();
+    expect($overridden->supports('stream'))->toBeTrue();
 });

--- a/tests/Unit/Requests/BatchTest.php
+++ b/tests/Unit/Requests/BatchTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Requests\Batch;
+use Atlasphp\Atlas\Requests\BatchLine;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
+
+it('wraps a request DTO with a custom id', function () {
+    $request = new TextRequest('gpt-5', null, 'Caption this.', [], [], null, null, null, [], [], []);
+    $line = new BatchLine('img-1', $request);
+
+    expect($line->customId)->toBe('img-1');
+    expect($line->request)->toBe($request);
+});
+
+it('holds provider, modality, lines and a default completion window', function () {
+    $lines = [
+        new BatchLine('a', new EmbedRequest('text-embedding-3-small', 'one')),
+        new BatchLine('b', new EmbedRequest('text-embedding-3-small', 'two')),
+    ];
+
+    $batch = new Batch('openai', Modality::Embed, $lines);
+
+    expect($batch->provider)->toBe('openai');
+    expect($batch->modality)->toBe(Modality::Embed);
+    expect($batch->lines)->toHaveCount(2);
+    expect($batch->completionWindow)->toBe('24h');
+    expect($batch->count())->toBe(2);
+});
+
+it('accepts a custom completion window', function () {
+    $batch = new Batch('anthropic', Modality::Text, [], '12h');
+
+    expect($batch->completionWindow)->toBe('12h');
+    expect($batch->count())->toBe(0);
+});

--- a/tests/Unit/Responses/BatchResponseTest.php
+++ b/tests/Unit/Responses/BatchResponseTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Enums\BatchResultStatus;
+use Atlasphp\Atlas\Enums\BatchStatus;
+use Atlasphp\Atlas\Enums\FinishReason;
+use Atlasphp\Atlas\Responses\BatchResponse;
+use Atlasphp\Atlas\Responses\BatchResult;
+use Atlasphp\Atlas\Responses\RequestCounts;
+use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\Usage;
+
+it('exposes the batch id, status and counts', function () {
+    $response = new BatchResponse(
+        batchId: 'batch_123',
+        status: BatchStatus::InProgress,
+        counts: new RequestCounts(total: 10, processing: 10),
+        inputFileId: 'file_in',
+    );
+
+    expect($response->batchId)->toBe('batch_123');
+    expect($response->status)->toBe(BatchStatus::InProgress);
+    expect($response->counts->total)->toBe(10);
+    expect($response->inputFileId)->toBe('file_in');
+    expect($response->isTerminal())->toBeFalse();
+    expect($response->isSuccessful())->toBeFalse();
+});
+
+it('reports terminal and successful from its status', function () {
+    $completed = new BatchResponse('b', BatchStatus::Completed, new RequestCounts);
+    $failed = new BatchResponse('b', BatchStatus::Failed, new RequestCounts);
+
+    expect($completed->isTerminal())->toBeTrue();
+    expect($completed->isSuccessful())->toBeTrue();
+    expect($failed->isTerminal())->toBeTrue();
+    expect($failed->isSuccessful())->toBeFalse();
+});
+
+it('round-trips request counts through an array', function () {
+    $counts = new RequestCounts(total: 5, succeeded: 3, failed: 1, processing: 1);
+
+    $array = $counts->toArray();
+    expect($array)->toBe(['total' => 5, 'succeeded' => 3, 'failed' => 1, 'processing' => 1]);
+
+    $restored = RequestCounts::fromArray($array);
+    expect($restored->total)->toBe(5);
+    expect($restored->succeeded)->toBe(3);
+    expect($restored->failed)->toBe(1);
+    expect($restored->processing)->toBe(1);
+});
+
+it('defaults request counts to zero from a null array', function () {
+    $counts = RequestCounts::fromArray(null);
+
+    expect($counts->total)->toBe(0);
+    expect($counts->succeeded)->toBe(0);
+});
+
+it('holds a parsed response on a successful result', function () {
+    $text = new TextResponse('A dog on a beach.', new Usage(10, 5), FinishReason::Stop);
+    $result = new BatchResult('img-1', BatchResultStatus::Succeeded, response: $text, usage: new Usage(10, 5));
+
+    expect($result->customId)->toBe('img-1');
+    expect($result->succeeded())->toBeTrue();
+    expect($result->response)->toBe($text);
+    expect($result->error)->toBeNull();
+});
+
+it('holds an error on a failed result', function () {
+    $error = new RuntimeException('image unreadable');
+    $result = new BatchResult('img-2', BatchResultStatus::Errored, error: $error);
+
+    expect($result->succeeded())->toBeFalse();
+    expect($result->response)->toBeNull();
+    expect($result->error)->toBe($error);
+});


### PR DESCRIPTION
This pull request introduces a major new feature: deferred batching support in Atlas, allowing large sets of requests to be submitted as batch jobs for significantly reduced cost and improved scalability. The update includes new documentation, configuration options, and database migrations to support persistent, trackable batch processing. Additionally, the README and changelog have been overhauled for clarity and to better showcase Atlas's capabilities.

**Batching support and persistence:**

- Added new `Atlas::batch()` method for submitting large sets of requests as deferred jobs, with polling and pruning commands (`atlas:batch-poll`, `atlas:batch-prune`) and result tracking keyed by `custom_id`. This enables ~50% lower cost for batch operations and introduces batch job management and retention controls.
- Introduced three new database migrations: `batch_groups`, `batch_jobs`, and `batch_results` tables, enabling persistent tracking of batch jobs, their groupings, and individual results. These migrations are required for tracked batching and are published with the new `atlas-migrations` tag. [[1]](diffhunk://#diff-5ddf3fae37fdbfbebc4e95b3d60e2273aed82c940a1a788ea3f227fcb5cb8f5cR1-R30) [[2]](diffhunk://#diff-f31c3653a45fc23ef3dd797205ca4625752023608065f7e7e1e4d585b613098eR1-R52) [[3]](diffhunk://#diff-777327a87a54bd0551a370bd33a044ff665c00bb7f4635b7edadd596a33bb2acR1-R40)
- Added batch-related configuration to `config/atlas.php`, allowing customization of polling limits, provider completion windows, and retention periods for batch history.

**Documentation and onboarding improvements:**

- Overhauled the `README.md` to provide a clearer, more compelling overview of Atlas, including new highlights, rationale, and a simplified quick start. The agent example is now a plant shop scenario, and the features list is expanded and reorganized for easier discovery. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R82) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99-R115) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R183) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R257)
- Updated the changelog to document the new batching feature and its migration requirements, with clear upgrade instructions for enabling persistence and tracked batching.
- Added a new "Batch" entry to the documentation sidebar for discoverability of the new modality.