### PR TITLE
docs(custom-drivers): document countTokens() on custom text handlers

### DIFF
--- a/docs/guides/custom-drivers.md
+++ b/docs/guides/custom-drivers.md
@@ -52,6 +52,7 @@ namespace App\Atlas;
 
 use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Providers\Concerns\BuildsHeaders;
+use Atlasphp\Atlas\Providers\Concerns\CountsTokens;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\HttpClient;
 use Atlasphp\Atlas\Providers\ProviderConfig;
@@ -59,11 +60,13 @@ use Atlasphp\Atlas\Requests\TextRequest;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 
 class MyTextHandler implements TextHandler
 {
     use BuildsHeaders;
+    use CountsTokens;
 
     public function __construct(
         private readonly ProviderConfig $config,
@@ -98,6 +101,18 @@ class MyTextHandler implements TextHandler
     public function structured(TextRequest $request): StructuredResponse
     {
         throw new \RuntimeException('Not implemented');
+    }
+
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        // Return the input-token count for a request before it is sent.
+        // If your provider has no native count endpoint, the CountsTokens
+        // trait estimates it heuristically from the request body and flags
+        // the result estimated: true.
+        return $this->estimateTokens($this->config->provider, $request->model, [
+            'model' => $request->model,
+            'prompt' => $request->message,
+        ]);
     }
 }
 ```
@@ -185,7 +200,7 @@ Each modality has a handler interface. Implement only the ones your provider sup
 
 | Interface | Methods | Input → Output |
 |-----------|---------|---------------|
-| `TextHandler` | `text()`, `stream()`, `structured()` | `TextRequest` → `TextResponse` / `StreamResponse` / `StructuredResponse` |
+| `TextHandler` | `text()`, `stream()`, `structured()`, `countTokens()` | `TextRequest` → `TextResponse` / `StreamResponse` / `StructuredResponse` / `TokenCount` |
 | `AudioHandler` | `audio()`, `audioToText()` | `AudioRequest` → `AudioResponse` / `TextResponse` |
 | `ImageHandler` | `image()`, `imageToText()` | `ImageRequest` → `ImageResponse` / `TextResponse` |
 | `VideoHandler` | `video()`, `videoToText()` | `VideoRequest` → `VideoResponse` / `TextResponse` |

--- a/sandbox/test-custom-driver.php
+++ b/sandbox/test-custom-driver.php
@@ -21,6 +21,7 @@ use Atlasphp\Atlas\Enums\FinishReason;
 use Atlasphp\Atlas\Http\HttpClient;
 use Atlasphp\Atlas\Middleware\MiddlewareStack;
 use Atlasphp\Atlas\Providers\Concerns\BuildsHeaders;
+use Atlasphp\Atlas\Providers\Concerns\CountsTokens;
 use Atlasphp\Atlas\Providers\Driver;
 use Atlasphp\Atlas\Providers\Handlers\TextHandler;
 use Atlasphp\Atlas\Providers\ProviderCapabilities;
@@ -31,6 +32,7 @@ use Atlasphp\Atlas\Responses\StreamChunk;
 use Atlasphp\Atlas\Responses\StreamResponse;
 use Atlasphp\Atlas\Responses\StructuredResponse;
 use Atlasphp\Atlas\Responses\TextResponse;
+use Atlasphp\Atlas\Responses\TokenCount;
 use Atlasphp\Atlas\Responses\Usage;
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -40,6 +42,7 @@ use Atlasphp\Atlas\Responses\Usage;
 class CustomOpenAiTextHandler implements TextHandler
 {
     use BuildsHeaders;
+    use CountsTokens;
 
     public function __construct(
         private readonly ProviderConfig $config,
@@ -137,6 +140,13 @@ class CustomOpenAiTextHandler implements TextHandler
     public function structured(TextRequest $request): StructuredResponse
     {
         throw new RuntimeException('Structured output not implemented in this custom handler');
+    }
+
+    public function countTokens(TextRequest $request): TokenCount
+    {
+        // No native count endpoint on this custom handler — estimate from the
+        // built request body via the CountsTokens trait (estimated: true).
+        return $this->estimateTokens($this->config->provider, $request->model, $this->buildPayload($request));
     }
 
     /**
@@ -393,6 +403,11 @@ test('withHandler replaces text handler on a resolved driver', function () use (
         public function structured(TextRequest $request): StructuredResponse
         {
             throw new RuntimeException('Not implemented');
+        }
+
+        public function countTokens(TextRequest $request): TokenCount
+        {
+            return (new CustomOpenAiTextHandler($this->config, $this->http))->countTokens($request);
         }
     };
 


### PR DESCRIPTION
`TextHandler` requires `countTokens()` (added in v3.6.0), but the custom-drivers guide's example and interface table omitted it — a handler built from the docs failed to load. Documents `countTokens()` with a drop-in implementation via the `CountsTokens` trait (heuristic estimate when a provider has no native count endpoint), adds it to the interface table, and updates the sandbox custom-driver example to match.

The feature itself is correct (all first-party handlers implement it; live token-counting verified 22/22) — docs gap only.