### PR TITLE
Pass provider through SSE parsing; add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `Atlas::batch()` submits large request sets as deferred jobs for ~50% lower cost — OpenAI (text, vision, embeddings), Anthropic and Google/Gemini (text, vision). With persistence on, `submit()` auto-tracks the job, `atlas:batch-poll` pulls results in keyed to your records by `custom_id`, and `atlas:batch-prune` bounds history (`atlas.batch.retention_days`, default 90); with it off, batching is stateless and you poll the provider yourself. Tools and per-request middleware aren't supported and are rejected up front.
+- `Atlas::batch()` submits large request sets as deferred jobs for ~50% lower cost — OpenAI (text, vision, embeddings), Anthropic and Google/Gemini (text, vision). With persistence on, `submit()` auto-tracks the job, `atlas:batch-poll` pulls results in keyed by `custom_id`, and `atlas:batch-prune` bounds history (`atlas.batch.retention_days`, default 90); with it off, batching is stateless and you poll the provider yourself. Tools and per-request middleware aren't supported and are rejected up front.
 - `->reasoning(ReasoningEffort)` on text and agent requests (and an `Agent::reasoning()` default) enables extended thinking at one effort level (`Minimal`/`Low`/`Medium`/`High`), mapped to each provider's format. Optional `budgetTokens:` and `includeSummary:`.
 - `->countTokens()` on text and agent requests returns input-token count before sending — exact on Anthropic/OpenAI/Google, estimated on xAI/Ollama/LM Studio. Returns a `TokenCount` with an `estimated` flag.
 
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Google (Gemini) `withProviderOptions()` no longer corrupts nested `generationConfig` fields — extra keys (e.g. `topP`) merge alongside Atlas's values, and an overridden key (e.g. `temperature`) now replaces the value instead of becoming a list Gemini rejects with a 400.
 - Chunked embeddings now work when persistence runs on a separate Postgres connection (`atlas.persistence.connection`) and the app default isn't Postgres — pgvector is detected on the persistence connection, so chunk writes and similarity search no longer fail.
 - OpenAI (and xAI) document inputs now send the correct `input_file` content part instead of `input_image`, so attaching a `Document` (PDF, Word, Excel, CSV, text, Markdown, …) works — previously non-file-ID documents were sent as images and rejected with a 400. URLs pass through as `file_url`; base64/path/storage/upload inline as `file_data`.
+- xAI streaming errors are now attributed to `xai`, not `openai` — a mid-stream error through the shared Responses parser previously carried `$provider === 'openai'`, misattributing xAI failures for anything branching on the provider (retry/fallback, metrics, logging).
 
 ### Migration
 

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -91,7 +91,7 @@ class Text implements TextHandler
             context: new ProviderRequestContext($this->config->provider, $request->model),
         );
 
-        return new StreamResponse($this->parseSSE($raw, $request->model));
+        return new StreamResponse($this->parseSSE($raw, $request->model, $this->config->provider ?: 'openai'));
     }
 
     public function structured(TextRequest $request): StructuredResponse
@@ -242,10 +242,10 @@ class Text implements TextHandler
      *
      * @return Generator<int, StreamChunk>
      */
-    protected function parseSSE(mixed $rawResponse, string $model = ''): Generator
+    protected function parseSSE(mixed $rawResponse, string $model = '', string $provider = 'openai'): Generator
     {
         foreach (SseParser::parse($rawResponse) as $event) {
-            yield $this->parser->parseStreamChunk($event, $model);
+            yield $this->parser->parseStreamChunk($event, $model, $provider);
         }
     }
 }

--- a/src/Providers/OpenAi/ResponseParser.php
+++ b/src/Providers/OpenAi/ResponseParser.php
@@ -155,10 +155,12 @@ class ResponseParser implements ResponseParserContract
      * Parse a streaming event into a StreamChunk.
      *
      * Receives an array with 'event' (the SSE event name) and 'data' (parsed JSON).
+     * The provider name is threaded through (like $model) so mid-stream errors are
+     * attributed to the real provider — this parser is shared by OpenAI and xAI.
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
+    public function parseStreamChunk(array $data, string $model = '', string $provider = 'openai'): StreamChunk
     {
         $event = (string) ($data['event'] ?? '');
         /** @var array<string, mixed> $payload */
@@ -212,7 +214,7 @@ class ResponseParser implements ResponseParserContract
             $error = $payload['response']['error'] ?? $payload['error'] ?? $payload;
             $error = is_array($error) ? $error : ['message' => (string) $error];
 
-            throw ProviderException::fromStreamError('openai', $model, $error);
+            throw ProviderException::fromStreamError($provider, $model, $error);
         }
 
         return new StreamChunk(type: ChunkType::Text, text: null);

--- a/tests/Feature/Persistence/AgentRequestPersistenceTest.php
+++ b/tests/Feature/Persistence/AgentRequestPersistenceTest.php
@@ -6,6 +6,7 @@ use Atlasphp\Atlas\Agent;
 use Atlasphp\Atlas\AgentRegistry;
 use Atlasphp\Atlas\AtlasConfig;
 use Atlasphp\Atlas\Enums\Provider;
+use Atlasphp\Atlas\Input\Document;
 use Atlasphp\Atlas\Input\Image;
 use Atlasphp\Atlas\Pending\AgentRequest;
 use Atlasphp\Atlas\Persistence\Concerns\HasConversations;
@@ -201,6 +202,37 @@ it('stores eager media attachments as assets linked to the message', function ()
         ->and(ConversationMessageAsset::where('message_id', $message->id)->where('asset_id', $asset->id)->count())->toBe(1);
 
     Storage::disk($asset->disk)->assertExists($asset->path);
+});
+
+it('stores an attached document as an AssetType::Document asset', function () {
+    config(['filesystems.default' => 'local']);
+    Storage::fake('local');
+
+    registerPersistAgent(PersistTestConversationAgent::class);
+    setupPersistFake();
+
+    $conversation = Conversation::factory()->create();
+
+    $request = makePersistRequest('persist-conv')
+        ->message('Summarize this file', [Document::fromBase64(base64_encode('%PDF-1.4 fake'), 'application/pdf')])
+        ->forConversation($conversation->id);
+
+    (new ReflectionMethod($request, 'storeUserMessageEagerly'))->invoke($request);
+
+    $message = ConversationMessage::where('conversation_id', $conversation->id)->first();
+    expect($message)->not->toBeNull();
+
+    $asset = Asset::first();
+    expect(Asset::count())->toBe(1)
+        ->and($asset->type)->toBe(AssetType::Document)
+        ->and($asset->mime_type)->toBe('application/pdf')
+        ->and(ConversationMessageAsset::where('message_id', $message->id)->where('asset_id', $asset->id)->count())->toBe(1);
+
+    Storage::disk($asset->disk)->assertExists($asset->path);
+
+    // The stored document round-trips back to a Document input on reload.
+    $reloaded = $message->toAtlasMessage();
+    expect(collect($reloaded->media)->contains(fn ($m) => $m instanceof Document))->toBeTrue();
 });
 
 it('sets conversation title from first user message', function () {

--- a/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/TextHandlerTest.php
@@ -266,6 +266,7 @@ it('a mid-stream error while streaming throws a ProviderException carrying the m
     expect($caught)->not->toBeNull();
     expect($caught->model)->toBe('gpt-4o');
     expect($caught->providerMessage)->toBe('boom');
+    expect($caught->provider)->toBe('openai');
 });
 
 it('forwards the request config to the HTTP layer when streaming', function () {

--- a/tests/Unit/Providers/OpenAi/ResponseParserTest.php
+++ b/tests/Unit/Providers/OpenAi/ResponseParserTest.php
@@ -278,6 +278,38 @@ it('a mid-stream error carries the model passed to the parser', function () {
     expect($caught->model)->toBe('gpt-4o');
 });
 
+it('a mid-stream error defaults to the openai provider', function () {
+    $caught = null;
+
+    try {
+        makeParser()->parseStreamChunk([
+            'event' => 'error',
+            'data' => ['error' => ['message' => 'boom']],
+        ], 'gpt-4o');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught?->provider)->toBe('openai');
+});
+
+it('a mid-stream error is attributed to the provider passed to the parser', function () {
+    $caught = null;
+
+    try {
+        makeParser()->parseStreamChunk([
+            'event' => 'error',
+            'data' => ['error' => ['message' => 'boom']],
+        ], 'grok-4', 'xai');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    // The shared OpenAI parser is reused by xAI; the error must say xai, not openai.
+    expect($caught?->provider)->toBe('xai');
+    expect($caught?->getMessage())->toContain('Provider [xai]');
+});
+
 it('returns empty text chunk for unknown events', function () {
     $parser = makeParser();
 

--- a/tests/Unit/Providers/Xai/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Xai/Handlers/TextHandlerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ReasoningEffort;
+use Atlasphp\Atlas\Exceptions\ProviderException;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Providers\OpenAi\MediaResolver;
 use Atlasphp\Atlas\Providers\OpenAi\ResponseParser;
@@ -26,7 +27,7 @@ function makeXaiTextHandler(?HttpClient $http = null): Text
     $toolMapper = new ToolMapper;
 
     return new Text(
-        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.x.ai/v1']),
+        config: ProviderConfig::fromArray(['api_key' => 'test-key', 'url' => 'https://api.x.ai/v1', 'provider' => 'xai']),
         http: $http ?? app(HttpClient::class),
         messages: new MessageFactory,
         media: new MediaResolver,
@@ -68,6 +69,30 @@ it('forwards the request config to the HTTP layer (post and stream)', function (
     $handler = makeXaiTextHandler($http);
     $handler->text(makeXaiHandlerTextRequest(['requestConfig' => $config]));
     $handler->stream(makeXaiHandlerTextRequest(['requestConfig' => $config]));
+});
+
+it('attributes a mid-stream error to xai, not openai (shared OpenAI parser)', function () {
+    Http::fake([
+        'api.x.ai/v1/responses' => Http::response(
+            "event: response.failed\ndata: {\"response\":{\"error\":{\"message\":\"boom\"}}}\n\n",
+            200,
+        ),
+    ]);
+
+    $caught = null;
+
+    try {
+        foreach (makeXaiTextHandler()->stream(makeXaiHandlerTextRequest(['model' => 'grok-4'])) as $chunk) {
+            // consume the stream
+        }
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->provider)->toBe('xai');
+    expect($caught->model)->toBe('grok-4');
+    expect($caught->getMessage())->toContain('Provider [xai]');
 });
 
 it('does not include instructions in body', function () {


### PR DESCRIPTION
Thread the provider name through SSE parsing so mid-stream errors are attributed to the correct provider. Updated Text handler to pass provider to parseSSE (defaulting to 'openai'), and updated ResponseParser::parseStreamChunk to accept a provider argument and use it when throwing ProviderException. Added unit tests to assert the default provider and provider attribution for mid-stream errors, and added a feature test to verify Document inputs are persisted as AssetType::Document (plus the required import).