### PR TITLE
fix(batch): reject mixed-model Google batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ---
 
+## [v3.6.1](https://github.com/atlas-php/atlas/releases/tag/v3.6.1) - 2026-07-20
+
+### Fixed
+
+- Google (Gemini) batches that mix models now fail fast with a clear error at submit time, instead of silently running every request under the first line's model — Gemini applies one model per batch. Split differing models into separate batches; OpenAI and Anthropic can still mix models freely.
+
+### Migration
+
+No breaking changes — drop-in upgrade. No consumer action required.
+
+---
+
 ## [v3.6.0]
 
 ### Added

--- a/docs/modalities/batch.md
+++ b/docs/modalities/batch.md
@@ -16,6 +16,10 @@ Batch is ideal for latency-tolerant fan-out work — captioning thousands of ima
 Asking a provider to batch a modality it doesn't support — or a non-batchable modality (audio, voice, rerank, …) — throws `UnsupportedFeatureException` up front. xAI batch, image/video batch, and embeddings batch for Anthropic/Google are a planned follow-up.
 :::
 
+::: warning Google uses one model per batch
+Gemini sets the model per batch in the request URL, so every line in a `google` batch must target the **same** model. Mixing models throws a `BatchException` at submit time (before anything is sent). Split differing models into separate batches. OpenAI and Anthropic carry the model per line, so they can mix freely.
+:::
+
 ## What can and cannot be batched
 
 A batch line is a single, one-shot request resolved later and out of band. What survives into a batch is everything that's part of the request body:

--- a/src/Exceptions/BatchException.php
+++ b/src/Exceptions/BatchException.php
@@ -53,6 +53,16 @@ class BatchException extends AtlasException
     }
 
     /**
+     * Two different models were mixed in one Google batch.
+     */
+    public static function mixedModel(string $expected, string $got): self
+    {
+        return new self(
+            "All Google batch requests must target one model; expected [{$expected}], got [{$got}]."
+        );
+    }
+
+    /**
      * A request with tools was added to a batch.
      */
     public static function toolsUnsupported(): self

--- a/src/Providers/Google/Handlers/Batch.php
+++ b/src/Providers/Google/Handlers/Batch.php
@@ -39,6 +39,8 @@ class Batch implements BatchHandler
 
     public function submit(BatchRequest $batch): BatchResponse
     {
+        $model = $this->modelFor($batch);
+
         $requests = array_map(function ($line): array {
             if (! $line->request instanceof TextRequest) {
                 throw BatchException::notBatchable($line->request::class);
@@ -51,7 +53,7 @@ class Batch implements BatchHandler
         }, $batch->lines);
 
         $data = $this->http->post(
-            url: "{$this->config->baseUrl}/v1beta/models/{$this->modelFor($batch)}:batchGenerateContent",
+            url: "{$this->config->baseUrl}/v1beta/models/{$model}:batchGenerateContent",
             headers: $this->headers(),
             body: ['batch' => [
                 'display_name' => 'atlas-batch',
@@ -112,14 +114,30 @@ class Batch implements BatchHandler
     }
 
     /**
-     * The model for the batch URL — taken from the first line (Google applies
-     * one model to the whole batch).
+     * The single model every line targets. Google applies one model to the
+     * whole batch — it lives in the request URL, not per line — so all lines
+     * must agree. Non-text lines are left for submit() to reject as not
+     * batchable.
+     *
+     * @throws BatchException when the batch's text lines target more than one model.
      */
     private function modelFor(BatchRequest $batch): string
     {
-        $first = $batch->lines[0] ?? null;
+        $model = null;
 
-        return $first !== null && $first->request instanceof TextRequest ? $first->request->model : '';
+        foreach ($batch->lines as $line) {
+            if (! $line->request instanceof TextRequest) {
+                continue;
+            }
+
+            if ($model !== null && $line->request->model !== $model) {
+                throw BatchException::mixedModel($model, $line->request->model);
+            }
+
+            $model ??= $line->request->model;
+        }
+
+        return $model ?? '';
     }
 
     /**

--- a/tests/Unit/Providers/Google/BatchHandlerTest.php
+++ b/tests/Unit/Providers/Google/BatchHandlerTest.php
@@ -91,6 +91,18 @@ it('rejects a non-text request line at submit', function () {
     googleBatchHandler($http)->submit($batch);
 })->throws(BatchException::class, 'cannot be batched');
 
+it('rejects mixed models because Google applies one model per batch URL', function () {
+    $http = Mockery::mock(HttpClient::class);
+    $http->shouldNotReceive('post'); // must fail before any HTTP call
+
+    $batch = new BatchRequest('google', Modality::Text, [
+        new BatchLine('request-1', new TextRequest('gemini-2.5-flash', null, 'Say ALPHA', [], [], null, null, null, [], [], [])),
+        new BatchLine('request-2', new TextRequest('gemini-1.5-pro', null, 'Say BETA', [], [], null, null, null, [], [], [])),
+    ]);
+
+    googleBatchHandler($http)->submit($batch);
+})->throws(BatchException::class, 'must target one model');
+
 it('correlates results by metadata.key, not array order', function () {
     $http = Mockery::mock(HttpClient::class);
     // Note: returned OUT OF ORDER (request-2 first) to prove key-based join.


### PR DESCRIPTION
## Problem

Gemini puts the target model in the batch **URL** (`/v1beta/models/{model}:batchGenerateContent`), so a single Google batch runs a single model. `Batch::modelFor()` read only the **first** line's model, so a batch mixing models (e.g. `gemini-2.5-flash` + `gemini-1.5-pro`) silently ran **every** line under the first model — wrong output and cost, no error. OpenAI and Anthropic carry the model per-line in the body, so only Google is affected.

Supersedes the draft in #57.

## Fix

- Add `BatchException::mixedModel($expected, $got)` (matching the existing `mixedModality`/`mixedProvider` factories).
- `modelFor()` now validates every line targets one model and throws **before any HTTP call**; non-text lines stay the responsibility of `submit()`'s existing `notBatchable` guard (no duplication).

## Validation

- New regression test asserts `$http->shouldNotReceive('post')` and the mixed-model exception — verified to **fail on the old code** and pass on the fix.
- `composer check` green: Pint, PHPStan (0 errors), **3447 Pest tests**.
- Live sandbox: Google single-model batch (`test-batch-google-e2e.php`) still passes both modes end-to-end — the fix does not affect the happy path.

## Changelog / docs

- `CHANGELOG.md` → **v3.6.1** (Fixed; no breaking changes, drop-in).
- `docs/modalities/batch.md` → warning that Google batches must use one model.