### PR TITLE
Reject mixed-model Google batches

### DIFF
--- a/docs/modalities/batch.md
+++ b/docs/modalities/batch.md
@@ -16,6 +16,10 @@ Batch is ideal for latency-tolerant fan-out work — captioning thousands of ima
 Asking a provider to batch a modality it doesn't support — or a non-batchable modality (audio, voice, rerank, …) — throws `UnsupportedFeatureException` up front. xAI batch, image/video batch, and embeddings batch for Anthropic/Google are a planned follow-up.
 :::
 
+::: warning Google batches
+Gemini batch jobs target one model per batch because the model is part of Google's batch URL. Split Google requests by model before calling `submit()`.
+:::
+
 ## What can and cannot be batched
 
 A batch line is a single, one-shot request resolved later and out of band. What survives into a batch is everything that's part of the request body:

--- a/src/Providers/Google/Handlers/Batch.php
+++ b/src/Providers/Google/Handlers/Batch.php
@@ -39,6 +39,8 @@ class Batch implements BatchHandler
 
     public function submit(BatchRequest $batch): BatchResponse
     {
+        $model = $this->modelFor($batch);
+
         $requests = array_map(function ($line): array {
             if (! $line->request instanceof TextRequest) {
                 throw BatchException::notBatchable($line->request::class);
@@ -51,7 +53,7 @@ class Batch implements BatchHandler
         }, $batch->lines);
 
         $data = $this->http->post(
-            url: "{$this->config->baseUrl}/v1beta/models/{$this->modelFor($batch)}:batchGenerateContent",
+            url: "{$this->config->baseUrl}/v1beta/models/{$model}:batchGenerateContent",
             headers: $this->headers(),
             body: ['batch' => [
                 'display_name' => 'atlas-batch',
@@ -117,9 +119,23 @@ class Batch implements BatchHandler
      */
     private function modelFor(BatchRequest $batch): string
     {
-        $first = $batch->lines[0] ?? null;
+        $model = null;
 
-        return $first !== null && $first->request instanceof TextRequest ? $first->request->model : '';
+        foreach ($batch->lines as $line) {
+            if (! $line->request instanceof TextRequest) {
+                throw BatchException::notBatchable($line->request::class);
+            }
+
+            $model ??= $line->request->model;
+
+            if ($line->request->model !== $model) {
+                throw new BatchException(
+                    "All Google batch requests must use one model; expected [{$model}], got [{$line->request->model}]."
+                );
+            }
+        }
+
+        return $model ?? '';
     }
 
     /**

--- a/tests/Unit/Providers/Google/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Google/BatchHandlerTest.php
@@ -91,6 +91,18 @@ it('rejects a non-text request line at submit', function () {
     googleBatchHandler($http)->submit($batch);
 })->throws(BatchException::class, 'cannot be batched');
 
+it('rejects mixed models because Google batch uses one model URL', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldNotReceive('post');
+
+    $batch = new BatchRequest('google', Modality::Text, [
+        new BatchLine('request-1', new TextRequest('gemini-2.5-flash', null, 'Say ALPHA', [], [], null, null, null, [], [], [])),
+        new BatchLine('request-2', new TextRequest('gemini-1.5-pro', null, 'Say BETA', [], [], null, null, null, [], [], [])),
+    ]);
+
+    googleBatchHandler($http)->submit($batch);
+})->throws(BatchException::class, 'All Google batch requests must use one model');
+
 it('correlates results by metadata.key, not array order', function () {
     $http = Mockery::mock(HttpClient::class);
     // Note: returned OUT OF ORDER (request-2 first) to prove key-based join.


### PR DESCRIPTION
## Summary
Reject Gemini text batches that mix request models before Atlas sends any Google batch HTTP request.

## Problem
- Mixed-model Gemini batches could silently run every line under the first request model.
- That can return wrong output or cost behavior for consumers who batch Google text requests with different models.
- Google batch jobs target one model in the URL, so later lines cannot carry their own model selection.

**Evidence:**
- On base `origin/3.x`, `src/Providers/Google/Handlers/Batch.php:53-55` posts to `/models/{modelFor($batch)}:batchGenerateContent`.
- On base `origin/3.x`, `src/Providers/Google/Handlers/Batch.php:115-122` gets that model from only the first line and never compares later line models.
- Bug-scan repro in this PR: a mocked batch with `gemini-2.5-flash` followed by `gemini-1.5-pro` built a request URL for only `gemini-2.5-flash`, while the second line body carried no model.

**Root cause:** Google's model is a per-batch URL parameter, but the handler accepted mixed `TextRequest` models and selected the first line model for the whole batch.

## Implementation
- Resolve the Google batch model once before building request bodies.
- Reject any Google batch line whose `TextRequest` model differs from the first line.
- Preserve the existing non-text line rejection path.
- Document that Gemini batches must be split by model before `submit()`.

## Validation
- ✅ Reproduced on base: the new mixed-model regression in `tests/Unit/Providers/Google/BatchHandlerTest.php:94-104` fails against the base behavior because `HttpClient::post()` is reached for mixed models.
- ✅ Verified after: the same regression passes on this PR and asserts no Google batch HTTP request is sent.
- ✅ Focused batch suite: `./vendor/bin/pest tests/Unit/Providers/Google/BatchHandlerTest.php` passed with 115 tests and 351 assertions.
- ✅ Suite / lint / static analysis: `composer check` passed with Pint, PHPStan, and Pest; PR CI is green for Lint, Static Analysis, Tests (PHP 8.2, SQLite), Tests - Persistence (PHP 8.2, PostgreSQL), and Codecov patch.
- ✅ Review: DevOps github-triage review on 2026-07-02 found no blocking code or test issues.

## How To Manual QA Test
- Construct a Gemini batch with two text lines that use different models, such as `gemini-2.5-flash` and `gemini-1.5-pro`.
- Submit it through the Google batch path.
- Expected result: Atlas raises a clear exception before sending the request; before this PR, Atlas submitted the batch under the first model.

---
🤖 added by Reggie [github-triage]
