### PR TITLE
test(sandbox): fix batch scripts for live verification

### DIFF
--- a/sandbox/test-batch-google.php
+++ b/sandbox/test-batch-google.php
@@ -19,6 +19,12 @@ $app['config']->set('atlas.providers', [
     ],
 ]);
 $app['config']->set('atlas.persistence.enabled', false); // stateless: exercise the provider API directly
+// The Atlas singletons + facade root are resolved in bootstrap before the toggle
+// above, so drop them to force a stateless rebuild — otherwise submit() runs in
+// tracked mode and returns a BatchJob whose camelCase batchId is null.
+$app->forgetInstance(\Atlasphp\Atlas\AtlasConfig::class);
+$app->forgetInstance(\Atlasphp\Atlas\AtlasManager::class);
+\Atlasphp\Atlas\Atlas::clearResolvedInstances();
 
 use Atlasphp\Atlas\Atlas;
 use Atlasphp\Atlas\Enums\BatchStatus;

--- a/sandbox/test-batch-modes.php
+++ b/sandbox/test-batch-modes.php
@@ -62,7 +62,7 @@ function batchFor(string $provider): object
     }
 
     return Atlas::batch('anthropic')
-        ->add(Atlas::text('anthropic', 'claude-sonnet-4-20250514')->message('Say OK'), key: 'a');
+        ->add(Atlas::text('anthropic', 'claude-sonnet-4-5-20250929')->message('Say OK'), key: 'a');
 }
 
 line('=== Atlas Batch — persistence-modes live audit ===');

--- a/sandbox/test-batch.php
+++ b/sandbox/test-batch.php
@@ -111,10 +111,10 @@ report('openai', $openaiTextId, $openaiTextStatus);
 line('');
 
 // ── 3. Anthropic text batch ──────────────────────────────────────────────────
-line('[3] Anthropic text batch (claude-sonnet-4-20250514, 2 prompts)');
+line('[3] Anthropic text batch (claude-sonnet-4-5-20250929, 2 prompts)');
 $anthropic = Atlas::batch('anthropic')
-    ->add(Atlas::text('anthropic', 'claude-sonnet-4-20250514')->message('Reply with exactly: ALPHA'), key: 'a')
-    ->add(Atlas::text('anthropic', 'claude-sonnet-4-20250514')->message('Reply with exactly: BETA'), key: 'b');
+    ->add(Atlas::text('anthropic', 'claude-sonnet-4-5-20250929')->message('Reply with exactly: ALPHA'), key: 'a')
+    ->add(Atlas::text('anthropic', 'claude-sonnet-4-5-20250929')->message('Reply with exactly: BETA'), key: 'b');
 $anthropicId = batchIdOf($anthropic->submit());
 line("  submitted: {$anthropicId}");
 $anthropicStatus = pollUntilTerminal('anthropic', $anthropicId);


### PR DESCRIPTION
Two sandbox-harness fixes surfaced by a full live audit (no package code changed):

- Bump the retired Anthropic model id (`claude-sonnet-4-20250514` → `claude-sonnet-4-5-20250929`) in `test-batch.php` and `test-batch-modes.php` so Anthropic batch lines stop erroring model-not-found.
- `test-batch-google.php`: clear the Atlas config/manager singletons + facade root after toggling persistence off, so stateless `submit()` returns a `BatchResponse` instead of a tracked `BatchJob` (was a TypeError on a null batchId).

Verified live: Google full round-trip (ALPHA/BETA), batch-modes both providers both modes, test-batch OpenAI complete + Anthropic submits cleanly.