### PR TITLE
Map Document inputs to OpenAI input_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Google (Gemini) tool calls no longer 400 on non-object results (number, boolean, array, quoted string) — wrapped automatically. Plain strings and JSON objects are unchanged.
 - Google (Gemini) `withProviderOptions()` no longer corrupts nested `generationConfig` fields — extra keys (e.g. `topP`) merge alongside Atlas's values, and an overridden key (e.g. `temperature`) now replaces the value instead of becoming a list Gemini rejects with a 400.
 - Chunked embeddings now work when persistence runs on a separate Postgres connection (`atlas.persistence.connection`) and the app default isn't Postgres — pgvector is detected on the persistence connection, so chunk writes and similarity search no longer fail.
+- OpenAI (and xAI) document inputs now send the correct `input_file` content part instead of `input_image`, so attaching a `Document` (PDF, Word, Excel, CSV, text, Markdown, …) works — previously non-file-ID documents were sent as images and rejected with a 400. URLs pass through as `file_url`; base64/path/storage/upload inline as `file_data`.
 
 ### Migration
 

--- a/src/Providers/OpenAi/MediaResolver.php
+++ b/src/Providers/OpenAi/MediaResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atlasphp\Atlas\Providers\OpenAi;
 
+use Atlasphp\Atlas\Input\Document;
 use Atlasphp\Atlas\Input\Input;
 use Atlasphp\Atlas\Providers\Concerns\ResolvesMediaUri;
 use Atlasphp\Atlas\Providers\Contracts\MediaResolverContract;
@@ -11,7 +12,7 @@ use Atlasphp\Atlas\Providers\Contracts\MediaResolverContract;
 /**
  * Converts Atlas Input types into OpenAI Responses API content parts.
  *
- * Maps media inputs to `input_image` or `input_file` content part format.
+ * Maps document inputs to `input_file` parts and other media to `input_image`.
  */
 class MediaResolver implements MediaResolverContract
 {
@@ -29,9 +30,82 @@ class MediaResolver implements MediaResolverContract
             ];
         }
 
+        if ($input instanceof Document) {
+            return $this->resolveDocument($input);
+        }
+
         return [
             'type' => 'input_image',
             'image_url' => $this->resolveToUri($input),
         ];
+    }
+
+    /**
+     * Resolve a document into an OpenAI `input_file` content part.
+     *
+     * URLs are passed through as `file_url` (OpenAI fetches them); every other
+     * source is inlined as a base64 `file_data` data URI with a filename, which
+     * OpenAI requires to infer the file type.
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveDocument(Document $input): array
+    {
+        if ($input->isUrl()) {
+            return [
+                'type' => 'input_file',
+                'file_url' => (string) $input->url(),
+            ];
+        }
+
+        return [
+            'type' => 'input_file',
+            'filename' => $this->documentFilename($input->mimeType()),
+            'file_data' => $this->resolveToUri($input),
+        ];
+    }
+
+    /**
+     * Derive a filename from the document's MIME type. OpenAI requires a
+     * filename alongside `file_data` and uses its extension to decide how to
+     * parse the file, so the extension must reflect the actual format. The map
+     * covers the document types OpenAI accepts inline; unrecognized types fall
+     * back to the MIME subtype (e.g. `application/foo` -> `foo`) and finally
+     * `bin`, rather than mislabeling everything as a PDF.
+     */
+    private function documentFilename(string $mimeType): string
+    {
+        $extension = match ($mimeType) {
+            'application/pdf' => 'pdf',
+            'text/plain' => 'txt',
+            'text/markdown' => 'md',
+            'text/html' => 'html',
+            'text/xml', 'application/xml' => 'xml',
+            'text/csv' => 'csv',
+            'text/tab-separated-values' => 'tsv',
+            'application/json' => 'json',
+            'application/rtf', 'text/rtf' => 'rtf',
+            'application/msword' => 'doc',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+            'application/vnd.oasis.opendocument.text' => 'odt',
+            'application/vnd.ms-excel' => 'xls',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+            'application/vnd.ms-powerpoint' => 'ppt',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+            default => $this->extensionFromSubtype($mimeType),
+        };
+
+        return "document.{$extension}";
+    }
+
+    /**
+     * Best-effort extension for an unmapped MIME type: use the subtype when it
+     * looks like a plain extension, otherwise `bin`.
+     */
+    private function extensionFromSubtype(string $mimeType): string
+    {
+        $subtype = substr((string) strrchr($mimeType, '/'), 1);
+
+        return $subtype !== '' && preg_match('/^[a-z0-9]+$/i', $subtype) === 1 ? $subtype : 'bin';
     }
 }

--- a/tests/Unit/Providers/OpenAi/MediaResolverTest.php
+++ b/tests/Unit/Providers/OpenAi/MediaResolverTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Atlasphp\Atlas\Input\Document;
 use Atlasphp\Atlas\Input\Image;
 use Atlasphp\Atlas\Providers\OpenAi\MediaResolver;
 
@@ -54,4 +55,93 @@ it('resolves file path to input_image with encoded data', function () {
     expect(base64_decode(str_replace('data:image/jpeg;base64,', '', $result['image_url'])))->toBe('fake-image-data');
 
     unlink($tempFile);
+});
+
+it('resolves a base64 document to input_file with filename and file_data', function () {
+    $resolver = new MediaResolver;
+    $input = Document::fromBase64('JVBERi0=', 'application/pdf');
+
+    $result = $resolver->resolve($input);
+
+    expect($result)->toBe([
+        'type' => 'input_file',
+        'filename' => 'document.pdf',
+        'file_data' => 'data:application/pdf;base64,JVBERi0=',
+    ]);
+});
+
+it('resolves a URL document to input_file with file_url (not downloaded)', function () {
+    $resolver = new MediaResolver;
+    $input = Document::fromUrl('https://example.com/report.pdf');
+
+    $result = $resolver->resolve($input);
+
+    expect($result)->toBe([
+        'type' => 'input_file',
+        'file_url' => 'https://example.com/report.pdf',
+    ]);
+});
+
+it('resolves a document path to input_file with encoded file_data', function () {
+    $resolver = new MediaResolver;
+    $tempFile = tempnam(sys_get_temp_dir(), 'atlas_doc_');
+    file_put_contents($tempFile, 'fake-pdf-bytes');
+
+    $input = Document::fromPath($tempFile, 'application/pdf');
+    $result = $resolver->resolve($input);
+
+    expect($result['type'])->toBe('input_file');
+    expect($result['filename'])->toBe('document.pdf');
+    expect($result['file_data'])->toStartWith('data:application/pdf;base64,');
+    expect(base64_decode(str_replace('data:application/pdf;base64,', '', $result['file_data'])))->toBe('fake-pdf-bytes');
+
+    unlink($tempFile);
+});
+
+it('derives the filename extension for every supported document mime type', function (string $mime, string $expected) {
+    $resolver = new MediaResolver;
+
+    expect($resolver->resolve(Document::fromBase64('eA==', $mime))['filename'])->toBe($expected);
+})->with([
+    'pdf' => ['application/pdf', 'document.pdf'],
+    'txt' => ['text/plain', 'document.txt'],
+    'markdown' => ['text/markdown', 'document.md'],
+    'html' => ['text/html', 'document.html'],
+    'xml (text)' => ['text/xml', 'document.xml'],
+    'xml (application)' => ['application/xml', 'document.xml'],
+    'csv' => ['text/csv', 'document.csv'],
+    'tsv' => ['text/tab-separated-values', 'document.tsv'],
+    'json' => ['application/json', 'document.json'],
+    'rtf (application)' => ['application/rtf', 'document.rtf'],
+    'rtf (text)' => ['text/rtf', 'document.rtf'],
+    'doc' => ['application/msword', 'document.doc'],
+    'docx' => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'document.docx'],
+    'odt' => ['application/vnd.oasis.opendocument.text', 'document.odt'],
+    'xls' => ['application/vnd.ms-excel', 'document.xls'],
+    'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'document.xlsx'],
+    'ppt' => ['application/vnd.ms-powerpoint', 'document.ppt'],
+    'pptx' => ['application/vnd.openxmlformats-officedocument.presentationml.presentation', 'document.pptx'],
+]);
+
+it('falls back to the mime subtype, then bin, for unmapped document types', function (string $mime, string $expected) {
+    $resolver = new MediaResolver;
+
+    expect($resolver->resolve(Document::fromBase64('eA==', $mime))['filename'])->toBe($expected);
+})->with([
+    'extension-like subtype is reused' => ['application/yaml', 'document.yaml'],
+    'vendor subtype (not a clean token) -> bin' => ['application/vnd.custom-thing', 'document.bin'],
+    'empty subtype -> bin' => ['application/', 'document.bin'],
+    'mime with no slash -> bin' => ['octet-stream', 'document.bin'],
+]);
+
+it('resolves a document file ID to input_file', function () {
+    $resolver = new MediaResolver;
+    $input = Document::fromFileId('file-doc789');
+
+    $result = $resolver->resolve($input);
+
+    expect($result)->toBe([
+        'type' => 'input_file',
+        'file_id' => 'file-doc789',
+    ]);
 });


### PR DESCRIPTION
Treat Document inputs as OpenAI `input_file` parts instead of `input_image`. Adds resolveDocument() to MediaResolver to emit `file_url` for URL documents or `filename` + base64 `file_data` for inline documents, with a documentFilename() map and extensionFromSubtype() fallback. Updates unit tests to cover URL, base64, path, file-id cases and various MIME types, and adds a changelog entry about correct document handling for OpenAI/xAI providers.