### PR TITLE
Handle pgvector, Anthropic thinking, OpenAI batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Extended thinking now works through multi-step tool calls and persisted-conversation reloads.
 - Google (Gemini) tool calls no longer 400 on non-object results (number, boolean, array, quoted string) — wrapped automatically. Plain strings and JSON objects are unchanged.
+- Chunked embeddings now work when persistence runs on a separate Postgres connection (`atlas.persistence.connection`) and the app default isn't Postgres — pgvector is detected on the persistence connection, so chunk writes and similarity search no longer fail.
 
 ### Migration
 

--- a/docs/modalities/text.md
+++ b/docs/modalities/text.md
@@ -338,7 +338,7 @@ Reasoning works inside the tool-call loop: Atlas replays each provider's signed 
 Notes:
 - Reasoning only takes effect on reasoning-capable models.
 - A raw `withProviderOptions()` value overrides `->reasoning()` if both set the same key.
-- On Anthropic, reasoning and structured output (`->withSchema()`) aren't combined — a structured turn forces a tool, which Anthropic disallows alongside thinking.
+- On Anthropic, reasoning isn't combined with a forced tool — structured output (`->withSchema()`), `->forceTools()`, or `->toolChoice(...)` for a specific/required tool all force a tool call, which Anthropic disallows alongside thinking. On those turns the forced tool wins and thinking is skipped; an `auto` choice keeps thinking.
 
 ## Queue Support
 

--- a/sandbox/test-reasoning-forced-tools.php
+++ b/sandbox/test-reasoning-forced-tools.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Repro: Anthropic extended thinking + a forced tool_choice.
+ *
+ * Anthropic rejects `thinking` combined with a forced tool_choice (type any/tool)
+ * with a 400. The regular text/agent path sets `thinking` from ->reasoning() but
+ * does NOT drop a forced tool_choice (only the structured() path does). Expect a
+ * 400 BEFORE the fix; a clean tool-loop completion AFTER.
+ *
+ * Usage: php sandbox/test-reasoning-forced-tools.php
+ */
+$app = require __DIR__.'/bootstrap.php';
+
+use Atlasphp\Atlas\Atlas;
+use Atlasphp\Atlas\Enums\ReasoningEffort;
+use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Schema\Schema;
+use Atlasphp\Atlas\Tools\Tool;
+use Atlasphp\Atlas\Tools\ToolChoice;
+
+$model = $argv[1] ?? 'claude-sonnet-4-5-20250929';
+
+$weather = new class extends Tool
+{
+    public function name(): string
+    {
+        return 'get_weather';
+    }
+
+    public function description(): string
+    {
+        return 'Get the current weather for a city. Returns a short description.';
+    }
+
+    public function parameters(): array
+    {
+        return [Schema::string('city', 'City name')];
+    }
+
+    /**
+     * @param  array<string, mixed>  $args
+     * @param  array<string, mixed>  $context
+     */
+    public function handle(array $args, array $context): mixed
+    {
+        return 'Sunny, 24C in '.($args['city'] ?? 'unknown');
+    }
+};
+
+/**
+ * @param  callable():TextResponse  $run
+ */
+function attempt(string $label, callable $run): void
+{
+    echo "\n=== {$label} ===\n";
+
+    try {
+        $response = $run();
+        echo 'OK — steps: '.count($response->steps).', text: '.substr((string) $response->text, 0, 80)."\n";
+        echo "RESULT: PASS (no 400)\n";
+    } catch (Throwable $e) {
+        echo 'ERROR ('.get_class($e).'): '.$e->getMessage()."\n";
+        echo "RESULT: FAIL (provider rejected)\n";
+    }
+}
+
+// 1) reasoning + forceTools() (tool_choice = required/any)
+attempt("anthropic / {$model} — reasoning + forceTools()", function () use ($model, $weather) {
+    return Atlas::text('anthropic', $model)
+        ->reasoning(ReasoningEffort::Low)
+        ->withTools([$weather])
+        ->forceTools()
+        ->withMaxSteps(4)
+        ->message('What is the weather in Paris? Use the tool.')
+        ->asText();
+});
+
+// 2) reasoning + a specific named tool choice (tool_choice = tool)
+attempt("anthropic / {$model} — reasoning + toolChoice(tool('get_weather'))", function () use ($model, $weather) {
+    return Atlas::text('anthropic', $model)
+        ->reasoning(ReasoningEffort::Low)
+        ->withTools([$weather])
+        ->toolChoice(ToolChoice::tool('get_weather'))
+        ->withMaxSteps(4)
+        ->message('What is the weather in Tokyo? Use the tool.')
+        ->asText();
+});
+
+// 3) Control: reasoning + tools with default (auto) choice — should already work
+attempt("anthropic / {$model} — reasoning + tools (auto choice, control)", function () use ($model, $weather) {
+    return Atlas::text('anthropic', $model)
+        ->reasoning(ReasoningEffort::Low)
+        ->withTools([$weather])
+        ->withMaxSteps(4)
+        ->message('What is the weather in Berlin? Use the tool.')
+        ->asText();
+});
+
+echo "\nDone.\n";

--- a/src/Batch/BatchService.php
+++ b/src/Batch/BatchService.php
@@ -103,7 +103,7 @@ class BatchService
 
             $this->hydrate($job, $response->counts, $results);
         } elseif ($response->status->isTerminal()) {
-            $job->markFailed($response->status, $response->error);
+            $job->markFailed($response->status, $response->counts, $response->error);
             $this->events->dispatch(new BatchFailed($job));
             $this->checkGroup($job);
         } else {

--- a/src/Console/ChunkCommand.php
+++ b/src/Console/ChunkCommand.php
@@ -10,7 +10,6 @@ use Atlasphp\Atlas\Persistence\Models\Chunk;
 use Atlasphp\Atlas\Queue\Jobs\ChunkContentJob;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Sweeps registered chunkable models for dirty rows and dispatches
@@ -79,18 +78,21 @@ class ChunkCommand extends Command
 
         $totalDispatched = 0;
         $totalOrphansDeleted = 0;
+
+        /** @var class-string<Chunk> $chunkModel */
+        $chunkModel = $config->model('chunk', Chunk::class);
+
         // Postgres treats NULL-vs-value as distinct under `IS DISTINCT
         // FROM`, which is the semantics we need (a fresh row has
         // indexed_hash = NULL and content_hash = some-hash, and must be
         // picked up). Other drivers don't have that operator; COALESCE
-        // approximates it.
-        $isPostgres = DB::connection()->getDriverName() === 'pgsql';
+        // approximates it. Detect the driver from the chunk model's own
+        // connection — the sweep queries run against it, and it may be a
+        // separate atlas.persistence.connection that differs from the default.
+        $isPostgres = (new $chunkModel)->getConnection()->getDriverName() === 'pgsql';
         $dirtyPredicate = $isPostgres
             ? 'content_hash IS DISTINCT FROM indexed_hash'
             : "COALESCE(content_hash, '') <> COALESCE(indexed_hash, '')";
-
-        /** @var class-string<Chunk> $chunkModel */
-        $chunkModel = $config->model('chunk', Chunk::class);
 
         foreach ($classes as $class) {
             /** @var class-string<Model> $class */

--- a/src/Embeddings/VectorQueryMacros.php
+++ b/src/Embeddings/VectorQueryMacros.php
@@ -37,12 +37,19 @@ class VectorQueryMacros
     }
 
     /**
-     * Check if the current database connection supports pgvector.
+     * Check if the database connection backing Atlas persistence supports pgvector.
+     *
+     * Uses atlas.persistence.connection when set (vector tables can be routed
+     * to a separate connection), falling back to the framework default. Reading
+     * only the default connection would miss a pgvector connection configured
+     * for persistence while the app default is sqlite/mysql.
      */
     public static function isPgvectorAvailable(): bool
     {
-        return config('database.default') === 'pgsql'
-            || config('database.connections.'.config('database.default').'.driver') === 'pgsql';
+        $connection = config('atlas.persistence.connection') ?: config('database.default');
+
+        return $connection === 'pgsql'
+            || config('database.connections.'.$connection.'.driver') === 'pgsql';
     }
 
     /**

--- a/src/Persistence/Models/BatchJob.php
+++ b/src/Persistence/Models/BatchJob.php
@@ -128,12 +128,20 @@ class BatchJob extends Model
     }
 
     /**
-     * Mark the job failed/expired with a terminal status and message.
+     * Mark the job failed/expired with a terminal status, counts, and message.
+     *
+     * Persists the provider's counts too — a job can end `expired`/`cancelled`
+     * after partially completing, so the succeeded/failed totals must survive on
+     * a terminal-but-not-successful job (group roll-ups and reporting read them).
      */
-    public function markFailed(BatchStatus $status, ?string $error = null): void
+    public function markFailed(BatchStatus $status, RequestCounts $counts, ?string $error = null): void
     {
         $this->update([
             'status' => $status,
+            'total' => $counts->total,
+            'succeeded' => $counts->succeeded,
+            'failed' => $counts->failed,
+            'processing' => $counts->processing,
             'error' => $error,
             'completed_at' => now(),
         ]);

--- a/src/Persistence/Services/ChunkContentService.php
+++ b/src/Persistence/Services/ChunkContentService.php
@@ -219,7 +219,13 @@ class ChunkContentService
         $morphClass = $model->getMorphClass();
         $chunkableId = $model->getKey();
         $now = now();
-        $isPostgres = DB::connection()->getDriverName() === 'pgsql';
+        // Detect Postgres from the chunk model's OWN connection, not the default
+        // one. When persistence is routed to a separate connection
+        // (atlas.persistence.connection) whose driver differs from the app
+        // default, reading the default connection here drops the vector on a
+        // pgvector table (NOT NULL violation) or writes one to a table without
+        // the column. The chunks migration detects the driver the same way.
+        $isPostgres = (new $chunkModel)->getConnection()->getDriverName() === 'pgsql';
 
         $rows = [];
         foreach ($insert as $i => $chunk) {

--- a/src/Providers/Anthropic/Handlers/Text.php
+++ b/src/Providers/Anthropic/Handlers/Text.php
@@ -205,7 +205,15 @@ class Text implements TextHandler
             $body = $this->applyToolChoice($body, $request, $this->tools);
         }
 
-        if ($request->reasoning !== null) {
+        // Anthropic rejects extended thinking alongside a forced tool_choice
+        // (`any` or a specific `tool`). When the caller forces a tool, honor the
+        // force and skip thinking for this turn — mirroring the structured path,
+        // which drops thinking because it forces the schema tool. Without this the
+        // provider 400s ("Thinking may not be enabled when tool_choice forces tool
+        // use"). `auto`/`none` choices are compatible with thinking and pass through.
+        $forcesTool = in_array($body['tool_choice']['type'] ?? null, ['any', 'tool'], true);
+
+        if ($request->reasoning !== null && ! $forcesTool) {
             $budget = $request->reasoning->budgetTokens();
             $body['thinking'] = ['type' => 'enabled', 'budget_tokens' => $budget];
 

--- a/src/Providers/Google/Handlers/Image.php
+++ b/src/Providers/Google/Handlers/Image.php
@@ -48,7 +48,10 @@ class Image implements ImageHandler
             ],
         ];
 
-        $body = array_merge_recursive($body, $request->providerOptions);
+        // array_replace_recursive (not array_merge_recursive): deep-merges nested
+        // generationConfig while overriding colliding scalars instead of turning
+        // them into lists (which Gemini rejects). See Text handler for detail.
+        $body = array_replace_recursive($body, $request->providerOptions);
 
         $data = $this->http->post(
             url: "{$this->config->baseUrl}/v1beta/models/{$request->model}:generateContent",

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -198,7 +198,12 @@ class Text implements TextHandler
             }
         }
 
-        return array_merge_recursive($body, $request->providerOptions);
+        // array_replace_recursive (not array_merge_recursive): deep-merges nested
+        // generationConfig so escape-hatch keys (topP, topK, …) sit alongside the
+        // fields Atlas sets, while a colliding scalar (e.g. temperature) is
+        // overridden rather than turned into a list — array_merge_recursive would
+        // produce ["temperature" => [0.7, 0.2]] and Gemini 400s on the array.
+        return array_replace_recursive($body, $request->providerOptions);
     }
 
     /**

--- a/src/Providers/OpenAi/Handlers/Batch.php
+++ b/src/Providers/OpenAi/Handlers/Batch.php
@@ -75,20 +75,34 @@ class Batch implements BatchHandler
     public function results(string $batchId): iterable
     {
         $batch = $this->fetch($batchId);
-        $outputFileId = $batch['output_file_id'] ?? null;
+        $modality = $this->modalityFromEndpoint((string) ($batch['endpoint'] ?? ''));
 
-        if (! is_string($outputFileId) || $outputFileId === '') {
-            return [];
+        // Successful and per-request HTTP-errored lines land in the output file.
+        // Lines OpenAI rejects before execution (validation failures) land in a
+        // SEPARATE error file — fetch both so every custom_id gets a result and
+        // nothing is silently dropped (the job's `failed` count would otherwise
+        // have no matching per-line record).
+        $results = [];
+
+        foreach (['output_file_id', 'error_file_id'] as $key) {
+            $fileId = $batch[$key] ?? null;
+
+            if (! is_string($fileId) || $fileId === '') {
+                continue;
+            }
+
+            $body = $this->http->getRaw(
+                "{$this->config->baseUrl}/files/{$fileId}/content",
+                $this->headers(),
+                $this->config->timeout,
+            );
+
+            foreach ($this->parseResults($body, $modality) as $result) {
+                $results[] = $result;
+            }
         }
 
-        $modality = $this->modalityFromEndpoint((string) ($batch['endpoint'] ?? ''));
-        $body = $this->http->getRaw(
-            "{$this->config->baseUrl}/files/{$outputFileId}/content",
-            $this->headers(),
-            $this->config->timeout,
-        );
-
-        return $this->parseResults($body, $modality);
+        return $results;
     }
 
     public function cancel(string $batchId): BatchResponse

--- a/tests/Feature/Persistence/BatchPersistenceTest.php
+++ b/tests/Feature/Persistence/BatchPersistenceTest.php
@@ -117,7 +117,8 @@ it('marks the job failed and fires BatchFailed on a terminal failure', function 
     $job = BatchJob::create(['provider' => 'openai', 'modality' => 'embed', 'batch_id' => 'b', 'status' => BatchStatus::InProgress]);
 
     $driver = Mockery::mock(Driver::class);
-    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Expired, new RequestCounts(total: 1)));
+    // Expired after partial completion: 6 of 10 succeeded before the window closed.
+    $driver->shouldReceive('batchStatus')->andReturn(new BatchResponse('b', BatchStatus::Expired, new RequestCounts(total: 10, succeeded: 6, failed: 4)));
 
     $registry = Mockery::mock(ProviderRegistryContract::class);
     $registry->shouldReceive('resolve')->andReturn($driver);
@@ -125,6 +126,10 @@ it('marks the job failed and fires BatchFailed on a terminal failure', function 
     $synced = batchService($registry)->syncFromProvider($job);
 
     expect($synced->status)->toBe(BatchStatus::Expired);
+    // Counts from the provider must survive on a terminal-but-not-successful job.
+    expect($synced->total)->toBe(10);
+    expect($synced->succeeded)->toBe(6);
+    expect($synced->failed)->toBe(4);
     Event::assertDispatched(BatchFailed::class);
 });
 

--- a/tests/Unit/Embeddings/VectorQueryMacrosTest.php
+++ b/tests/Unit/Embeddings/VectorQueryMacrosTest.php
@@ -28,6 +28,15 @@ it('returns true when default connection driver is pgsql', function () {
     expect(VectorQueryMacros::isPgvectorAvailable())->toBeTrue();
 });
 
+it('returns true when persistence is routed to a pgsql connection while the default is sqlite', function () {
+    config(['database.default' => 'sqlite']);
+    config(['database.connections.sqlite.driver' => 'sqlite']);
+    config(['atlas.persistence.connection' => 'atlas_pg']);
+    config(['database.connections.atlas_pg.driver' => 'pgsql']);
+
+    expect(VectorQueryMacros::isPgvectorAvailable())->toBeTrue();
+});
+
 // ─── toVectorLiteral ────────────────────────────────────────────────────────
 
 it('converts float array to pgvector literal', function () {

--- a/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Anthropic/Handlers/TextHandlerTest.php
@@ -443,6 +443,32 @@ it('bumps max_tokens above the thinking budget and drops temperature', function 
     Http::assertSent(fn ($request) => $request['max_tokens'] === 8192 + 4096 && ! isset($request['temperature']));
 });
 
+it('drops the thinking block when a tool is forced, honoring the forced tool', function () {
+    Http::fake(['api.anthropic.com/*' => Http::response(fakeAnthropicTextResponse())]);
+
+    // Anthropic 400s if `thinking` is sent with a forced tool_choice (any/tool).
+    // The forced choice must win and thinking must be dropped for this turn.
+    makeAnthropicTextHandler()->text(makeAnthropicTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        'toolChoice' => ToolChoice::required(),
+        'reasoning' => new Reasoning(ReasoningEffort::Medium),
+    ]));
+
+    Http::assertSent(fn ($request) => $request['tool_choice'] === ['type' => 'any'] && ! isset($request['thinking']));
+});
+
+it('keeps thinking when the tool choice is auto (compatible with thinking)', function () {
+    Http::fake(['api.anthropic.com/*' => Http::response(fakeAnthropicTextResponse())]);
+
+    makeAnthropicTextHandler()->text(makeAnthropicTextRequest([
+        'tools' => [new ToolDefinition('get_weather', 'Get weather', ['type' => 'object'])],
+        'toolChoice' => ToolChoice::auto(),
+        'reasoning' => new Reasoning(ReasoningEffort::Medium),
+    ]));
+
+    Http::assertSent(fn ($request) => $request['tool_choice'] === ['type' => 'auto'] && $request['thinking']['type'] === 'enabled');
+});
+
 it('omits the thinking block when reasoning is not set', function () {
     Http::fake([
         'api.anthropic.com/*' => Http::response([

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -193,6 +193,38 @@ it('includes generationConfig with maxOutputTokens and temperature', function ()
     });
 });
 
+it('deep-merges providerOptions generationConfig keys alongside the fields Atlas sets', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse()),
+    ]);
+
+    $handler = makeGoogleTextHandler();
+    $handler->text(makeGoogleTextRequest([
+        'temperature' => 0.7,
+        'providerOptions' => ['generationConfig' => ['topP' => 0.9]],
+    ]));
+
+    Http::assertSent(function ($request) {
+        return $request['generationConfig']['temperature'] === 0.7
+            && $request['generationConfig']['topP'] === 0.9;
+    });
+});
+
+it('overrides a colliding generationConfig scalar instead of turning it into a list', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse()),
+    ]);
+
+    $handler = makeGoogleTextHandler();
+    $handler->text(makeGoogleTextRequest([
+        'temperature' => 0.7,
+        'providerOptions' => ['generationConfig' => ['temperature' => 0.2]],
+    ]));
+
+    // array_merge_recursive would emit ["temperature" => [0.7, 0.2]] and Gemini 400s.
+    Http::assertSent(fn ($request) => $request['generationConfig']['temperature'] === 0.2);
+});
+
 it('sets responseMimeType and responseSchema for structured output', function () {
     Http::fake([
         'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse(['text' => '{"name":"John"}'])),

--- a/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/BatchHandlerTest.php
@@ -180,6 +180,30 @@ it('parses completed embedding results via the embed parser', function () {
     expect($results[1]->error->getMessage())->toBe('bad input');
 });
 
+it('reads validation-rejected lines from the error file too, not just the output file', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldReceive('get')->once()->andReturn([
+        'id' => 'b', 'status' => 'completed', 'endpoint' => '/v1/responses',
+        'output_file_id' => 'file_out', 'error_file_id' => 'file_err',
+    ]);
+
+    $outputJsonl = json_encode(['custom_id' => 't1', 'response' => ['status_code' => 200, 'body' => ['output' => [['type' => 'message', 'content' => [['type' => 'output_text', 'text' => 'HELLO']]]], 'usage' => ['input_tokens' => 5, 'output_tokens' => 1]]]]);
+    $errorJsonl = json_encode(['custom_id' => 't2', 'error' => ['message' => 'invalid model']]);
+
+    // Output file fetched first, then the error file — both parsed.
+    $http->shouldReceive('getRaw')->once()->with(Mockery::pattern('/file_out/'), Mockery::any(), Mockery::any())->andReturn($outputJsonl);
+    $http->shouldReceive('getRaw')->once()->with(Mockery::pattern('/file_err/'), Mockery::any(), Mockery::any())->andReturn($errorJsonl);
+
+    $results = iterator_to_array(openAiBatchHandler($http)->results('b'));
+
+    expect($results)->toHaveCount(2);
+    expect($results[0]->customId)->toBe('t1');
+    expect($results[0]->status)->toBe(BatchResultStatus::Succeeded);
+    expect($results[1]->customId)->toBe('t2');
+    expect($results[1]->status)->toBe(BatchResultStatus::Errored);
+    expect($results[1]->error->getMessage())->toBe('invalid model');
+});
+
 it('throws when the input-file upload returns no id', function () {
     $http = Mockery::mock(HttpClient::class);
     $http->shouldReceive('postMultipart')->once()->andReturn(['object' => 'file']); // no 'id'


### PR DESCRIPTION
Multiple fixes and enhancements:

- Persistence/pgvector: Detect pgvector on the atlas.persistence.connection instead of the app default. VectorQueryMacros, ChunkCommand, and ChunkContentService now check the chunk/persistence connection driver so chunk writes and similarity searches work when persistence uses a separate Postgres connection. Added unit test and changelog/docs notes.

- Anthropic text handler: Skip/omit the `thinking` block when a forced tool_choice (`any` or `tool`) is present so Anthropic doesn't 400; `auto` still allows thinking. Added tests and a sandbox repro.

- Google handlers: Use array_replace_recursive when merging providerOptions (generationConfig) to override colliding scalars instead of producing arrays that Gemini rejects. Tests added to ensure deep-merge and scalar override behavior.

- OpenAI batch handler: Read both output and error files (output_file_id and error_file_id) so validation-rejected lines in the error file are parsed and not dropped. Adjusted tests accordingly.

- Batch counts: Persist provider RequestCounts on terminal job states. BatchJob::markFailed signature updated to accept counts and BatchService now passes counts; tests updated to assert preserved totals.

- Misc: Added sandbox repro script and adjusted changelog/docs. Unit and feature tests updated to cover these behaviors.