### PR TITLE
Use configured provider name and fix parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Extended thinking now works through multi-step tool calls and persisted-conversation reloads.
 - Google (Gemini) tool calls no longer 400 on non-object results (number, boolean, array, quoted string) — wrapped automatically. Plain strings and JSON objects are unchanged.
 - Google (Gemini) `withProviderOptions()` no longer corrupts nested `generationConfig` fields — extra keys (e.g. `topP`) merge alongside Atlas's values, and an overridden key (e.g. `temperature`) now replaces the value instead of becoming a list Gemini rejects with a 400.
+- Google (Gemini) now honors `temperature: 0.0` instead of silently dropping it, so deterministic output works.
+- Streaming Google (Gemini) tool calls now surface `FinishReason::ToolCalls` and keep every call when several arrive in one chunk — previously a streamed, tool-terminated response lost its finish reason and could drop a parallel call.
 - Chunked embeddings now work when persistence runs on a separate Postgres connection (`atlas.persistence.connection`) and the app default isn't Postgres — pgvector is detected on the persistence connection, so chunk writes and similarity search no longer fail.
 - OpenAI (and xAI) document inputs now send the correct `input_file` content part instead of `input_image`, so attaching a `Document` (PDF, Word, Excel, CSV, text, Markdown, …) works — previously non-file-ID documents were sent as images and rejected with a 400. URLs pass through as `file_url`; base64/path/storage/upload inline as `file_data`.
-- xAI streaming errors are now attributed to `xai`, not `openai` — a mid-stream error through the shared Responses parser previously carried `$provider === 'openai'`, misattributing xAI failures for anything branching on the provider (retry/fallback, metrics, logging).
-- Providers built on the shared `chat_completions`/`responses` drivers (Ollama, Groq, LM Studio, custom OpenAI-compatible endpoints) now report the configured provider key in exceptions, transport events, and middleware — previously failures were attributed to the generic driver type (`chat_completions`), so two such providers were indistinguishable when branching on the provider.
-- Google (Gemini) now honors `temperature: 0.0` instead of silently dropping it, so requests for deterministic output are no longer ignored.
-- Google (Gemini) tool calls made during streaming now surface `FinishReason::ToolCalls` and keep every tool call when several arrive in one chunk — previously a streamed, tool-terminated response lost its finish reason and could drop a parallel call.
+- xAI streaming errors are now attributed to `xai`, not `openai` — a mid-stream error through the shared Responses parser previously carried `$provider === 'openai'`, misattributing xAI failures for anything branching on the provider.
+- Providers on the shared `chat_completions`/`responses` drivers (Ollama, Groq, LM Studio, custom OpenAI-compatible endpoints) now report their configured provider key in exceptions, events, and middleware — previously failures were attributed to the generic driver type (`chat_completions`), making two such providers indistinguishable.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 - Chunked embeddings now work when persistence runs on a separate Postgres connection (`atlas.persistence.connection`) and the app default isn't Postgres — pgvector is detected on the persistence connection, so chunk writes and similarity search no longer fail.
 - OpenAI (and xAI) document inputs now send the correct `input_file` content part instead of `input_image`, so attaching a `Document` (PDF, Word, Excel, CSV, text, Markdown, …) works — previously non-file-ID documents were sent as images and rejected with a 400. URLs pass through as `file_url`; base64/path/storage/upload inline as `file_data`.
 - xAI streaming errors are now attributed to `xai`, not `openai` — a mid-stream error through the shared Responses parser previously carried `$provider === 'openai'`, misattributing xAI failures for anything branching on the provider (retry/fallback, metrics, logging).
+- Providers built on the shared `chat_completions`/`responses` drivers (Ollama, Groq, LM Studio, custom OpenAI-compatible endpoints) now report the configured provider key in exceptions, transport events, and middleware — previously failures were attributed to the generic driver type (`chat_completions`), so two such providers were indistinguishable when branching on the provider.
+- Google (Gemini) now honors `temperature: 0.0` instead of silently dropping it, so requests for deterministic output are no longer ignored.
+- Google (Gemini) tool calls made during streaming now surface `FinishReason::ToolCalls` and keep every tool call when several arrive in one chunk — previously a streamed, tool-terminated response lost its finish reason and could drop a parallel call.
 
 ### Migration
 

--- a/src/Pending/Concerns/ResolvesProvider.php
+++ b/src/Pending/Concerns/ResolvesProvider.php
@@ -28,7 +28,9 @@ trait ResolvesProvider
     protected function ensureCapability(Driver $driver, string $feature): void
     {
         if (! $driver->capabilities()->supports($feature)) {
-            throw UnsupportedFeatureException::make($feature, $driver->name());
+            // Report the configured provider key (e.g. 'groq'), not the shared
+            // driver type returned by name() (e.g. 'chat_completions').
+            throw UnsupportedFeatureException::make($feature, $this->resolveProviderKey());
         }
     }
 

--- a/src/Providers/Anthropic/ResponseParser.php
+++ b/src/Providers/Anthropic/ResponseParser.php
@@ -130,7 +130,7 @@ class ResponseParser implements ResponseParserContract
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
+    public function parseStreamChunk(array $data, string $model = '', string $provider = 'anthropic'): StreamChunk
     {
         $event = $data['event'] ?? '';
         $payload = $data['data'] ?? [];
@@ -138,7 +138,7 @@ class ResponseParser implements ResponseParserContract
         if ($event === 'error') {
             $error = $payload['error'] ?? $payload;
 
-            throw ProviderException::fromStreamError('anthropic', $model, is_array($error) ? $error : ['message' => (string) $error]);
+            throw ProviderException::fromStreamError($provider, $model, is_array($error) ? $error : ['message' => (string) $error]);
         }
 
         if ($event === 'content_block_delta') {

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -75,7 +75,7 @@ class Text implements TextHandler
             context: new ProviderRequestContext($this->config->provider, $request->model),
         );
 
-        return new StreamResponse($this->parseSSE($raw, $request->model));
+        return new StreamResponse($this->parseSSE($raw, $request->model, $this->config->provider ?: 'chat_completions'));
     }
 
     public function structured(TextRequest $request): StructuredResponse
@@ -161,7 +161,7 @@ class Text implements TextHandler
      *
      * @return Generator<int, StreamChunk>
      */
-    protected function parseSSE(mixed $rawResponse, string $model = ''): Generator
+    protected function parseSSE(mixed $rawResponse, string $model = '', string $provider = 'chat_completions'): Generator
     {
         /** @var array<int, array{id: string, name: string, arguments: string}> $toolBlocks */
         $toolBlocks = [];
@@ -210,7 +210,7 @@ class Text implements TextHandler
                 $toolBlocks = [];
             }
 
-            yield $this->parser->parseStreamChunk($data, $model);
+            yield $this->parser->parseStreamChunk($data, $model, $provider);
         }
     }
 

--- a/src/Providers/ChatCompletions/Handlers/Text.php
+++ b/src/Providers/ChatCompletions/Handlers/Text.php
@@ -75,7 +75,7 @@ class Text implements TextHandler
             context: new ProviderRequestContext($this->config->provider, $request->model),
         );
 
-        return new StreamResponse($this->parseSSE($raw, $request->model, $this->config->provider ?: 'chat_completions'));
+        return new StreamResponse($this->parseSSE($raw, $request->model, $this->config->providerName('chat_completions')));
     }
 
     public function structured(TextRequest $request): StructuredResponse

--- a/src/Providers/ChatCompletions/ResponseParser.php
+++ b/src/Providers/ChatCompletions/ResponseParser.php
@@ -91,12 +91,12 @@ class ResponseParser implements ResponseParserContract
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
+    public function parseStreamChunk(array $data, string $model = '', string $provider = 'chat_completions'): StreamChunk
     {
         if (isset($data['error'])) {
             $error = is_array($data['error']) ? $data['error'] : ['message' => (string) $data['error']];
 
-            throw ProviderException::fromStreamError('chat_completions', $model, $error);
+            throw ProviderException::fromStreamError($provider, $model, $error);
         }
 
         /** @var array<string, mixed> $delta */

--- a/src/Providers/Contracts/ResponseParserContract.php
+++ b/src/Providers/Contracts/ResponseParserContract.php
@@ -30,7 +30,13 @@ interface ResponseParserContract
     public function parseFinishReason(array $data): FinishReason;
 
     /**
+     * Parse a streaming event into a StreamChunk.
+     *
+     * The provider name is threaded through (alongside $model) so a mid-stream
+     * error is attributed to the configured provider — parsers shared across
+     * providers (OpenAI/xAI, the chat_completions drivers) must not hardcode it.
+     *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data, string $model = ''): StreamChunk;
+    public function parseStreamChunk(array $data, string $model = '', string $provider = ''): StreamChunk;
 }

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -399,7 +399,7 @@ abstract class Driver
      */
     protected function providerName(): string
     {
-        return $this->config->provider !== '' ? $this->config->provider : $this->name();
+        return $this->config->providerName($this->name());
     }
 
     // ─── Error Handling ──────────────────────────────────────────────────

--- a/src/Providers/Driver.php
+++ b/src/Providers/Driver.php
@@ -211,7 +211,7 @@ abstract class Driver
     public function batch(Batch $request): BatchResponse
     {
         if (! $this->capabilities()->canBatch($request->modality)) {
-            throw UnsupportedFeatureException::make('batch:'.$request->modality->value, $this->name());
+            throw UnsupportedFeatureException::make('batch:'.$request->modality->value, $this->providerName());
         }
 
         return $this->translating('', fn () => $this->resolveHandler('batch', fn () => $this->batchHandler())->submit($request));
@@ -266,7 +266,7 @@ abstract class Driver
             }
 
             $context = new ProviderContext(
-                provider: $this->name(),
+                provider: $this->providerName(),
                 model: $request->model,
                 method: $method,
                 request: $request,
@@ -297,7 +297,7 @@ abstract class Driver
             $this->handleRequestException($model ?? '', $e);
         } catch (HttpConnectionException $e) {
             // Network-level failure before any response (timeout, DNS, refused).
-            throw new ConnectionException($this->name(), $model ?? '', $e);
+            throw new ConnectionException($this->providerName(), $model ?? '', $e);
         }
     }
 
@@ -305,47 +305,47 @@ abstract class Driver
 
     protected function textHandler(): TextHandler
     {
-        throw UnsupportedFeatureException::make('text', $this->name());
+        throw UnsupportedFeatureException::make('text', $this->providerName());
     }
 
     protected function imageHandler(): ImageHandler
     {
-        throw UnsupportedFeatureException::make('image', $this->name());
+        throw UnsupportedFeatureException::make('image', $this->providerName());
     }
 
     protected function audioHandler(): AudioHandler
     {
-        throw UnsupportedFeatureException::make('audio', $this->name());
+        throw UnsupportedFeatureException::make('audio', $this->providerName());
     }
 
     protected function videoHandler(): VideoHandler
     {
-        throw UnsupportedFeatureException::make('video', $this->name());
+        throw UnsupportedFeatureException::make('video', $this->providerName());
     }
 
     protected function embedHandler(): EmbedHandler
     {
-        throw UnsupportedFeatureException::make('embed', $this->name());
+        throw UnsupportedFeatureException::make('embed', $this->providerName());
     }
 
     protected function moderateHandler(): ModerateHandler
     {
-        throw UnsupportedFeatureException::make('moderate', $this->name());
+        throw UnsupportedFeatureException::make('moderate', $this->providerName());
     }
 
     protected function rerankHandler(): RerankHandler
     {
-        throw UnsupportedFeatureException::make('rerank', $this->name());
+        throw UnsupportedFeatureException::make('rerank', $this->providerName());
     }
 
     protected function voiceHandler(): VoiceHandler
     {
-        throw UnsupportedFeatureException::make('voice', $this->name());
+        throw UnsupportedFeatureException::make('voice', $this->providerName());
     }
 
     protected function batchHandler(): BatchHandler
     {
-        throw UnsupportedFeatureException::make('batch', $this->name());
+        throw UnsupportedFeatureException::make('batch', $this->providerName());
     }
 
     // ─── Provider Interrogation ──────────────────────────────────────────
@@ -372,14 +372,35 @@ abstract class Driver
      */
     protected function providerHandler(string $feature = 'provider'): ProviderHandler
     {
-        throw UnsupportedFeatureException::make($feature, $this->name());
+        throw UnsupportedFeatureException::make($feature, $this->providerName());
     }
 
     // ─── Capabilities & Identity ─────────────────────────────────────────
 
     abstract public function capabilities(): ProviderCapabilities;
 
+    /**
+     * The driver's wire-format identity (e.g. 'openai', 'chat_completions').
+     *
+     * Used internally to route by driver type (e.g. provider-tool support).
+     * For consumer-facing attribution (exceptions, events, middleware) use
+     * {@see providerName()} instead, which honors the configured provider key.
+     */
     abstract public function name(): string;
+
+    /**
+     * The configured provider key for consumer-facing attribution.
+     *
+     * Prefers the registry-stamped config key (e.g. 'groq', 'ollama') so a
+     * provider built on a shared driver (chat_completions, responses) is
+     * reported under its real name rather than the driver type. Falls back to
+     * the driver's wire-format name when no key was stamped (e.g. a directly
+     * constructed driver in tests).
+     */
+    protected function providerName(): string
+    {
+        return $this->config->provider !== '' ? $this->config->provider : $this->name();
+    }
 
     // ─── Error Handling ──────────────────────────────────────────────────
 
@@ -389,17 +410,18 @@ abstract class Driver
     public function handleRequestException(string $model, RequestException $e): never
     {
         $status = $e->response->status();
+        $provider = $this->providerName();
 
         // Each category resolves the provider's real error text (the typed
         // factories extract it from the response); match evaluates one arm.
         match ($status) {
-            400 => throw new InvalidRequestException($this->name(), $model, $status, $this->errorMessage($e), $e),
-            401 => throw AuthenticationException::from($this->name(), $model, $e, $this->extractErrorMessage($e)),
-            403 => throw AuthorizationException::from($this->name(), $model, $e, $this->extractErrorMessage($e)),
-            404 => throw new ModelNotFoundException($this->name(), $model, $status, $this->errorMessage($e), $e),
-            429, 529 => throw RateLimitException::from($this->name(), $model, $e),
-            500, 502, 503, 504 => throw new ServerException($this->name(), $model, $status, $this->errorMessage($e), $e),
-            default => throw new ProviderException($this->name(), $model, $status, $this->errorMessage($e), $e),
+            400 => throw new InvalidRequestException($provider, $model, $status, $this->errorMessage($e), $e),
+            401 => throw AuthenticationException::from($provider, $model, $e, $this->extractErrorMessage($e)),
+            403 => throw AuthorizationException::from($provider, $model, $e, $this->extractErrorMessage($e)),
+            404 => throw new ModelNotFoundException($provider, $model, $status, $this->errorMessage($e), $e),
+            429, 529 => throw RateLimitException::from($provider, $model, $e),
+            500, 502, 503, 504 => throw new ServerException($provider, $model, $status, $this->errorMessage($e), $e),
+            default => throw new ProviderException($provider, $model, $status, $this->errorMessage($e), $e),
         };
     }
 

--- a/src/Providers/Google/Handlers/Text.php
+++ b/src/Providers/Google/Handlers/Text.php
@@ -168,10 +168,17 @@ class Text implements TextHandler
             $body['system_instruction'] = $messageData['system_instruction'];
         }
 
-        $genConfig = array_filter([
-            'maxOutputTokens' => $request->maxTokens,
-            'temperature' => $request->temperature,
-        ]);
+        // Explicit null checks, not array_filter: temperature 0.0 is a valid,
+        // deliberate value (deterministic output) and must not be filtered as falsy.
+        $genConfig = [];
+
+        if ($request->maxTokens !== null) {
+            $genConfig['maxOutputTokens'] = $request->maxTokens;
+        }
+
+        if ($request->temperature !== null) {
+            $genConfig['temperature'] = $request->temperature;
+        }
 
         if ($genConfig !== []) {
             $body['generationConfig'] = $genConfig;

--- a/src/Providers/Google/ResponseParser.php
+++ b/src/Providers/Google/ResponseParser.php
@@ -113,33 +113,31 @@ class ResponseParser implements ResponseParserContract
     /**
      * Parse a streaming SSE data payload into a StreamChunk.
      *
-     * Note: Processes only the first matching part per chunk. If Gemini sends
-     * multi-part chunks (e.g., text + function call), only the first part is emitted.
-     * This matches observed Gemini streaming behavior where parts arrive separately.
+     * Collects every functionCall part in the chunk (Gemini bundles parallel
+     * calls plus the terminal finishReason + usage into a single chunk), then
+     * falls through to thinking/text parts.
      *
      * @param  array<string, mixed>  $data
      */
-    public function parseStreamChunk(array $data, string $model = ''): StreamChunk
+    public function parseStreamChunk(array $data, string $model = '', string $provider = 'google'): StreamChunk
     {
         if (isset($data['error'])) {
             $error = is_array($data['error']) ? $data['error'] : ['message' => (string) $data['error']];
 
-            throw ProviderException::fromStreamError('google', $model, $error);
+            throw ProviderException::fromStreamError($provider, $model, $error);
         }
 
         $candidate = $data['candidates'][0] ?? [];
         $parts = $candidate['content']['parts'] ?? [];
         $finishReason = $candidate['finishReason'] ?? null;
 
-        // Gemini's final chunk often carries both text content AND finishReason + usageMetadata.
-        // Extract usage from the terminal chunk regardless of content.
+        // Gemini's final chunk often carries content AND finishReason + usageMetadata.
+        // Resolve both from the terminal chunk once and reuse across branches.
         $usage = $finishReason !== null ? $this->parseUsage($data) : null;
+        $resolvedFinish = $finishReason !== null ? $this->parseFinishReason($data) : null;
 
-        // Gemini bundles functionCall parts with finishReason + usage in the same
-        // terminal chunk, and may emit several functionCall parts (parallel calls)
-        // in one chunk. Collect them all and carry finishReason through, mirroring
-        // the non-streaming path — otherwise a tool-terminated stream ends with a
-        // null finishReason and parallel calls past the first are dropped.
+        // Carry the finishReason through so a tool-terminated stream resolves to
+        // ToolCalls, and keep every parallel call — mirroring the non-streaming path.
         $functionCallParts = array_values(array_filter(
             $parts,
             fn (array $part): bool => isset($part['functionCall']),
@@ -150,7 +148,7 @@ class ResponseParser implements ResponseParserContract
                 type: ChunkType::ToolCall,
                 toolCalls: $this->toolMapper->parseToolCalls($functionCallParts),
                 usage: $usage,
-                finishReason: $finishReason !== null ? $this->parseFinishReason($data) : null,
+                finishReason: $resolvedFinish,
             );
         }
 
@@ -171,7 +169,7 @@ class ResponseParser implements ResponseParserContract
                         type: ChunkType::Done,
                         text: $part['text'],
                         usage: $usage,
-                        finishReason: $this->parseFinishReason($data),
+                        finishReason: $resolvedFinish,
                     );
                 }
 
@@ -187,7 +185,7 @@ class ResponseParser implements ResponseParserContract
             return new StreamChunk(
                 type: ChunkType::Done,
                 usage: $usage,
-                finishReason: $this->parseFinishReason($data),
+                finishReason: $resolvedFinish,
             );
         }
 

--- a/src/Providers/Google/ResponseParser.php
+++ b/src/Providers/Google/ResponseParser.php
@@ -135,15 +135,26 @@ class ResponseParser implements ResponseParserContract
         // Extract usage from the terminal chunk regardless of content.
         $usage = $finishReason !== null ? $this->parseUsage($data) : null;
 
-        foreach ($parts as $part) {
-            if (isset($part['functionCall'])) {
-                return new StreamChunk(
-                    type: ChunkType::ToolCall,
-                    toolCalls: $this->toolMapper->parseToolCalls([$part]),
-                    usage: $usage,
-                );
-            }
+        // Gemini bundles functionCall parts with finishReason + usage in the same
+        // terminal chunk, and may emit several functionCall parts (parallel calls)
+        // in one chunk. Collect them all and carry finishReason through, mirroring
+        // the non-streaming path — otherwise a tool-terminated stream ends with a
+        // null finishReason and parallel calls past the first are dropped.
+        $functionCallParts = array_values(array_filter(
+            $parts,
+            fn (array $part): bool => isset($part['functionCall']),
+        ));
 
+        if ($functionCallParts !== []) {
+            return new StreamChunk(
+                type: ChunkType::ToolCall,
+                toolCalls: $this->toolMapper->parseToolCalls($functionCallParts),
+                usage: $usage,
+                finishReason: $finishReason !== null ? $this->parseFinishReason($data) : null,
+            );
+        }
+
+        foreach ($parts as $part) {
             if (isset($part['thought']) && $part['thought'] === true && isset($part['text'])) {
                 return new StreamChunk(
                     type: ChunkType::Thinking,

--- a/src/Providers/OpenAi/Handlers/Text.php
+++ b/src/Providers/OpenAi/Handlers/Text.php
@@ -91,7 +91,7 @@ class Text implements TextHandler
             context: new ProviderRequestContext($this->config->provider, $request->model),
         );
 
-        return new StreamResponse($this->parseSSE($raw, $request->model, $this->config->provider ?: 'openai'));
+        return new StreamResponse($this->parseSSE($raw, $request->model, $this->config->providerName('openai')));
     }
 
     public function structured(TextRequest $request): StructuredResponse

--- a/src/Providers/OpenAi/Handlers/Video.php
+++ b/src/Providers/OpenAi/Handlers/Video.php
@@ -77,7 +77,7 @@ class Video implements VideoHandler
 
         if ($videoId === '') {
             throw new ProviderException(
-                provider: 'openai',
+                provider: $this->config->provider ?: 'openai',
                 model: $request->model,
                 statusCode: 500,
                 providerMessage: 'Video generation response missing id',
@@ -101,7 +101,7 @@ class Video implements VideoHandler
 
         if ($written === false) {
             throw new ProviderException(
-                provider: 'openai',
+                provider: $this->config->provider ?: 'openai',
                 model: $request->model,
                 statusCode: 500,
                 providerMessage: 'Failed to write video to temporary file',
@@ -122,7 +122,7 @@ class Video implements VideoHandler
 
     public function videoToText(VideoRequest $request): TextResponse
     {
-        throw UnsupportedFeatureException::make('videoToText', 'openai');
+        throw UnsupportedFeatureException::make('videoToText', $this->config->provider ?: 'openai');
     }
 
     /**
@@ -156,7 +156,7 @@ class Video implements VideoHandler
                     : (string) ($data['error'] ?? 'Unknown error');
 
                 throw new ProviderException(
-                    provider: 'openai',
+                    provider: $this->config->provider ?: 'openai',
                     model: $model,
                     statusCode: 422,
                     providerMessage: "Video generation failed for {$videoId}: {$errorMessage}",
@@ -165,7 +165,7 @@ class Video implements VideoHandler
         }
 
         throw new ProviderException(
-            provider: 'openai',
+            provider: $this->config->provider ?: 'openai',
             model: $model,
             statusCode: 408,
             providerMessage: "Video generation timed out after polling {$videoId} for ".($this->maxAttempts * $this->pollInterval).' seconds',
@@ -208,7 +208,7 @@ class Video implements VideoHandler
 
             if ($raw === false) {
                 throw new ProviderException(
-                    provider: 'openai',
+                    provider: $this->config->provider ?: 'openai',
                     model: $model,
                     statusCode: 400,
                     providerMessage: "Cannot read image file: {$input->path()}",
@@ -223,7 +223,7 @@ class Video implements VideoHandler
                 return ['image_url' => "data:{$input->mimeType()};base64,".base64_encode($input->contents())];
             } catch (\RuntimeException $e) {
                 throw new ProviderException(
-                    provider: 'openai',
+                    provider: $this->config->provider ?: 'openai',
                     model: $model,
                     statusCode: 400,
                     providerMessage: 'Cannot read image from storage: '.$e->getMessage(),
@@ -232,7 +232,7 @@ class Video implements VideoHandler
         }
 
         throw new ProviderException(
-            provider: 'openai',
+            provider: $this->config->provider ?: 'openai',
             model: $model,
             statusCode: 400,
             providerMessage: 'Cannot resolve image input — no supported source set.',

--- a/src/Providers/OpenAi/Handlers/Video.php
+++ b/src/Providers/OpenAi/Handlers/Video.php
@@ -77,7 +77,7 @@ class Video implements VideoHandler
 
         if ($videoId === '') {
             throw new ProviderException(
-                provider: $this->config->provider ?: 'openai',
+                provider: $this->config->providerName('openai'),
                 model: $request->model,
                 statusCode: 500,
                 providerMessage: 'Video generation response missing id',
@@ -101,7 +101,7 @@ class Video implements VideoHandler
 
         if ($written === false) {
             throw new ProviderException(
-                provider: $this->config->provider ?: 'openai',
+                provider: $this->config->providerName('openai'),
                 model: $request->model,
                 statusCode: 500,
                 providerMessage: 'Failed to write video to temporary file',
@@ -122,7 +122,7 @@ class Video implements VideoHandler
 
     public function videoToText(VideoRequest $request): TextResponse
     {
-        throw UnsupportedFeatureException::make('videoToText', $this->config->provider ?: 'openai');
+        throw UnsupportedFeatureException::make('videoToText', $this->config->providerName('openai'));
     }
 
     /**
@@ -156,7 +156,7 @@ class Video implements VideoHandler
                     : (string) ($data['error'] ?? 'Unknown error');
 
                 throw new ProviderException(
-                    provider: $this->config->provider ?: 'openai',
+                    provider: $this->config->providerName('openai'),
                     model: $model,
                     statusCode: 422,
                     providerMessage: "Video generation failed for {$videoId}: {$errorMessage}",
@@ -165,7 +165,7 @@ class Video implements VideoHandler
         }
 
         throw new ProviderException(
-            provider: $this->config->provider ?: 'openai',
+            provider: $this->config->providerName('openai'),
             model: $model,
             statusCode: 408,
             providerMessage: "Video generation timed out after polling {$videoId} for ".($this->maxAttempts * $this->pollInterval).' seconds',
@@ -208,7 +208,7 @@ class Video implements VideoHandler
 
             if ($raw === false) {
                 throw new ProviderException(
-                    provider: $this->config->provider ?: 'openai',
+                    provider: $this->config->providerName('openai'),
                     model: $model,
                     statusCode: 400,
                     providerMessage: "Cannot read image file: {$input->path()}",
@@ -223,7 +223,7 @@ class Video implements VideoHandler
                 return ['image_url' => "data:{$input->mimeType()};base64,".base64_encode($input->contents())];
             } catch (\RuntimeException $e) {
                 throw new ProviderException(
-                    provider: $this->config->provider ?: 'openai',
+                    provider: $this->config->providerName('openai'),
                     model: $model,
                     statusCode: 400,
                     providerMessage: 'Cannot read image from storage: '.$e->getMessage(),
@@ -232,7 +232,7 @@ class Video implements VideoHandler
         }
 
         throw new ProviderException(
-            provider: $this->config->provider ?: 'openai',
+            provider: $this->config->providerName('openai'),
             model: $model,
             statusCode: 400,
             providerMessage: 'Cannot resolve image input — no supported source set.',

--- a/src/Providers/ProviderConfig.php
+++ b/src/Providers/ProviderConfig.php
@@ -25,6 +25,18 @@ class ProviderConfig
     ) {}
 
     /**
+     * Resolve the consumer-facing provider name for attribution.
+     *
+     * Prefers the registry-stamped config key (e.g. 'groq', 'ollama') so a
+     * provider built on a shared driver reports under its real name, and falls
+     * back to the given driver default when no key was stamped.
+     */
+    public function providerName(string $default): string
+    {
+        return $this->provider !== '' ? $this->provider : $default;
+    }
+
+    /**
      * Create a ProviderConfig from a configuration array.
      *
      * The provider key is injected by the registry under `provider` so handlers

--- a/src/Testing/FakeDriver.php
+++ b/src/Testing/FakeDriver.php
@@ -60,6 +60,16 @@ class FakeDriver extends Driver
         return $this->providerName;
     }
 
+    /**
+     * The fake skips the parent constructor, so {@see Driver::$config} is never
+     * set. Resolve attribution from the fake's own name instead of reading the
+     * uninitialized config, keeping every base-class path (e.g. batch()) safe.
+     */
+    protected function providerName(): string
+    {
+        return $this->name();
+    }
+
     public function capabilities(): ProviderCapabilities
     {
         return new ProviderCapabilities(

--- a/tests/Unit/Providers/Anthropic/ResponseParserTest.php
+++ b/tests/Unit/Providers/Anthropic/ResponseParserTest.php
@@ -41,6 +41,34 @@ it('a mid-stream error carries the model passed to the parser', function () {
     expect($caught?->model)->toBe('claude-sonnet-4-5');
 });
 
+it('a mid-stream error defaults to the anthropic provider and honors an override', function () {
+    $default = null;
+
+    try {
+        makeAnthropicResponseParser()->parseStreamChunk([
+            'event' => 'error',
+            'data' => ['error' => ['message' => 'Overloaded']],
+        ], 'claude-sonnet-4-5');
+    } catch (ProviderException $e) {
+        $default = $e;
+    }
+
+    expect($default?->provider)->toBe('anthropic');
+
+    $aliased = null;
+
+    try {
+        makeAnthropicResponseParser()->parseStreamChunk([
+            'event' => 'error',
+            'data' => ['error' => ['message' => 'Overloaded']],
+        ], 'claude-sonnet-4-5', 'anthropic-prod');
+    } catch (ProviderException $e) {
+        $aliased = $e;
+    }
+
+    expect($aliased?->provider)->toBe('anthropic-prod');
+});
+
 it('parses text from content blocks', function () {
     $parser = makeAnthropicResponseParser();
 

--- a/tests/Unit/Providers/ChatCompletions/ResponseParserTest.php
+++ b/tests/Unit/Providers/ChatCompletions/ResponseParserTest.php
@@ -39,6 +39,37 @@ it('a mid-stream error carries the model passed to the parser', function () {
     expect($caught?->model)->toBe('llama3.2');
 });
 
+it('attributes a mid-stream error to the configured provider key (regression)', function () {
+    // chat_completions is the driver for secondary providers (Groq, Ollama, …);
+    // a streamed error must report the configured key, not the driver type.
+    $caught = null;
+
+    try {
+        makeCcParser()->parseStreamChunk([
+            'error' => ['message' => 'rate limited'],
+        ], 'llama3.2', 'groq');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught?->provider)->toBe('groq');
+    expect($caught?->getMessage())->not->toContain('chat_completions');
+});
+
+it('defaults the mid-stream error provider to chat_completions when none is threaded', function () {
+    $caught = null;
+
+    try {
+        makeCcParser()->parseStreamChunk([
+            'error' => ['message' => 'boom'],
+        ], 'llama3.2');
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught?->provider)->toBe('chat_completions');
+});
+
 it('parses text from choices message', function () {
     $parser = makeCcParser();
 

--- a/tests/Unit/Providers/DriverProviderNameTest.php
+++ b/tests/Unit/Providers/DriverProviderNameTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use Atlasphp\Atlas\Exceptions\AuthenticationException;
+use Atlasphp\Atlas\Exceptions\ConnectionException;
+use Atlasphp\Atlas\Exceptions\ProviderException;
+use Atlasphp\Atlas\Exceptions\RateLimitException;
+use Atlasphp\Atlas\Exceptions\ServerException;
+use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
+use Atlasphp\Atlas\Http\HttpClient;
+use Atlasphp\Atlas\Providers\Driver;
+use Atlasphp\Atlas\Providers\Handlers\TextHandler;
+use Atlasphp\Atlas\Providers\ProviderCapabilities;
+use Atlasphp\Atlas\Providers\ProviderConfig;
+use Atlasphp\Atlas\Requests\EmbedRequest;
+use Atlasphp\Atlas\Requests\TextRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Regression coverage for provider mislabeling: drivers built on a shared
+ * wire-format type (chat_completions, responses) must attribute errors,
+ * connection failures, and unsupported-feature messages to the consumer's
+ * configured provider key — not the driver type returned by name().
+ */
+function makeSharedDriver(string $providerKey): Driver
+{
+    $config = new ProviderConfig(apiKey: 'test', baseUrl: 'https://api.test.com', provider: $providerKey);
+    $http = Mockery::mock(HttpClient::class);
+
+    // name() returns the wire-format type, mimicking ChatCompletionsDriver/ResponsesDriver.
+    return new class($config, $http) extends Driver
+    {
+        public function capabilities(): ProviderCapabilities
+        {
+            return new ProviderCapabilities(text: true);
+        }
+
+        public function name(): string
+        {
+            return 'chat_completions';
+        }
+    };
+}
+
+function makeReqExceptionStatus(int $status): RequestException
+{
+    Http::fake(['*' => Http::response('error', $status)]);
+
+    try {
+        Http::get('https://api.test.com/fail')->throw();
+    } catch (RequestException $e) {
+        return $e;
+    }
+
+    throw new RuntimeException('Expected RequestException');
+}
+
+function textRequestForProviderName(): TextRequest
+{
+    return new TextRequest('model', null, null, [], [], null, null, null, [], [], []);
+}
+
+it('attributes a typed HTTP error to the configured provider key, not the driver type', function (string $exceptionClass, int $status) {
+    $caught = null;
+
+    try {
+        makeSharedDriver('groq')->handleRequestException('llama-3', makeReqExceptionStatus($status));
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf($exceptionClass);
+    expect($caught->provider)->toBe('groq');
+    expect($caught->getMessage())->not->toContain('chat_completions');
+})->with([
+    'auth 401' => [AuthenticationException::class, 401],
+    'rate limit 429' => [RateLimitException::class, 429],
+    'server 503' => [ServerException::class, 503],
+    'base 500' => [ProviderException::class, 500],
+]);
+
+it('attributes a connection failure to the configured provider key', function () {
+    $handler = Mockery::mock(TextHandler::class);
+    $handler->shouldReceive('text')->andThrow(
+        new Illuminate\Http\Client\ConnectionException('cURL error 28: timed out')
+    );
+
+    $caught = null;
+
+    try {
+        makeSharedDriver('ollama')->withHandler('text', $handler)->text(textRequestForProviderName());
+    } catch (ConnectionException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf(ConnectionException::class);
+    expect($caught->provider)->toBe('ollama');
+});
+
+it('names the configured provider in an unsupported-feature error', function () {
+    $caught = null;
+
+    try {
+        makeSharedDriver('groq')->embed(new EmbedRequest('model', 'text'));
+    } catch (UnsupportedFeatureException $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->toBeInstanceOf(UnsupportedFeatureException::class);
+    expect($caught->getMessage())->toContain('groq');
+    expect($caught->getMessage())->not->toContain('chat_completions');
+});
+
+it('falls back to the driver wire-format name when no provider key is stamped', function () {
+    $config = new ProviderConfig(apiKey: 'test', baseUrl: 'https://api.test.com'); // provider = ''
+    $http = Mockery::mock(HttpClient::class);
+
+    $driver = new class($config, $http) extends Driver
+    {
+        public function capabilities(): ProviderCapabilities
+        {
+            return new ProviderCapabilities;
+        }
+
+        public function name(): string
+        {
+            return 'chat_completions';
+        }
+    };
+
+    $caught = null;
+
+    try {
+        $driver->handleRequestException('m', makeReqExceptionStatus(401));
+    } catch (AuthenticationException $e) {
+        $caught = $e;
+    }
+
+    expect($caught->provider)->toBe('chat_completions');
+});

--- a/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
+++ b/tests/Unit/Providers/Google/Handlers/TextHandlerTest.php
@@ -193,6 +193,31 @@ it('includes generationConfig with maxOutputTokens and temperature', function ()
     });
 });
 
+it('sends temperature 0.0 instead of dropping it as falsy (regression)', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse()),
+    ]);
+
+    $handler = makeGoogleTextHandler();
+    $handler->text(makeGoogleTextRequest(['temperature' => 0.0]));
+
+    Http::assertSent(function ($request) {
+        return array_key_exists('temperature', $request['generationConfig'] ?? [])
+            && $request['generationConfig']['temperature'] === 0.0;
+    });
+});
+
+it('omits generationConfig entirely when neither maxTokens nor temperature is set', function () {
+    Http::fake([
+        'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse()),
+    ]);
+
+    $handler = makeGoogleTextHandler();
+    $handler->text(makeGoogleTextRequest(['maxTokens' => null, 'temperature' => null]));
+
+    Http::assertSent(fn ($request) => ! array_key_exists('generationConfig', $request->data()));
+});
+
 it('deep-merges providerOptions generationConfig keys alongside the fields Atlas sets', function () {
     Http::fake([
         'generativelanguage.googleapis.com/*' => Http::response(fakeGeminiTextResponse()),

--- a/tests/Unit/Providers/Google/ResponseParserTest.php
+++ b/tests/Unit/Providers/Google/ResponseParserTest.php
@@ -37,6 +37,28 @@ it('a mid-stream error carries the model passed to the parser', function () {
     expect($caught?->model)->toBe('gemini-2.5-flash');
 });
 
+it('a mid-stream error defaults to the google provider and honors an override', function () {
+    $default = null;
+
+    try {
+        makeGoogleResponseParser()->parseStreamChunk(['error' => ['message' => 'boom']], 'gemini-2.5-flash');
+    } catch (ProviderException $e) {
+        $default = $e;
+    }
+
+    expect($default?->provider)->toBe('google');
+
+    $aliased = null;
+
+    try {
+        makeGoogleResponseParser()->parseStreamChunk(['error' => ['message' => 'boom']], 'gemini-2.5-flash', 'gemini-prod');
+    } catch (ProviderException $e) {
+        $aliased = $e;
+    }
+
+    expect($aliased?->provider)->toBe('gemini-prod');
+});
+
 it('parses text from candidates parts', function () {
     $parser = makeGoogleResponseParser();
 

--- a/tests/Unit/Providers/Google/ResponseParserTest.php
+++ b/tests/Unit/Providers/Google/ResponseParserTest.php
@@ -302,3 +302,38 @@ it('parses stream chunk as done when finishReason present', function () {
 
     expect($result->type)->toBe(ChunkType::Done);
 });
+
+it('emits a Done chunk carrying text, usage, and the resolved finishReason when a terminal chunk bundles text (regression)', function () {
+    // Gemini's final chunk often carries a text part AND finishReason + usage in
+    // the same payload; the Done chunk must surface all three.
+    $parser = makeGoogleResponseParser();
+
+    $result = $parser->parseStreamChunk([
+        'candidates' => [[
+            'content' => ['parts' => [['text' => 'final answer']]],
+            'finishReason' => 'STOP',
+        ]],
+        'usageMetadata' => ['promptTokenCount' => 7, 'candidatesTokenCount' => 3],
+    ]);
+
+    expect($result->type)->toBe(ChunkType::Done);
+    expect($result->text)->toBe('final answer');
+    expect($result->finishReason)->toBe(FinishReason::Stop);
+    expect($result->usage?->inputTokens)->toBe(7);
+    expect($result->usage?->outputTokens)->toBe(3);
+});
+
+it('maps a non-STOP finishReason on a terminal text chunk (resolvedFinish branch)', function () {
+    $parser = makeGoogleResponseParser();
+
+    $result = $parser->parseStreamChunk([
+        'candidates' => [[
+            'content' => ['parts' => [['text' => 'truncated']]],
+            'finishReason' => 'MAX_TOKENS',
+        ]],
+    ]);
+
+    expect($result->type)->toBe(ChunkType::Done);
+    expect($result->text)->toBe('truncated');
+    expect($result->finishReason)->toBe(FinishReason::Length);
+});

--- a/tests/Unit/Providers/Google/ResponseParserTest.php
+++ b/tests/Unit/Providers/Google/ResponseParserTest.php
@@ -214,6 +214,50 @@ it('parses stream chunk with function call', function () {
     expect($result->toolCalls[0]->thoughtSignature)->toBe('signature-from-gemini');
 });
 
+it('carries finishReason on a streamed chunk that bundles a function call (regression)', function () {
+    // Gemini bundles functionCall + finishReason + usageMetadata into one
+    // terminal SSE chunk. The finishReason must survive so a tool-terminated
+    // stream resolves to FinishReason::ToolCalls, not null.
+    $parser = makeGoogleResponseParser();
+
+    $result = $parser->parseStreamChunk([
+        'candidates' => [[
+            'content' => ['parts' => [
+                ['functionCall' => ['name' => 'get_weather', 'args' => ['city' => 'Paris']]],
+            ]],
+            'finishReason' => 'STOP',
+        ]],
+        'usageMetadata' => ['promptTokenCount' => 10, 'candidatesTokenCount' => 5],
+    ]);
+
+    expect($result->type)->toBe(ChunkType::ToolCall);
+    expect($result->toolCalls)->toHaveCount(1);
+    expect($result->finishReason)->toBe(FinishReason::ToolCalls);
+    expect($result->usage?->inputTokens)->toBe(10);
+});
+
+it('emits all function calls bundled in one streamed chunk (regression)', function () {
+    // Parallel tool calls may arrive as multiple functionCall parts in a single
+    // chunk; none may be dropped.
+    $parser = makeGoogleResponseParser();
+
+    $result = $parser->parseStreamChunk([
+        'candidates' => [[
+            'content' => ['parts' => [
+                ['functionCall' => ['name' => 'get_weather', 'args' => ['city' => 'Paris']]],
+                ['functionCall' => ['name' => 'get_weather', 'args' => ['city' => 'Tokyo']]],
+            ]],
+            'finishReason' => 'STOP',
+        ]],
+    ]);
+
+    expect($result->type)->toBe(ChunkType::ToolCall);
+    expect($result->toolCalls)->toHaveCount(2);
+    expect($result->toolCalls[0]->arguments)->toBe(['city' => 'Paris']);
+    expect($result->toolCalls[1]->arguments)->toBe(['city' => 'Tokyo']);
+    expect($result->finishReason)->toBe(FinishReason::ToolCalls);
+});
+
 it('parses stream chunk with thinking', function () {
     $parser = makeGoogleResponseParser();
 

--- a/tests/Unit/Providers/OpenAi/Handlers/VideoHandlerTest.php
+++ b/tests/Unit/Providers/OpenAi/Handlers/VideoHandlerTest.php
@@ -172,6 +172,50 @@ it('throws ProviderException when id is missing', function () {
     $handler->video(makeOpenAiVideoRequest());
 })->throws(ProviderException::class, 'missing id');
 
+it('attributes a handler-built error to the configured provider key, not openai (regression)', function () {
+    // The OpenAI Video handler is reused by the chat_completions and responses
+    // drivers; a custom provider's video error must not be mislabeled 'openai'.
+    Http::fake([
+        'api.openai.com/v1/videos' => Http::response(['status' => 'queued']), // no id
+    ]);
+
+    $handler = new Video(
+        config: ProviderConfig::fromArray([
+            'api_key' => 'test-key',
+            'url' => 'https://api.openai.com/v1',
+            'provider' => 'fireworks',
+        ]),
+        http: app(HttpClient::class),
+        pollInterval: 0,
+    );
+
+    $caught = null;
+
+    try {
+        $handler->video(makeOpenAiVideoRequest());
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught->provider)->toBe('fireworks');
+});
+
+it('falls back to openai for handler-built errors when no provider key is set', function () {
+    Http::fake([
+        'api.openai.com/v1/videos' => Http::response(['status' => 'queued']), // no id
+    ]);
+
+    $caught = null;
+
+    try {
+        makeOpenAiVideoHandler()->video(makeOpenAiVideoRequest());
+    } catch (ProviderException $e) {
+        $caught = $e;
+    }
+
+    expect($caught->provider)->toBe('openai');
+});
+
 it('an unresolvable reference image throws a ProviderException carrying the model', function () {
     $caught = null;
 

--- a/tests/Unit/Providers/ProviderConfigTest.php
+++ b/tests/Unit/Providers/ProviderConfigTest.php
@@ -131,3 +131,18 @@ it('defaults the provider to an empty string when absent', function () {
 
     expect($config->provider)->toBe('');
 });
+
+it('providerName() returns the stamped key, or the given default when unset', function () {
+    $stamped = ProviderConfig::fromArray([
+        'api_key' => 'sk-test',
+        'url' => 'https://api.test.com',
+        'provider' => 'groq',
+    ]);
+    $unstamped = ProviderConfig::fromArray([
+        'api_key' => 'sk-test',
+        'url' => 'https://api.test.com',
+    ]);
+
+    expect($stamped->providerName('chat_completions'))->toBe('groq');
+    expect($unstamped->providerName('chat_completions'))->toBe('chat_completions');
+});

--- a/tests/Unit/Testing/FakeDriverTest.php
+++ b/tests/Unit/Testing/FakeDriverTest.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 use Atlasphp\Atlas\Enums\ChunkType;
+use Atlasphp\Atlas\Enums\Modality;
+use Atlasphp\Atlas\Exceptions\UnsupportedFeatureException;
 use Atlasphp\Atlas\Requests\AudioRequest;
+use Atlasphp\Atlas\Requests\Batch;
 use Atlasphp\Atlas\Requests\EmbedRequest;
 use Atlasphp\Atlas\Requests\ImageRequest;
 use Atlasphp\Atlas\Requests\ModerateRequest;
@@ -302,6 +305,21 @@ it('records rerank calls for assertions', function () {
     expect($driver->recorded('rerank'))->toHaveCount(1);
     expect($driver->recorded('rerank')[0]->method)->toBe('rerank');
     expect($driver->recorded('rerank')[0]->request->query)->toBe('Test');
+});
+
+// ─── Base-class paths stay safe despite the skipped constructor ──────────────
+
+it('batch() on a fake throws UnsupportedFeatureException, not an uninitialized-config error (regression)', function () {
+    // FakeDriver skips the parent constructor, so $config is never set. The base
+    // batch() path resolves the provider name for its error — it must not read
+    // the uninitialized config and fatal.
+    $driver = new FakeDriver('openai');
+
+    expect(fn () => $driver->batch(new Batch(
+        provider: 'openai',
+        modality: Modality::Text,
+        lines: [],
+    )))->toThrow(UnsupportedFeatureException::class, 'openai');
 });
 
 // ─── Per-Instance Isolation ─────────────────────────────────────────────────


### PR DESCRIPTION
Make consumer-facing attribution use the configured provider key rather than the driver's wire-format name by adding Driver::providerName() and using it for exceptions, connection errors, and unsupported-feature messages. Thread the provider key through chat_completions streaming (parseSSE -> parseStreamChunk) so mid-stream errors are attributed correctly. Google: preserve temperature=0.0 by avoiding array_filter on generationConfig and collect functionCall parts in streamed chunks while carrying finishReason/usage and emitting all parallel tool calls. OpenAI Video handler now reports the configured provider key in ProviderException/UnsupportedFeatureException. Add tests for these regressions and update the CHANGELOG.